### PR TITLE
SaveDuringPlay - Test type string equality instead of contains

### DIFF
--- a/Editor/Utility/SaveDuringPlay.cs
+++ b/Editor/Utility/SaveDuringPlay.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Cinemachine;
 using UnityEditor;
 using UnityEngine;
 
@@ -244,7 +245,7 @@ namespace SaveDuringPlay
             var attrs = b.GetType().GetCustomAttributes(true);
             foreach (var attr in attrs)
             {
-                if (attr.GetType().Name.Contains("SaveDuringPlay"))
+                if (attr is SaveDuringPlayAttribute)
                 {
                     return true;
                 }
@@ -511,7 +512,7 @@ namespace SaveDuringPlay
                 var attrs = b.GetType().GetCustomAttributes(true);
                 foreach (var attr in attrs)
                 {
-                    if (attr.GetType().Name.Contains("SaveDuringPlay"))
+                    if (attr is SaveDuringPlayAttribute)
                     {
                         //Debug.Log("Found " + ObjectTreeUtil.GetFullName(b.gameObject) + " for hot-save");
                         objects.Add(b.transform);

--- a/Editor/Utility/SaveDuringPlay.cs
+++ b/Editor/Utility/SaveDuringPlay.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Cinemachine;
 using UnityEditor;
 using UnityEngine;
 
@@ -245,7 +244,7 @@ namespace SaveDuringPlay
             var attrs = b.GetType().GetCustomAttributes(true);
             foreach (var attr in attrs)
             {
-                if (attr is SaveDuringPlayAttribute)
+                if (attr.GetType().Name.Equals("SaveDuringPlayAttribute"))
                 {
                     return true;
                 }
@@ -333,7 +332,7 @@ namespace SaveDuringPlay
         {
             var attrs = fieldInfo.GetCustomAttributes(false);
             foreach (var attr in attrs)
-                if (attr.GetType().Name.Contains("NoSaveDuringPlay"))
+                if (attr.GetType().Name.Equals("NoSaveDuringPlayAttribute"))
                     return false;
             return true;
         }
@@ -512,7 +511,7 @@ namespace SaveDuringPlay
                 var attrs = b.GetType().GetCustomAttributes(true);
                 foreach (var attr in attrs)
                 {
-                    if (attr is SaveDuringPlayAttribute)
+                    if (attr.GetType().Name.Equals("SaveDuringPlayAttribute"))
                     {
                         //Debug.Log("Found " + ObjectTreeUtil.GetFullName(b.gameObject) + " for hot-save");
                         objects.Add(b.transform);

--- a/Editor/Utility/SaveDuringPlay.cs
+++ b/Editor/Utility/SaveDuringPlay.cs
@@ -383,19 +383,28 @@ namespace SaveDuringPlay
 
         static string StringFromLeafObject(object obj)
         {
-            switch (obj)
+            if (obj == null)
+                return string.Empty;
+
+            if (typeof(Component).IsAssignableFrom(obj.GetType()))
             {
-                case null:
+                Component c = (Component)obj;
+                if (c == null) // Component overrides the == operator, so we have to check
                     return string.Empty;
-                case Component c:
-                    return c == null ? string.Empty : ObjectTreeUtil.GetFullName(c.gameObject);
-                case GameObject go:
-                    return ObjectTreeUtil.GetFullName(go);
-                case ScriptableObject so:
-                    return AssetDatabase.GetAssetPath(so);
-                default:
-                    return obj.ToString();
+                return ObjectTreeUtil.GetFullName(c.gameObject);
             }
+            if (typeof(GameObject).IsAssignableFrom(obj.GetType()))
+            {
+                GameObject go = (GameObject)obj;
+                if (go == null) // GameObject overrides the == operator, so we have to check
+                    return string.Empty;
+                return ObjectTreeUtil.GetFullName(go);
+            }
+            if (typeof(ScriptableObject).IsAssignableFrom(obj.GetType()))
+            {
+                return AssetDatabase.GetAssetPath(obj as ScriptableObject);
+            }
+            return obj.ToString();
         }
     };
 

--- a/Editor/Utility/SaveDuringPlay.cs
+++ b/Editor/Utility/SaveDuringPlay.cs
@@ -551,6 +551,7 @@ namespace SaveDuringPlay
                     Undo.RegisterFullObjectHierarchyUndo(go, "SaveDuringPlay");
                     if (saver.PutFieldValues(go, roots))
                     {
+                        //Debug.Log("SaveDuringPlay: updated settings of " + saver.ObjetFullPath);
                         EditorUtility.SetDirty(go);
                         dirty = true;
                     }


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

Made SaveDuringPlay string with equality instead of contains.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
