### PR TITLE
CMCL-244: Add CinemachineCore.OnTargetObjectWarped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Added CollisionDamping property to Cinemachine3rdPersonFollow to control how gradually the camera returns to its normal position after having been corrected by the built-in collision resolution system.
+- Added CinemachineCore.OnTargetObjectWarped() to warp all vcams targeting an object
 - Default PostProcessing profile priority is now configurable, and defaults to 1000
 - Bugfix: 3rdPersonFollow collision resolution was failing when the camera radius was large
 - Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -503,5 +503,22 @@ namespace Cinemachine
             }
             return null;
         }
+
+        /// <summary>Call this to notify all virtual camewras that may be tracking a target
+        /// that the target's position has suddenly warped to somewhere else, so that
+        /// so that the virtual cameras can update their internal state to make the camera
+        /// warp seamlessy along with the target.
+        /// 
+        /// All virtual cameras are iterated so this call will work no matter how many 
+        /// are tracking the target, and whether they are active or inactive.
+        /// </summary>
+        /// <param name="target">The object that was warped</param>
+        /// <param name="positionDelta">The amount the target's position changed</param>
+        public void OnTargetObjectWarped(Transform target, Vector3 positionDelta)
+        {
+            int numVcams = VirtualCameraCount;
+            for (int i = 0; i < numVcams; ++i)
+                GetVirtualCamera(i).OnTargetObjectWarped(target, positionDelta);
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Make it easier for clients to call OnTargetObjectWarped - one call instead of iterating over vcams

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

0

### Comments to reviewers

Just look at the code

### Package version
- [ ] Updated package version
