### PR TITLE
[skip ci] switch to Ubuntu for trigger tests and validation

### DIFF
--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -3,6 +3,7 @@ all_editors:
   - version: 2019.4
   - version: 2020.2
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 all_platforms:
   - name: win
@@ -27,16 +28,9 @@ test_editors:
   - version: 2019.4
   - version: 2020.2
   - version: 2021.1
-  - version: trunk
+  - version: 2021.2
+- version: trunk
 test_platforms:
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: m1.mac
   - name: ubuntu
     type: Unity::VM
     image: package-ci/ubuntu:stable
@@ -45,9 +39,9 @@ test_platforms:
 validation_editors:
   - version: 2020.2
 validation_platforms:
-  - name: win
+  - name: ubuntu
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/ubuntu:stable
     flavor: b1.large
 ---
 

--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -3,7 +3,6 @@ all_editors:
   - version: 2019.4
   - version: 2020.2
   - version: 2021.1
-  - version: 2021.2
   - version: trunk
 all_platforms:
   - name: win
@@ -28,8 +27,7 @@ test_editors:
   - version: 2019.4
   - version: 2020.2
   - version: 2021.1
-  - version: 2021.2
-- version: trunk
+  - version: trunk
 test_platforms:
   - name: ubuntu
     type: Unity::VM


### PR DESCRIPTION
### Purpose of this PR

Developer services advised that Ubuntu is the cheapest/fastest platform for testing. Switches our triggered tests & validation to Ubuntu.

