### PR TITLE
CMPostprocessing state bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, after changing the targets, set PreviousStateIsValid to false.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
+- Bugfix: CMPostProcessing components, that relied on the vcam's position (e.g. Depth of Field), did not work correctly with Framing Transposer. 
 
 
 ## [2.8.0-exp.1] - 2021-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, after changing the targets, set PreviousStateIsValid to false.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
-- Bugfix: CMPostProcessing components, that relied on the vcam's position (e.g. Depth of Field), did not work correctly with Framing Transposer. 
+- Bugfix: CmPostProcessing and CmVolumeSettings components, that relied on the vcam's position (e.g. Depth of Field), did not work correctly with Framing Transposer. 
 
 
 ## [2.8.0-exp.1] - 2021-03-31

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -171,7 +171,7 @@ namespace Cinemachine.PostFX
         {
             // Set the focus after the camera has been fully positioned.
             // GML todo: what about collider?
-            if (stage == CinemachineCore.Stage.Aim)
+            if (stage == CinemachineCore.Stage.Finalize)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 if (!IsValid)

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -170,7 +170,6 @@ namespace Cinemachine.PostFX
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             // Set the focus after the camera has been fully positioned.
-            // GML todo: what about collider?
             if (stage == CinemachineCore.Stage.Finalize)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);

--- a/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -167,8 +167,7 @@ namespace Cinemachine.PostFX
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             // Set the focus after the camera has been fully positioned.
-            // GML todo: what about collider?
-            if (stage == CinemachineCore.Stage.Aim)
+            if (stage == CinemachineCore.Stage.Finalize)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 if (!IsValid)


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-290
https://forum.unity.com/threads/depth-of-field-effect-is-broken-when-using-cinemachine-2-6-0-and-above.1088446/

Fix a regression in CMPostProcessing.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

The problem is only with Framing Transposer, because the state is incorrect in the post aim stage.
Applying PostProcessing post Finalize (or Noise) stage fixes this. However, I suspect that there was a reason for applying it post aim. If that's the case, let's discuss a solution. Note, vcam.State.FinalPosition has the correct position value.

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
