### PR TITLE
CMCL-237: Invalidate previous state on target change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: 3rdPersonFollow was stuttering when z damping was high
 - Regression fix: CinemachineInputProvider had stopped providing input
 - Bugfix: lens aspect and sensorSize were not getting updated if lens OverrideMode != None
+- Bugfix: changing targets on a live vcam was misbehaving
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -343,6 +343,7 @@ namespace Cinemachine
         /// <param name="deltaTime">Delta time for time-based effects (ignore if less than 0)</param>
         override public void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
         {
+            UpdateTargetCache();
             UpdateRigCache();
 
             // Update the current state by invoking the component pipeline

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -148,6 +148,8 @@ namespace Cinemachine
         /// <param name="deltaTime">Effective deltaTime</param>
         override public void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
         {
+            UpdateTargetCache();
+
             // Update the state by invoking the component pipeline
             m_State = CalculateNewState(worldUp, deltaTime);
             ApplyPositionBlendMethod(ref m_State, m_Transitions.m_BlendHint);

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -153,8 +153,9 @@ namespace Cinemachine
                 TrackedPoint = pos;
             else
             {
+                var resetLookahead = VirtualCamera.LookAtTargetChanged || !VirtualCamera.PreviousStateIsValid;
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
-                m_Predictor.AddPosition(pos, VirtualCamera.PreviousStateIsValid ? deltaTime : -1, m_LookaheadTime);
+                m_Predictor.AddPosition(pos, resetLookahead ? -1 : deltaTime, m_LookaheadTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)
                     delta = delta.ProjectOntoPlane(up);

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -440,9 +440,10 @@ namespace Cinemachine
             LensSettings lens = curState.Lens;
             Vector3 followTargetPosition = FollowTargetPosition + (FollowTargetRotation * m_TrackedObjectOffset);
             bool previousStateIsValid = deltaTime >= 0 && VirtualCamera.PreviousStateIsValid;
+            if (!previousStateIsValid || VirtualCamera.FollowTargetChanged)
+                m_Predictor.Reset();
             if (!previousStateIsValid)
             {
-                m_Predictor.Reset();
                 m_PreviousCameraPosition = curState.RawPosition;
                 m_prevFOV = lens.Orthographic ? lens.OrthographicSize : lens.FieldOfView;
                 m_prevRotation = curState.RawOrientation;

--- a/Runtime/Components/CinemachineTransposer.cs
+++ b/Runtime/Components/CinemachineTransposer.cs
@@ -240,8 +240,7 @@ namespace Cinemachine
             if (m_previousTarget != FollowTarget || !prevStateValid)
             {
                 m_previousTarget = FollowTarget;
-                m_targetOrientationOnAssign
-                    = (m_previousTarget == null) ? Quaternion.identity : FollowTargetRotation;
+                m_targetOrientationOnAssign = FollowTargetRotation;
             }
             if (!prevStateValid)
             {

--- a/Runtime/Core/CinemachineComponentBase.cs
+++ b/Runtime/Core/CinemachineComponentBase.cs
@@ -31,7 +31,7 @@ namespace Cinemachine
             get
             {
                 CinemachineVirtualCameraBase vcam = VirtualCamera;
-                return vcam == null ? null : vcam.Follow;
+                return vcam == null ? null : vcam.ResolveFollow(vcam.Follow);
             }
         }
 
@@ -41,42 +41,15 @@ namespace Cinemachine
             get
             {
                 CinemachineVirtualCameraBase vcam = VirtualCamera;
-                return vcam == null ? null : vcam.LookAt;
-            }
-        }
-
-        private Transform mCachedFollowTarget;
-        private CinemachineVirtualCameraBase mCachedFollowTargetVcam;
-        private ICinemachineTargetGroup mCachedFollowTargetGroup;
-
-        void UpdateFollowTargetCache()
-        {
-            mCachedFollowTargetVcam = null;
-            mCachedFollowTargetGroup = null;
-            mCachedFollowTarget = FollowTarget;
-            if (mCachedFollowTarget != null)
-            {
-                mCachedFollowTargetVcam = mCachedFollowTarget.GetComponent<CinemachineVirtualCameraBase>();
-                mCachedFollowTargetGroup = mCachedFollowTarget.GetComponent<ICinemachineTargetGroup>();
+                return vcam == null ? null : vcam.ResolveLookAt(vcam.LookAt);
             }
         }
 
         /// <summary>Get Follow target as ICinemachineTargetGroup, or null if target is not a group</summary>
-        public ICinemachineTargetGroup AbstractFollowTargetGroup
-        {
-            get
-            {
-                if (FollowTarget != mCachedFollowTarget)
-                    UpdateFollowTargetCache();
-                return mCachedFollowTargetGroup;
-            }
-        }
+        public ICinemachineTargetGroup AbstractFollowTargetGroup => VirtualCamera.AbstractFollowTargetGroup;
 
         /// <summary>Get Follow target as CinemachineTargetGroup, or null if target is not a CinemachineTargetGroup</summary>
-        public CinemachineTargetGroup FollowTargetGroup
-        {
-            get { return AbstractFollowTargetGroup as CinemachineTargetGroup; }
-        }
+        public CinemachineTargetGroup FollowTargetGroup => AbstractFollowTargetGroup as CinemachineTargetGroup;
 
         /// <summary>Get the position of the Follow target.  Special handling: If the Follow target is
         /// a VirtualCamera, returns the vcam State's position, not the transform's position</summary>
@@ -84,11 +57,10 @@ namespace Cinemachine
         {
             get
             {
+                var vcam = VirtualCamera.FollowTargetAsVcam;
+                if (vcam != null)
+                    return vcam.State.FinalPosition;
                 Transform target = FollowTarget;
-                if (target != mCachedFollowTarget)
-                    UpdateFollowTargetCache();
-                if (mCachedFollowTargetVcam != null)
-                    return mCachedFollowTargetVcam.State.FinalPosition;
                 if (target != null)
                     return TargetPositionCache.GetTargetPosition(target);
                 return Vector3.zero;
@@ -101,54 +73,21 @@ namespace Cinemachine
         {
             get
             {
+                var vcam = VirtualCamera.FollowTargetAsVcam;
+                if (vcam != null)
+                    return vcam.State.FinalOrientation;
                 Transform target = FollowTarget;
-                if (target != mCachedFollowTarget)
-                {
-                    mCachedFollowTargetVcam = null;
-                    mCachedFollowTarget = target;
-                    if (target != null)
-                        mCachedFollowTargetVcam = target.GetComponent<CinemachineVirtualCameraBase>();
-                }
-                if (mCachedFollowTargetVcam != null)
-                    return mCachedFollowTargetVcam.State.FinalOrientation;
                 if (target != null)
                     return TargetPositionCache.GetTargetRotation(target);
                 return Quaternion.identity;
             }
         }
 
-        private Transform mCachedLookAtTarget;
-        private CinemachineVirtualCameraBase mCachedLookAtTargetVcam;
-        private ICinemachineTargetGroup mCachedLookAtTargetGroup;
-
-        void UpdateLookAtTargetCache()
-        {
-            mCachedLookAtTargetVcam = null;
-            mCachedLookAtTargetGroup = null;
-            mCachedLookAtTarget = LookAtTarget;
-            if (mCachedLookAtTarget != null)
-            {
-                mCachedLookAtTargetVcam = mCachedLookAtTarget.GetComponent<CinemachineVirtualCameraBase>();
-                mCachedLookAtTargetGroup = mCachedLookAtTarget.GetComponent<ICinemachineTargetGroup>();
-            }
-        }
-
         /// <summary>Get LookAt target as ICinemachineTargetGroup, or null if target is not a group</summary>
-        public ICinemachineTargetGroup AbstractLookAtTargetGroup
-        {
-            get
-            {
-                if (LookAtTarget != mCachedLookAtTarget)
-                    UpdateLookAtTargetCache();
-                return mCachedLookAtTargetGroup;
-            }
-        }
+        public ICinemachineTargetGroup AbstractLookAtTargetGroup => VirtualCamera.AbstractLookAtTargetGroup;
 
         /// <summary>Get LookAt target as CinemachineTargetGroup, or null if target is not a CinemachineTargetGroup</summary>
-        public CinemachineTargetGroup LookAtTargetGroup
-        {
-            get { return AbstractLookAtTargetGroup as CinemachineTargetGroup; }
-        }
+        public CinemachineTargetGroup LookAtTargetGroup => AbstractLookAtTargetGroup as CinemachineTargetGroup;
 
         /// <summary>Get the position of the LookAt target.  Special handling: If the LookAt target is
         /// a VirtualCamera, returns the vcam State's position, not the transform's position</summary>
@@ -156,11 +95,10 @@ namespace Cinemachine
         {
             get
             {
+                var vcam = VirtualCamera.LookAtTargetAsVcam;
+                if (vcam != null)
+                    return vcam.State.FinalPosition;
                 Transform target = LookAtTarget;
-                if (target != mCachedLookAtTarget)
-                    UpdateLookAtTargetCache();
-                if (mCachedLookAtTargetVcam != null)
-                    return mCachedLookAtTargetVcam.State.FinalPosition;
                 if (target != null)
                     return TargetPositionCache.GetTargetPosition(target);
                 return Vector3.zero;
@@ -173,11 +111,10 @@ namespace Cinemachine
         {
             get
             {
+                var vcam = VirtualCamera.LookAtTargetAsVcam;
+                if (vcam != null)
+                    return vcam.State.FinalOrientation;
                 Transform target = LookAtTarget;
-                if (target != mCachedLookAtTarget)
-                    UpdateLookAtTargetCache();
-                if (mCachedLookAtTargetVcam != null)
-                    return mCachedLookAtTargetVcam.State.FinalOrientation;
                 if (target != null)
                     return TargetPositionCache.GetTargetRotation(target);
                 return Quaternion.identity;

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -611,7 +611,7 @@ namespace Cinemachine
         /// the parent vcam's LookAt target.</summary>
         /// <param name="localLookAt">This vcam's LookAt value.</param>
         /// <returns>The same value, or the parent's if null and a parent exists.</returns>
-        protected Transform ResolveLookAt(Transform localLookAt)
+        public Transform ResolveLookAt(Transform localLookAt)
         {
             Transform lookAt = localLookAt;
             if (lookAt == null && ParentCamera != null)
@@ -623,7 +623,7 @@ namespace Cinemachine
         /// the parent vcam's Follow target.</summary>
         /// <param name="localFollow">This vcam's Follow value.</param>
         /// <returns>The same value, or the parent's if null and a parent exists.</returns>
-        protected Transform ResolveFollow(Transform localFollow)
+        public Transform ResolveFollow(Transform localFollow)
         {
             Transform follow = localFollow;
             if (follow == null && ParentCamera != null)
@@ -736,5 +736,73 @@ namespace Cinemachine
             state.Lens = lens;
             return state;
         }
+
+        private Transform m_CachedFollowTarget;
+        private CinemachineVirtualCameraBase m_CachedFollowTargetVcam;
+        private ICinemachineTargetGroup m_CachedFollowTargetGroup;
+
+        private Transform m_CachedLookAtTarget;
+        private CinemachineVirtualCameraBase m_CachedLookAtTargetVcam;
+        private ICinemachineTargetGroup m_CachedLookAtTargetGroup;
+
+
+        /// <summary>
+        /// This property is true if the Follow target was changed this frame.
+        /// </summary>
+        public bool FollowTargetChanged { get; private set; }
+
+        /// <summary>
+        /// This property is true if the LookAttarget was changed this frame.
+        /// </summary>
+        public bool LookAtTargetChanged { get; private set; }
+
+        /// <summary>
+        /// Call this from InternalUpdateCameraState() to check for changed 
+        /// targets and update the target cache.  This is needed for tracking
+        /// when a target object changes.
+        /// </summary>
+        protected void UpdateTargetCache()
+        {
+            var target = ResolveFollow(Follow);
+            FollowTargetChanged = target != m_CachedFollowTarget;
+            m_CachedFollowTarget = target;
+            m_CachedFollowTargetVcam = null;
+            m_CachedFollowTargetGroup = null;
+            if (m_CachedFollowTarget != null)
+            {
+                m_CachedFollowTargetVcam = target.GetComponent<CinemachineVirtualCameraBase>();
+                m_CachedFollowTargetGroup = target.GetComponent<ICinemachineTargetGroup>();
+            }
+
+            target = ResolveLookAt(LookAt);
+            LookAtTargetChanged = target != m_CachedLookAtTarget;
+            m_CachedLookAtTarget = target;
+            m_CachedLookAtTargetVcam = null;
+            m_CachedLookAtTargetGroup = null;
+            if (target != null)
+            {
+                m_CachedLookAtTargetVcam = target.GetComponent<CinemachineVirtualCameraBase>();
+                m_CachedLookAtTargetGroup = target.GetComponent<ICinemachineTargetGroup>();
+            }
+            // Reset if target changed
+            if (FollowTargetChanged || LookAtTargetChanged)
+                PreviousStateIsValid = false;
+        }
+
+        /// <summary>Get Follow target as ICinemachineTargetGroup, 
+        /// or null if target is not a ICinemachineTargetGroup</summary>
+        public ICinemachineTargetGroup AbstractFollowTargetGroup => m_CachedFollowTargetGroup;
+
+        /// <summary>Get Follow target as CinemachineVirtualCameraBase, 
+        /// or null if target is not a CinemachineVirtualCameraBase</summary>
+        public CinemachineVirtualCameraBase FollowTargetAsVcam => m_CachedFollowTargetVcam;
+
+        /// <summary>Get LookAt target as ICinemachineTargetGroup, 
+        /// or null if target is not a ICinemachineTargetGroup</summary>
+        public ICinemachineTargetGroup AbstractLookAtTargetGroup => m_CachedLookAtTargetGroup;
+
+        /// <summary>Get LookAt target as CinemachineVirtualCameraBase, 
+        /// or null if target is not a CinemachineVirtualCameraBase</summary>
+        public CinemachineVirtualCameraBase LookAtTargetAsVcam => m_CachedLookAtTargetVcam;
     }
 }

--- a/Runtime/Experimental/CinemachineNewFreeLook.cs
+++ b/Runtime/Experimental/CinemachineNewFreeLook.cs
@@ -375,6 +375,8 @@ namespace Cinemachine
         /// <param name="deltaTime">Delta time for time-based effects (ignore if less than 0)</param>
         override public void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
         {
+            UpdateTargetCache();
+
             FollowTargetAttachment = 1;
             LookAtTargetAttachment = 1;
 

--- a/Runtime/Experimental/CinemachineNewVirtualCamera.cs
+++ b/Runtime/Experimental/CinemachineNewVirtualCamera.cs
@@ -178,6 +178,8 @@ namespace Cinemachine
         /// <param name="deltaTime">Delta time for time-based effects (ignore if less than 0)</param>
         override public void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
         {
+            UpdateTargetCache();
+
             FollowTargetAttachment = 1;
             LookAtTargetAttachment = 1;
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-237: vcam does not respond correctly when target is programmatically changed on a live vcam.

It seems like a big change, but much of it was to set up for upcoming change (allow smooth transitions when target changes on live vcam).

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Can test with sample project included in Jira issue.  

