### PR TITLE
Prototype: Blend start and end callbacks on Brain

### DIFF
--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -164,6 +164,18 @@ namespace Cinemachine
         /// The parameters are (incoming_vcam, outgoing_vcam), in that order.
         /// </summary>
         [Serializable] public class VcamActivatedEvent : UnityEvent<ICinemachineCamera, ICinemachineCamera> {}
+        
+        /// <summary>
+        /// Event that is fired when a blend has started.
+        /// The parameters are (incoming_vcam, outgoing_vcam), in that order.
+        /// </summary>
+        [Serializable] public class VcamBlendStartedEvent : UnityEvent<ICinemachineCamera, ICinemachineCamera> {}
+        
+        /// <summary>
+        /// Event that is fired when a blend has ended.
+        /// The parameters are (incoming_vcam, outgoing_vcam), in that order.
+        /// </summary>
+        [Serializable] public class VcamBlendEndedEvent : UnityEvent<ICinemachineCamera, ICinemachineCamera> {}
 
         /// <summary>This event will fire whenever a virtual camera goes live and there is no blend</summary>
         [Tooltip("This event will fire whenever a virtual camera goes live and there is no blend")]
@@ -176,6 +188,9 @@ namespace Cinemachine
         [Tooltip("This event will fire whenever a virtual camera goes live.  If a blend is "
             + "involved, then the event will fire on the first frame of the blend.")]
         public VcamActivatedEvent m_CameraActivatedEvent = new VcamActivatedEvent();
+
+        public VcamBlendStartedEvent m_BlendStartEvent = new VcamBlendStartedEvent();
+        public VcamBlendEndedEvent m_BlendEndEvent = new VcamBlendEndedEvent();
 
         /// <summary>
         /// API for the Unity Editor.
@@ -219,6 +234,9 @@ namespace Cinemachine
 
             SceneManager.sceneLoaded += OnSceneLoaded;
             SceneManager.sceneUnloaded += OnSceneUnloaded;
+
+            mCurrentLiveCameras.m_BlendStartCallbacks = m_BlendStartEvent;
+            mCurrentLiveCameras.m_BlendEndCallbacks = m_BlendEndEvent;
         }
 
         private void OnDisable()


### PR DESCRIPTION
A user requested access to blend start and end events. (https://jira.unity3d.com/browse/CMCL-34, https://forum.unity.com/threads/faster-than-camera-main.841246/#post-5555557) 
I thought adding a callback would be a good idea.

This is a very simple prototype. I did not want to implement the feature fully without agreeing on it with you. (so no editor scripts, not fully thought out, did not test with timeline, etc).

I found the way I check for blend start and blend end works in a simple scene with a couple of vcams. But maybe there is a better way of checking and wiring the callbacks to the blend. Maybe the start and end callbacks should be in brain and not passed to blend definition. Not sure.

What do you think?