### PR TITLE
Dev/lens override mode bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Default PostProcessing profile priority is now configurable, and defaults to 1000
 - Bugfix: 3rdPersonFollow collision resolution was failing when the camera radius was large
 - Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space
+- Bugfix: lens aspect and sensorSize were not getting updated if lens OverrideMode != None
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -221,13 +221,17 @@ namespace Cinemachine
             {
                 m_OrthoFromCamera = camera.orthographic;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
-                if (IsPhysicalCamera)
+            }
+            if (IsPhysicalCamera)
+            {
+                if (camera != null)
                     m_SensorSize = camera.sensorSize;
-                else
-                {
+            }
+            else
+            {
+                if (camera != null)
                     m_SensorSize = new Vector2(camera.aspect, 1f);
-                    LensShift = Vector2.zero;
-                }
+                LensShift = Vector2.zero;
             }
         }
 
@@ -242,9 +246,9 @@ namespace Cinemachine
                 m_OrthoFromCamera = lens.Orthographic;
                 m_SensorSize = lens.m_SensorSize;
                 m_PhysicalFromCamera = lens.IsPhysicalCamera;
-                if (!IsPhysicalCamera)
-                    LensShift = Vector2.zero;
             }
+            if (!IsPhysicalCamera)
+                LensShift = Vector2.zero;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Found on forum via PM: lens aspect and SensorSize were not getting updated if lens OverrideMode != None

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

low

### Comments to reviewers

- Make ortho camera with confiner 2D, simple rectangle shape
- Set vcam lens override mode to Orthographic
- Adjust the aspect ratio of the game view, notice that the confiner does not confine properly, because its aspect is stuck somewhere and not getting updated

### Package version

- [ ] Updated package version
