### PR TITLE
Collision handling off by default on 3rdPersonFollow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: changing targets on a live vcam was misbehaving
 - Bugfix: Framing transposer now handles empty groups
 - Bugfix: Interrupting a transition with InheritPosition enabled was broken
+- Cinemachine3rdPersonFollow is not handling collision by default.
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -119,7 +119,7 @@ namespace Cinemachine
             CameraDistance = 2.0f;
             Damping = new Vector3(0.1f, 0.5f, 0.3f);
 #if CINEMACHINE_PHYSICS
-            CameraCollisionFilter = 1;
+            CameraCollisionFilter = 0;
             CameraRadius = 0.2f;
             DampingIntoCollision = 0;
             DampingFromCollision = 2f;
@@ -251,6 +251,11 @@ namespace Cinemachine
             float cameraRadius, ref float collisionCorrection)
         {
 #if CINEMACHINE_PHYSICS
+            if (CameraCollisionFilter.value == 0)
+            {
+                return tip;
+            }
+            
             var dir = tip - root;
             var len = dir.magnitude;
             dir /= len;


### PR DESCRIPTION
https://jira.unity3d.com/browse/CMCL-282
By default collision handling should be off.

### Purpose of this PR

Change the default value of 3rdPersonFollow's collision detection to Nothing. This way, collision detection is off by default. Also added a check if the collision filter is nothing, we can just return tip in CollisionHandling.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

0

### Comments to reviewers

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
