### PR TITLE
CMCL-233: 3rdPerson damping should be in camera space not worldspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Added CollisionDamping property to Cinemachine3rdPersonFollow to control how gradually the camera returns to its normal position after having been corrected by the built-in collision resolution system.
 - Default PostProcessing profile priority is now configurable, and defaults to 1000
+- Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -136,37 +136,37 @@ namespace Cinemachine
 
         void PositionCamera(ref CameraState curState, float deltaTime)
         {
-            var followTarget = FollowTargetPosition;
+            var targetPos = FollowTargetPosition;
             if (deltaTime < 0)
             {
                 // No damping - reset all state info
-                m_PreviousFollowTargetPosition = followTarget;
+                m_PreviousFollowTargetPosition = targetPos;
                 m_HandCollisionCorrection = m_CamPosCollisionCorrection = 0;
             }
             var prevTargetPos = m_PreviousFollowTargetPosition;
 
             // Compute damped target pos (compute in camera space)
-            var dampedTargetPos = Quaternion.Inverse(curState.RawOrientation) * (followTarget - prevTargetPos);
+            var targetRot = FollowTargetRotation;
+            var dampedTargetPos = Quaternion.Inverse(targetRot) * (targetPos - prevTargetPos);
             if (deltaTime >= 0)
                 dampedTargetPos = VirtualCamera.DetachedFollowTargetDamp(
                     dampedTargetPos, Damping, deltaTime);
-            dampedTargetPos = prevTargetPos + curState.RawOrientation * dampedTargetPos;
+            dampedTargetPos = prevTargetPos + targetRot * dampedTargetPos;
 
             // Get target rotation (worldspace)
             var fwd = Vector3.forward;
             var up = Vector3.up;
-            var followTargetRotation = FollowTargetRotation;
-            var followTargetForward = followTargetRotation * fwd;
+            var targetForward = targetRot * fwd;
             var angle = UnityVectorExtensions.SignedAngle(
-                fwd, followTargetForward.ProjectOntoPlane(up), up);
+                fwd, targetForward.ProjectOntoPlane(up), up);
             if (deltaTime < 0)
                 m_PreviousHeadingAngle = angle; // no damping
             var deltaHeading = angle - m_PreviousHeadingAngle;
             m_PreviousHeadingAngle = angle;
 
             // Bypass user-sourced rotation
-            dampedTargetPos = followTarget 
-                + Quaternion.AngleAxis(deltaHeading, up) * (dampedTargetPos - followTarget);
+            dampedTargetPos = targetPos 
+                + Quaternion.AngleAxis(deltaHeading, up) * (dampedTargetPos - targetPos);
             m_PreviousFollowTargetPosition = dampedTargetPos;
 
             GetRigPositions(out Vector3 root, out _, out Vector3 hand);
@@ -179,13 +179,13 @@ namespace Cinemachine
                 root, hand, deltaTime, CameraRadius * 1.05f, ref m_HandCollisionCorrection);
 
             // 2. Try to place the camera to the preferred distance
-            Vector3 camPos = hand - (followTargetForward * CameraDistance);
+            Vector3 camPos = hand - (targetForward * CameraDistance);
             camPos = ResolveCollisions(
                 hand, camPos, deltaTime, CameraRadius, ref m_CamPosCollisionCorrection);
 
             // Set state
             curState.RawPosition = camPos;
-            curState.RawOrientation = followTargetRotation;
+            curState.RawOrientation = targetRot;
             curState.ReferenceUp = up;
         }
 


### PR DESCRIPTION
### Purpose of this PR 
CMCL-233: 3rdPerson damping should be in camera space not worldspace
This is the same as PR #183, plus some local name changes for consistency.  Re-done for the main brnch, which has other changes in that file

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

- Open AimingRig sample, give the vcam body a high z damping
- Play the game and observe damping is in world space
- Should be in camera space