### PR TITLE
Fix CMCL-228: Add IsLiveInBlend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space
 - Regression fix: CinemachineInputProvider had stopped providing input
 - Bugfix: lens aspect and sensorSize were not getting updated if lens OverrideMode != None
+- Bugfix: Interrupting a transition with InheritPosition enabled was broken
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -460,6 +460,26 @@ namespace Cinemachine
         }
 
         /// <summary>
+        /// Checks if the vcam is live as part of an outgoing blend.  
+        /// Does not check whether the vcam is also the current active vcam.
+        /// </summary>
+        /// <param name="vcam">The virtual camera to check</param>
+        /// <returns>True if the virtual camera is part of a live outgoing blend, false otherwise</returns>
+        public bool IsLiveInBlend(ICinemachineCamera vcam)
+        {
+            // Ignore mCurrentLiveCameras.CamB
+            if (vcam == mCurrentLiveCameras.CamA)
+                return true;
+            var b = mCurrentLiveCameras.CamA as BlendSourceVirtualCamera;
+            if (b != null && b.Blend.Uses(vcam))
+                return true;
+            ICinemachineCamera parent = vcam.ParentCamera;
+            if (parent != null && parent.IsLiveChild(vcam, false))
+                return IsLiveInBlend(parent);
+            return false;
+        }
+
+        /// <summary>
         /// Is there a blend in progress?
         /// </summary>
         public bool IsBlending { get { return ActiveBlend != null; } }

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -390,7 +390,8 @@ namespace Cinemachine
 //              m_YAxis.m_Recentering.DoRecentering(ref m_YAxis, -1, 0.5f);
 //            m_RecenterToTargetHeading.CancelRecentering();
 //            m_YAxis.m_Recentering.CancelRecentering();
-            if (fromCam != null && m_Transitions.m_InheritPosition)
+            if (fromCam != null && m_Transitions.m_InheritPosition 
+                && !CinemachineCore.Instance.IsLiveInBlend(this))
             {
                 var cameraPos = fromCam.State.RawPosition;
 

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -593,7 +593,8 @@ namespace Cinemachine
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
             bool forceUpdate = false;
 
-            if (m_Transitions.m_InheritPosition && fromCam != null)
+            if (m_Transitions.m_InheritPosition && fromCam != null
+                 && !CinemachineCore.Instance.IsLiveInBlend(this))
                 ForceCameraPosition(fromCam.State.FinalPosition, fromCam.State.FinalOrientation);
 
             UpdateComponentPipeline(); // avoid GetComponentPipeline() here because of GC

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -386,7 +386,8 @@ namespace Cinemachine
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
             ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
         {
-            if (fromCam != null && transitionParams.m_InheritPosition)
+            if (fromCam != null && transitionParams.m_InheritPosition
+                 && !CinemachineCore.Instance.IsLiveInBlend(VirtualCamera))
             {
                 transform.rotation = fromCam.State.RawOrientation;
                 InheritingPosition = true;

--- a/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -308,7 +308,8 @@ namespace Cinemachine
             m_RecenterToTargetHeading.CancelRecentering();
             if (fromCam != null //&& fromCam.Follow == FollowTarget
                 && m_BindingMode != CinemachineTransposer.BindingMode.SimpleFollowWithWorldUp
-                && transitionParams.m_InheritPosition)
+                && transitionParams.m_InheritPosition
+                && !CinemachineCore.Instance.IsLiveInBlend(VirtualCamera))
             {
                 m_XAxis.Value = GetAxisClosestValue(fromCam.State.RawPosition, worldUp);
                 return true;

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -190,7 +190,8 @@ namespace Cinemachine
             m_VerticalRecentering.DoRecentering(ref m_VerticalAxis, -1, 0);
             m_HorizontalRecentering.CancelRecentering();
             m_VerticalRecentering.CancelRecentering();
-            if (fromCam != null && transitionParams.m_InheritPosition)
+            if (fromCam != null && transitionParams.m_InheritPosition  
+                && !CinemachineCore.Instance.IsLiveInBlend(VirtualCamera))
             {
                 SetAxesForRotation(fromCam.State.RawOrientation);
                 return true;

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -428,6 +428,26 @@ namespace Cinemachine
         }
 
         /// <summary>
+        /// Checks if the vcam is live as part of an outgoing blend in any active CinemachineBrain.  
+        /// Does not check whether the vcam is also the current active vcam.
+        /// </summary>
+        /// <param name="vcam">The virtual camera to check</param>
+        /// <returns>True if the virtual camera is part of a live outgoing blend, false otherwise</returns>
+        public bool IsLiveInBlend(ICinemachineCamera vcam)
+        {return false;
+            if (vcam != null)
+            {
+                for (int i = 0; i < BrainCount; ++i)
+                {
+                    CinemachineBrain b = GetActiveBrain(i);
+                    if (b != null && b.IsLiveInBlend(vcam))
+                        return true;
+                }
+            }
+            return false;
+        }
+        
+        /// <summary>
         /// Signal that the virtual has been activated.
         /// If the camera is live, then all CinemachineBrains that are showing it will
         /// send an activation event.

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -434,7 +434,7 @@ namespace Cinemachine
         /// <param name="vcam">The virtual camera to check</param>
         /// <returns>True if the virtual camera is part of a live outgoing blend, false otherwise</returns>
         public bool IsLiveInBlend(ICinemachineCamera vcam)
-        {return false;
+        {
             if (vcam != null)
             {
                 for (int i = 0; i < BrainCount; ++i)

--- a/Runtime/Experimental/CinemachineNewFreeLook.cs
+++ b/Runtime/Experimental/CinemachineNewFreeLook.cs
@@ -302,7 +302,8 @@ namespace Cinemachine
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
             m_VerticalAxis.m_Recentering.DoRecentering(ref m_VerticalAxis, -1, 0.5f);
             m_VerticalAxis.m_Recentering.CancelRecentering();
-            if (fromCam != null && m_Transitions.m_InheritPosition)
+            if (fromCam != null && m_Transitions.m_InheritPosition
+                 && !CinemachineCore.Instance.IsLiveInBlend(this))
             {
                 // Note: horizontal axis already taken care of by base class
                 var cameraPos = fromCam.State.RawPosition;

--- a/Runtime/Experimental/CinemachineNewVirtualCamera.cs
+++ b/Runtime/Experimental/CinemachineNewVirtualCamera.cs
@@ -149,9 +149,11 @@ namespace Cinemachine
             base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
             bool forceUpdate = false;
-            if (m_Transitions.m_InheritPosition && fromCam != null)
+            if (m_Transitions.m_InheritPosition && fromCam != null  
+                && !CinemachineCore.Instance.IsLiveInBlend(this))
+            {
                 ForceCameraPosition(fromCam.State.FinalPosition, fromCam.State.FinalOrientation);
-
+            }
             UpdateComponentCache();
             for (int i = 0; i < m_Components.Length; ++i)
             {


### PR DESCRIPTION
### Purpose of this PR

fixes CMCL-228: Interrupting a transition with InheritPosition enabled is broken

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

low

### Comments to reviewers

Install the unitypackage included with CMCL-228 for a repro

### Package version

- [ ] Updated package version
