### PR TITLE
Dev/physical camera override bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
 - New sample scene: Boss cam, that demonstrates how to setup a camera that follows the player and looks at the player and the boss. It also shows examples of custom extensions.
+- Bugfix: Physical camera properties were overwritten by vcams even when "override mode: physical" was not selected.
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -873,7 +873,7 @@ namespace Cinemachine
                     cam.lensShift = state.Lens.LensShift;
                     cam.orthographic = state.Lens.Orthographic;
                     cam.usePhysicalProperties = state.Lens.IsPhysicalCamera;
-                    if (state.Lens.IsPhysicalCamera)
+                    if (state.Lens.IsPhysicalCamera && state.Lens.ModeOverride == LensSettings.OverrideModes.Physical)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -270,6 +270,7 @@ namespace Cinemachine
             FarClipPlane = farClip;
             Dutch = dutch;
             m_SensorSize = new Vector2(1, 1);
+            GateFit = Camera.GateFitMode.Horizontal;
 
 #if CINEMACHINE_HDRP
             Iso = 200;

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -87,10 +87,10 @@ namespace Cinemachine
 
         /// <summary>
         /// This setting controls whether the Perspective/Ortho, IsPhysical, SensorSize, 
-        /// and GateFit are set in the Camera object, or are overidden here.
+        /// and GateFit are set in the Camera object, or are overridden here.
         /// </summary>
         [Tooltip("This setting controls whether the Perspective/Ortho, IsPhysical, SensorSize, "
-            + "and GateFit are set in the Camera object, or are overidden here.")]
+            + "and GateFit are set in the Camera object, or are overridden here.")]
         public OverrideModes ModeOverride;
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-288
https://forum.unity.com/threads/aspect-ratios-for-all-my-cameras-got-screwed-up-after-updating-to-unity-2021-1.1088641/

Physical camera parameters should be only overwritten when Override mode: physical is selected.


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

0

### Comments to reviewers



### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
