### PR TITLE
CMCL-269: Framing transposer now handles empty groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: 3rdPersonFollow was stuttering when z damping was high
 - Regression fix: CinemachineInputProvider had stopped providing input
 - Bugfix: lens aspect and sensorSize were not getting updated if lens OverrideMode != None
+- Bugfix: Framing transposer now handles empty groups
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -462,7 +462,7 @@ namespace Cinemachine
 
             // Compute group bounds and adjust follow target for group framing
             ICinemachineTargetGroup group = AbstractFollowTargetGroup;
-            bool isGroupFraming = group != null && m_GroupFramingMode != FramingMode.None;
+            bool isGroupFraming = group != null && m_GroupFramingMode != FramingMode.None && !group.IsEmpty;
             if (isGroupFraming)
                 followTargetPosition = ComputeGroupBounds(group, ref curState);
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-269: Framing transposer does not handle empty groups

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
