### PR TITLE
bumped Cinemachine version to 2.8.0

### DIFF
--- a/Documentation~/cinemachine.md
+++ b/Documentation~/cinemachine.md
@@ -14,6 +14,6 @@ Cinemachine works well with other Unity tools, acting as a powerful complement t
 
 Cinemachine has no external dependencies. Just install it and start using it. 
 
-This Cinemachine version 2.7.2 is compatible with the following versions of the Unity Editor:
+This Cinemachine version 2.8.0 is compatible with the following versions of the Unity Editor:
 
 * 2018.4.17f1 and later

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -11,7 +11,7 @@ namespace Cinemachine
         /// or
         /// [HelpURL(Documentation.BaseURL + "manual/some-page.html")]
         /// It cannot support String.Format nor string interpolation</summary>
-        public const string BaseURL = "https://docs.unity3d.com/Packages/com.unity.cinemachine@2.7/";
+        public const string BaseURL = "https://docs.unity3d.com/Packages/com.unity.cinemachine@2.8/";
     }
 
     /// <summary>A singleton that manages complete lists of CinemachineBrain and,
@@ -24,7 +24,7 @@ namespace Cinemachine
         public static readonly int kStreamingVersion = 20170927;
 
         /// <summary>Human-readable Cinemachine Version</summary>
-        public static readonly string kVersionString = "2.7.2";
+        public static readonly string kVersionString = "2.8.0";
 
         /// <summary>
         /// Stages in the Cinemachine Component pipeline, used for

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.8.0",
+    "version": "2.8.0-pre.1",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR

Bumped cinemachine version to 2.8.0 

### Package version

Minor version bump due to adding new functionality and APIs.

- [X] Updated package version
- [X] Added `[Unreleased]` section to changelog
