### PR TITLE
3rdPerson refactor

### DIFF
--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -95,12 +95,13 @@ namespace Cinemachine
         {
             var aimDistance = AimDistance;
             var player = VirtualCamera.Follow;
-            var playerOrientation = player.transform.rotation;
-            var fwd = playerOrientation * Vector3.forward;
             
             // We don't want to hit targets behind the player
+            var fwd = Vector3.forward;
             if (player != null)
             {
+                var playerOrientation = player.transform.rotation;
+                fwd = playerOrientation * Vector3.forward;
                 var playerPos = Quaternion.Inverse(playerOrientation) * (player.position - camPos);
                 if (playerPos.z > 0)
                 {
@@ -110,8 +111,7 @@ namespace Cinemachine
             }
 
             aimDistance = Mathf.Max(1, aimDistance);
-            bool hasHit = RuntimeUtility.RaycastIgnoreTag(
-                new Ray(camPos, fwd), 
+            bool hasHit = RuntimeUtility.RaycastIgnoreTag(new Ray(camPos, fwd), 
                 out RaycastHit hitInfo, aimDistance, AimCollisionFilter, IgnoreTag);
             return hasHit ? hitInfo.point : camPos + fwd * aimDistance;
         }

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -9,7 +9,8 @@ namespace Cinemachine
 #if CINEMACHINE_PHYSICS
     /// <summary>
     /// An add-on module for Cinemachine Virtual Camera that forces the LookAt
-    /// point to the center of the screen, cancelling noise and other corrections.
+    /// point to the center of the screen, based on the Follow target's orientation,
+    /// cancelling noise and other corrections.
     /// This is useful for third-person style aim cameras that want a dead-accurate
     /// aim at all times, even in the presence of positional or rotational noise.
     /// </summary>
@@ -90,17 +91,17 @@ namespace Cinemachine
             }
         }
 
-        Vector3 GetLookAtPoint(ref CameraState state)
+        Vector3 GetLookAtPoint(Vector3 camPos)
         {
-            var fwd = state.CorrectedOrientation * Vector3.forward;
-            var camPos = state.CorrectedPosition;
             var aimDistance = AimDistance;
-
-            // We don't want to hit targets behind the player
             var player = VirtualCamera.Follow;
+            var playerOrientation = player.transform.rotation;
+            var fwd = playerOrientation * Vector3.forward;
+            
+            // We don't want to hit targets behind the player
             if (player != null)
             {
-                var playerPos = Quaternion.Inverse(state.CorrectedOrientation) * (player.position - camPos);
+                var playerPos = Quaternion.Inverse(playerOrientation) * (player.position - camPos);
                 if (playerPos.z > 0)
                 {
                     camPos += fwd * playerPos.z;
@@ -130,7 +131,7 @@ namespace Cinemachine
             if (stage == CinemachineCore.Stage.Body)
             {
                 // Raycast to establish what we're actually aiming at
-                state.ReferenceLookAt = GetLookAtPoint(ref state);
+                state.ReferenceLookAt = GetLookAtPoint(state.CorrectedPosition);
             }
             if (stage == CinemachineCore.Stage.Finalize)
             {

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -186,7 +186,7 @@ namespace Cinemachine
             {
                 // Damping correction is applied to the shoulder offset - stretching the rig
                 m_DampingCorrection += Quaternion.Inverse(heading) * (m_PreviousFollowTargetPosition - targetPos);
-                m_DampingCorrection -= VirtualCamera.DetachedFollowTargetDamp(m_DampingCorrection, Damping, deltaTime);
+                m_DampingCorrection -= Damper.Damp(m_DampingCorrection, Damping, deltaTime);
             }
 
             m_PreviousFollowTargetPosition = targetPos;
@@ -206,7 +206,6 @@ namespace Cinemachine
 
             // Set state
             curState.RawPosition = camPos;
-            curState.RawOrientation = targetRot;
             curState.ReferenceUp = up;
         }
 

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -186,7 +186,7 @@ namespace Cinemachine
             {
                 // Damping correction is applied to the shoulder offset - stretching the rig
                 m_DampingCorrection += Quaternion.Inverse(heading) * (m_PreviousFollowTargetPosition - targetPos);
-                m_DampingCorrection -= Damper.Damp(m_DampingCorrection, Damping, deltaTime);
+                m_DampingCorrection -= VirtualCamera.DetachedFollowTargetDamp(m_DampingCorrection, Damping, deltaTime);
             }
 
             m_PreviousFollowTargetPosition = targetPos;
@@ -206,6 +206,7 @@ namespace Cinemachine
 
             // Set state
             curState.RawPosition = camPos;
+            curState.RawOrientation = targetRot; // not necessary, but left in to avoid breaking scenes that depend on this
             curState.ReferenceUp = up;
         }
 


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-307
3rdPersonFollow should not set the rotation of the camera to align with CM pipeline. 3rdPersonAim can deduce rotation from Follow target's transform. This also enables other vcam types to emerge (3rdPersonFollow + any Aim component).

Relates to:
https://jira.unity3d.com/browse/CMDO-209

Tests:
Tested manually with all aim components.

1 and 2 are great rigs!

1. Aim: Same As Follow Target -> This works like 3rd Person Aim (without the hit marker)!
2. Aim: HardLookAt -> If looking at the Follow Target, then we have a simpler version of Freelook!
3. Aim: POV -> Feels weird in the example, because player rotates with POV rotations. But, otherwise it is a useful setup. Use case example: submarine periscope (POV looks around, Follow part sets itself so it is where the periscope should be). Possible with other setups too.
4. Aim: Composer -> Use case: third person follow is used like a crane on a target. Composer looks around.
Does not work well if composer is looking at Follow target. Jerky movement.

*********
TODO: changelog
Should we advertise the new interesting rigs? 

1. No hit target 3rd person camera: 3rdPersonFollow + Same As Follow Target
2. Simple Freelook: 3rdPersonFollow + HardLookAt (same target)?

Or should I create example scenes for them, and add them to this PR?

Rest of the changes don't really affect users.
*********

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
