### PR TITLE
[2.7 backport] CMCL-233: 3rdPerson damping in camera space not worldspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space
+
+
 ## [2.7.2] - 2021-02-15
 - CinemachineConfiner2D now handles cases where camera window is oversized
 - New sample scene (FadeOutNearbyObjects) demonstrating fade out effect for objects between camera and target using shaders. The example includes a cinemachine extension giving convenient control over the shader parameters

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -125,17 +125,17 @@ namespace Cinemachine
             var prevTargetPos = deltaTime >= 0 ? PreviousFollowTargetPosition : targetPos;
 
             // Compute damped target pos (compute in camera space)
-            var dampedTargetPos = Quaternion.Inverse(curState.RawOrientation) 
+            var followTargetRotation = FollowTargetRotation;
+            var dampedTargetPos = Quaternion.Inverse(followTargetRotation) 
                 * (targetPos - prevTargetPos);
             if (deltaTime >= 0)
                 dampedTargetPos = VirtualCamera.DetachedFollowTargetDamp(
                     dampedTargetPos, Damping, deltaTime);
-            dampedTargetPos = prevTargetPos + curState.RawOrientation * dampedTargetPos;
+            dampedTargetPos = prevTargetPos + followTargetRotation * dampedTargetPos;
 
             // Get target rotation (worldspace)
             var fwd = Vector3.forward;
             var up = Vector3.up;
-            var followTargetRotation = FollowTargetRotation;
             var followTargetForward = followTargetRotation * fwd;
             var angle = UnityVectorExtensions.SignedAngle(
                 fwd, followTargetForward.ProjectOntoPlane(up), up);
@@ -161,7 +161,7 @@ namespace Cinemachine
             camPos = PullTowardsStartOnCollision(in hand, in camPos, in CameraCollisionFilter, CameraRadius);
 
             curState.RawPosition = camPos;
-            curState.RawOrientation = FollowTargetRotation;
+            curState.RawOrientation = followTargetRotation;
             curState.ReferenceUp = up;
         }
 


### PR DESCRIPTION
### Purpose of this PR
CMCL-233: 3rdPerson damping should be in camera space not worldspace

Backport for #184 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers
- Open AimingRig sample, give the vcam body a high z damping
- Play the game and observe damping is in world space
- Should be in camera space

Note: this fix is needed for starter assets project, so it needs to be backported for 2020 LTS verified version
