### PR TITLE
Default PostProcessing profile priority is now configurable, and defa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.7.3] - unreleased
+## [Unreleased]
 - Default PostProcessing profile priority is now configurable, and defaults to 1000
 
 ## [2.7.2] - 2021-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [2.7.3] - unreleased
-- Default PostProcessing profile priority is now configuraable, and defaults to 1000
+- Default PostProcessing profile priority is now configurable, and defaults to 1000
 
 ## [2.7.2] - 2021-02-15
 - CinemachineConfiner2D now handles cases where camera window is oversized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.7.3] - unreleased
+- Default PostProcessing profile priority is now configuraable, and defaults to 1000
+
 ## [2.7.2] - 2021-02-15
 - CinemachineConfiner2D now handles cases where camera window is oversized
 - New sample scene (FadeOutNearbyObjects) demonstrating fade out effect for objects between camera and target using shaders. The example includes a cinemachine extension giving convenient control over the shader parameters

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -52,6 +52,13 @@ namespace Cinemachine.PostFX
     [HelpURL(Documentation.BaseURL + "manual/CinemachinePostProcessing.html")]
     public class CinemachinePostProcessing : CinemachineExtension
     {
+        /// <summary>
+        /// This is the priority for the vcam's PostProcessing volumes.  It's set to a high
+        /// number in order to ensure that it overrides other volumes for the active vcam.
+        /// You can change this value if necessary to work with other systems.
+        /// </summary>
+        static public float s_VolumePriority = 1000f;
+
         /// <summary>This is obsolete, please use m_FocusTracking</summary>
         [HideInInspector]
         public bool m_FocusTracksTarget;
@@ -244,7 +251,7 @@ namespace Cinemachine.PostFX
                         firstVolume = v;
                     v.sharedProfile = profile;
                     v.isGlobal = true;
-                    v.priority = float.MaxValue-(numBlendables-i)-1;
+                    v.priority = s_VolumePriority - (numBlendables - i) - 1;
                     v.weight = b.m_Weight;
                     ++numPPblendables;
                 }

--- a/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -49,6 +49,13 @@ namespace Cinemachine.PostFX
     [HelpURL(Documentation.BaseURL + "manual/CinemachineVolumeSettings.html")]
     public class CinemachineVolumeSettings : CinemachineExtension
     {
+        /// <summary>
+        /// This is the priority for the vcam's PostProcessing volumes.  It's set to a high
+        /// number in order to ensure that it overrides other volumes for the active vcam.
+        /// You can change this value if necessary to work with other systems.
+        /// </summary>
+        static public float s_VolumePriority = 1000f;
+
         /// <summary>This is obsolete, please use m_FocusTracking</summary>
         [HideInInspector]
         public bool m_FocusTracksTarget;
@@ -257,7 +264,7 @@ namespace Cinemachine.PostFX
                         firstVolume = v;
                     v.sharedProfile = profile;
                     v.isGlobal = true;
-                    v.priority = float.MaxValue - (numBlendables - i - 1) * 1.0e35f;
+                    v.priority = s_VolumePriority - (numBlendables - i) - 1;
                     v.weight = b.m_Weight;
                     ++numPPblendables;
                 }


### PR DESCRIPTION
…ults to 1000

### Purpose of this PR

From forum: https://forum.unity.com/threads/blend-between-postprocess-profile-at-runtime.974898/#post-6339579

When CM creates PostProcessing profiles, they are given float.MaxValue as priority, so it's impossible to override them.  They should use a lower number.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [X] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [X] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [X] Commented all public classes, properties, and methods

### Technical risk

low

