### PR TITLE
Blendlist reset works correctly now

### DIFF
--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -320,7 +320,7 @@ namespace Cinemachine
             m_ChildCameras = list.ToArray();
             ValidateInstructions();
         }
-        
+
         /// <summary>Internal API for the inspector editor.</summary>
         /// // GML todo: make this private, part of UpdateListOfChildren()
         internal void ValidateInstructions()
@@ -378,6 +378,5 @@ namespace Cinemachine
         {
             m_ChildCameras = null;
         }
-
     }
 }

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -30,7 +30,7 @@ namespace Cinemachine
             + "specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
         [VcamTargetProperty]
-        public Transform m_LookAt = null;
+        public Transform m_LookAt;
 
         /// <summary>Default object for the camera children wants to move with (the body target), 
         /// if not specified in a child rig.  May be empty</summary>
@@ -38,19 +38,19 @@ namespace Cinemachine
             + "if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
         [VcamTargetProperty]
-        public Transform m_Follow = null;
+        public Transform m_Follow;
 
         /// <summary>When enabled, the current camera and blend will be indicated in the game window, for debugging</summary>
         [Tooltip("When enabled, the current child camera and blend will be indicated in the game window, for debugging")]
-        public bool m_ShowDebugText = false;
+        public bool m_ShowDebugText;
 
         /// <summary>When enabled, the child vcams will cycle indefinitely instead of just stopping at the last one</summary>
         [Tooltip("When enabled, the child vcams will cycle indefinitely instead of just stopping at the last one")]
-        public bool m_Loop = false;
+        public bool m_Loop;
 
         /// <summary>Internal API for the editor.  Do not use this field</summary>
         [SerializeField][HideInInspector][NoSaveDuringPlay]
-        internal CinemachineVirtualCameraBase[] m_ChildCameras = null;
+        internal CinemachineVirtualCameraBase[] m_ChildCameras;
 
         /// <summary>This represents a single entry in the instrunction list of the BlendListCamera.</summary>
         [Serializable]
@@ -93,6 +93,16 @@ namespace Cinemachine
             }
         }
 
+        void Reset()
+        {
+            m_LookAt = null;
+            m_Follow = null;
+            m_ShowDebugText = false;
+            m_Loop = false;
+            m_Instructions = null;
+            m_ChildCameras = null;
+        }
+        
         /// <summary>Get the current "best" child virtual camera, that would be chosen
         /// if the State Driven Camera were active.</summary>
         public ICinemachineCamera LiveChild { set; get; }
@@ -372,11 +382,6 @@ namespace Cinemachine
                 if (m_Loop && mCurrentInstruction == m_Instructions.Length)
                     mCurrentInstruction = 0;
             }
-        }
-        
-        void Reset()
-        {
-            m_ChildCameras = null;
         }
     }
 }

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -320,7 +320,7 @@ namespace Cinemachine
             m_ChildCameras = list.ToArray();
             ValidateInstructions();
         }
-
+        
         /// <summary>Internal API for the inspector editor.</summary>
         /// // GML todo: make this private, part of UpdateListOfChildren()
         internal void ValidateInstructions()
@@ -373,5 +373,11 @@ namespace Cinemachine
                     mCurrentInstruction = 0;
             }
         }
+        
+        void Reset()
+        {
+            m_ChildCameras = null;
+        }
+
     }
 }


### PR DESCRIPTION
https://jira.unity3d.com/browse/CMCL-143
When using a CM BlendListCamera, if you add Virtual Camera Children and you do a Reset on the CinemachineBlendListCamera, they will disapear.

### Purpose of this PR

Fix blend list camera children inspector UI after Reset.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

Do we need to update changelog for this?

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
