### PR TITLE
Fixes CMCL-238: Added ability for vcam to have a negative clip plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Added CollisionDamping property to Cinemachine3rdPersonFollow to control how gradually the camera returns to its normal position after having been corrected by the built-in collision resolution system.
 - Added CinemachineCore.OnTargetObjectWarped() to warp all vcams targeting an object
+- Added ability for vcam to have a negative near clip plane
 - Default PostProcessing profile priority is now configurable, and defaults to 1000
 - Bugfix: 3rdPersonFollow collision resolution was failing when the camera radius was large
 - Bugfix: 3rdPersonFollow damping was being done in world space instead of camera space

--- a/Editor/Editors/CinemachineBrainEditor.cs
+++ b/Editor/Editors/CinemachineBrainEditor.cs
@@ -83,7 +83,7 @@ namespace Cinemachine.Editor
         [DrawGizmo(GizmoType.Selected | GizmoType.NonSelected, typeof(CinemachineBrain))]
         private static void DrawBrainGizmos(CinemachineBrain brain, GizmoType drawType)
         {
-            if (brain.OutputCamera != null && brain.m_ShowCameraFrustum)
+            if (brain.OutputCamera != null && brain.m_ShowCameraFrustum && brain.isActiveAndEnabled)
             {
                 DrawCameraFrustumGizmo(
                     brain, LensSettings.FromCamera(brain.OutputCamera),
@@ -113,7 +113,7 @@ namespace Cinemachine.Editor
                 Vector3 size = new Vector3(
                         aspect * lens.OrthographicSize * 2,
                         lens.OrthographicSize * 2,
-                        lens.NearClipPlane + lens.FarClipPlane);
+                        lens.FarClipPlane - lens.NearClipPlane);
                 Gizmos.DrawWireCube(
                     new Vector3(0, 0, (size.z / 2) + lens.NearClipPlane), size);
             }

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -316,7 +316,8 @@ namespace Cinemachine
         /// <summary>Make sure lens settings are sane.  Call this from OnValidate().</summary>
         public void Validate()
         {
-            NearClipPlane = Mathf.Max(NearClipPlane, Orthographic ? 0 : 0.001f);
+            if (!Orthographic)
+                NearClipPlane = Mathf.Max(NearClipPlane, 0.001f);
             FarClipPlane = Mathf.Max(FarClipPlane, NearClipPlane + 0.001f);
             FieldOfView = Mathf.Clamp(FieldOfView, 0.01f, 179f);
             m_SensorSize.x = Mathf.Max(m_SensorSize.x, 0.1f);


### PR DESCRIPTION
### Purpose of this PR

Fixes CMCL-238: If I have an orthographic camera, the CinemachineBrain component prevents me from giving it a negative near clip plane (which should be fine for an orthographic camera). 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

