### PR TITLE
Normalized Blend Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+- Bugfix: Reversing a blend in progress respects asymmetric blend times.
+
+
 ## [2.8.0-exp.1] - 2021-03-31
 - Added simplified modes for impulse generation, added secondary reaction settings to Impulse Listener.
 - Added Storyboard support for ScreenSpaceOverlay and ScreenSpaceCamera camera render modes.
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Cinemachine3rdPersonFollow was not handling collision by default.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
-- Blends continue from interrupted blends progress.
 
 
 ## [2.7.2] - 2021-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Cinemachine3rdPersonFollow was not handling collision by default.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
+- Blends continue from interrupted blends progress.
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -683,7 +683,7 @@ namespace Cinemachine
                                 && frame.blend.CamB == outGoingCamera
                                 && frame.blend.Duration <= blendDef.BlendTime)
                             {
-                                blendDef.m_Time = frame.blend.TimeInBlend;
+                                blendDef.m_Time = (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;
                             }
 
                             // Chain to existing blend

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -678,12 +678,13 @@ namespace Cinemachine
                         else
                         {
                             // Special case: if backing out of a blend-in-progress
-                            // with the same blend in reverse, adjust the belnd time
+                            // with the same blend in reverse, adjust the blend time
                             if (frame.blend.CamA == activeCamera
                                 && frame.blend.CamB == outGoingCamera
                                 && frame.blend.Duration <= blendDef.BlendTime)
                             {
-                                blendDef.m_Time = (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;
+                                blendDef.m_Time = 
+                                    (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;
                             }
 
                             // Chain to existing blend


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-286
Basically, the user is saying that if we have a fast blend in (from A to B), and a slow blend out (from B to A), then: * if Blend In is interrupted by Blend Out, then Blend Out is going to be fast.

The reason is that in we set the Time without normalizing in CinemachineBrain
if (frame.blend.CamA == activeCamera
&& frame.blend.CamB == outGoingCamera
&& frame.blend.Duration <= blendDef.BlendTime)

{ blendDef.m_Time = frame.blend.TimeInBlend; // <--- here }
I think, instead we should normalize the time like this:
blendDef.m_Time = (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
