### PR TITLE
CMCL-292: 3rdPersonFollow keeps player in view when Z damping high

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, after changing the targets, set PreviousStateIsValid to false.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
+- Regression fix: 3rdPersonFollow keeps player in view when Z damping is high
 - New sample scene: Boss cam, that demonstrates how to setup a camera that follows the player and looks at the player and the boss. It also shows examples of custom extensions.
 
 

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -97,7 +97,7 @@ namespace Cinemachine
 
         // State info
         Vector3 m_PreviousFollowTargetPosition;
-        Vector3 m_DampingCorrection;
+        Vector3 m_DampingCorrection; // this is in local rig space
         float m_CamPosCollisionCorrection;
 
         void OnValidate()
@@ -200,7 +200,7 @@ namespace Cinemachine
             var collidedHand = ResolveCollisions(root, hand, -1, CameraRadius * 1.05f, ref dummy);
 
             // Place the camera at the correct distance from the hand
-            Vector3 camPos = hand - (targetForward * CameraDistance);
+            Vector3 camPos = hand - (targetForward * (CameraDistance - m_DampingCorrection.z));
             camPos = ResolveCollisions(
                 collidedHand, camPos, deltaTime, CameraRadius, ref m_CamPosCollisionCorrection);
 
@@ -241,7 +241,8 @@ namespace Cinemachine
         {
             var shoulderPivotReflected = Vector3.Reflect(ShoulderOffset, Vector3.right);
             var shoulderOffset = Vector3.Lerp(shoulderPivotReflected, ShoulderOffset, CameraSide);
-            shoulderOffset += m_DampingCorrection;
+            shoulderOffset.x += m_DampingCorrection.x;
+            shoulderOffset.y += m_DampingCorrection.y;
             shoulder = root + heading * shoulderOffset;
             hand = shoulder + targetRot * new Vector3(0, VerticalArmLength, 0);   
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-292: 3rdPersonFollow keeps player in view when Z damping high

### Testing status

- [x] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

See forum post and test with AimingRig sample
