### PR TITLE
[2.7.x] Backport bugfixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Framing transposer now handles empty groups
 - Bugfix: BlendListCamera inspector reset did not reset properly.
 - Bugfix: Cinemachine3rdPersonFollow handled collisions by default, now it is disabled by default.
+- Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: BlendListCamera inspector reset did not reset properly.
 - Bugfix: Cinemachine3rdPersonFollow handled collisions by default, now it is disabled by default.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
+- Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Bugfix: Framing transposer now handles empty groups
 - Bugfix: BlendListCamera inspector reset did not reset properly.
+- Bugfix: Cinemachine3rdPersonFollow handled collisions by default, now it is disabled by default.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
 - Regression fix: 3rdPersonFollow did not keep keep player in view when Z damping is high
 - Regression fix: CmPostProcessing and CmVolumeSettings components setting Depth of Field did not work correctly with Framing Transposer. 
+- Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: 3rdPersonFollow did not keep keep player in view when Z damping is high
 - Regression fix: CmPostProcessing and CmVolumeSettings components setting Depth of Field did not work correctly with Framing Transposer. 
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
+- Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
 - Regression fix: 3rdPersonFollow did not keep keep player in view when Z damping is high
+- Regression fix: CmPostProcessing and CmVolumeSettings components setting Depth of Field did not work correctly with Framing Transposer. 
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
+- Regression fix: 3rdPersonFollow did not keep keep player in view when Z damping is high
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Bugfix: Framing transposer now handles empty groups
+- Bugfix: BlendListCamera inspector reset did not reset properly.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Cinemachine3rdPersonFollow handled collisions by default, now it is disabled by default.
 - Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
 - Bugfix: SaveDuringPlay saves only components that have the SaveDuringPlay attribute.
+- Bugfix: Reversing a blend in progress respects asymmetric blend times.
 
 
 ## [2.7.3] - 2021-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Bugfix: Framing transposer now handles empty groups
+
+
 ## [2.7.3] - 2021-03-24
 - Bugfix: 3rdPersonFollow collision resolution failed when the camera radius was large.
 - Bugfix: 3rdPersonFollow damping was done in world space instead of camera space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: CmPostProcessing and CmVolumeSettings components setting Depth of Field did not work correctly with Framing Transposer. 
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 - Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
+- Regression fix: Physical camera properties were overwritten by vcams even when "override mode: physical" was not selected.
 
 
 ## [2.7.3] - 2021-03-24

--- a/Editor/Utility/EmbeddedAssetHelpers.cs
+++ b/Editor/Utility/EmbeddedAssetHelpers.cs
@@ -63,7 +63,8 @@ namespace Cinemachine.Editor
             string showLabel, bool indent)
         {
             SerializedProperty property = m_Owner.serializedObject.FindProperty(m_PropertyName);
-            UpdateEditor(property);
+            if (m_Editor == null)
+                UpdateEditor(property);
             if (m_Editor == null)
                 AssetFieldWithCreateButton(property, title, defaultName, extension, message);
             else
@@ -103,13 +104,13 @@ namespace Cinemachine.Editor
                             OnChanged(property.objectReferenceValue as T);
                     }
                     GUI.enabled = true;
-                    if(m_Editor.target != null)
+                    if (m_Editor.target != null)
                     {
-			            if (!canEditAsset && GUILayout.Button("Check out"))
-			            {
+                        if (!canEditAsset && GUILayout.Button("Check out"))
+                        {
                             Task task = Provider.Checkout(AssetDatabase.GetAssetPath(m_Editor.target), CheckoutMode.Asset);
-			                task.Wait();
-			            }
+                            task.Wait();
+                        }
                     }
                 }
                 EditorGUILayout.EndVertical();
@@ -154,7 +155,7 @@ namespace Cinemachine.Editor
                 m_Editor = null;
             }
         }
-
+        
         public void UpdateEditor(SerializedProperty property)
         {
             var target = property.objectReferenceValue;

--- a/Editor/Utility/SaveDuringPlay.cs
+++ b/Editor/Utility/SaveDuringPlay.cs
@@ -218,7 +218,7 @@ namespace SaveDuringPlay
         }
 
         /// <summary>
-        /// Recursively scan the MonoBehaviours of a GameObject and its children.
+        /// Recursively scan [SaveDuringPlay] MonoBehaviours of a GameObject and its children.
         /// For each leaf field found, call the OnFieldValue delegate.
         /// </summary>
         public bool ScanFields(GameObject go, string prefix = null)
@@ -233,12 +233,26 @@ namespace SaveDuringPlay
             for (int i = 0; i < components.Length; ++i)
             {
                 MonoBehaviour c = components[i];
-                if (c != null && ScanFields(prefix + c.GetType().FullName + i, c))
+                if (c != null && HasSaveDuringPlay(c) && ScanFields(prefix + c.GetType().FullName + i, c))
                     doneSomething = true;
             }
             return doneSomething;
         }
+
+        static bool HasSaveDuringPlay(MonoBehaviour b)
+        {
+            var attrs = b.GetType().GetCustomAttributes(true);
+            foreach (var attr in attrs)
+            {
+                if (attr.GetType().Name.Contains("SaveDuringPlay"))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     };
+    
 
 
     /// <summary>

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -15,6 +15,7 @@ namespace Cinemachine
     /// </summary>
     [AddComponentMenu("")] // Hide in menu
     [ExecuteAlways]
+    [SaveDuringPlay]
     [DisallowMultipleComponent]
     public class Cinemachine3rdPersonAim : CinemachineExtension
     {

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -30,7 +30,7 @@ namespace Cinemachine
             + "specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
         [VcamTargetProperty]
-        public Transform m_LookAt = null;
+        public Transform m_LookAt;
 
         /// <summary>Default object for the camera children wants to move with (the body target), 
         /// if not specified in a child rig.  May be empty</summary>
@@ -38,19 +38,19 @@ namespace Cinemachine
             + "if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
         [VcamTargetProperty]
-        public Transform m_Follow = null;
+        public Transform m_Follow;
 
         /// <summary>When enabled, the current camera and blend will be indicated in the game window, for debugging</summary>
         [Tooltip("When enabled, the current child camera and blend will be indicated in the game window, for debugging")]
-        public bool m_ShowDebugText = false;
+        public bool m_ShowDebugText;
 
         /// <summary>When enabled, the child vcams will cycle indefinitely instead of just stopping at the last one</summary>
         [Tooltip("When enabled, the child vcams will cycle indefinitely instead of just stopping at the last one")]
-        public bool m_Loop = false;
+        public bool m_Loop;
 
         /// <summary>Internal API for the editor.  Do not use this field</summary>
         [SerializeField][HideInInspector][NoSaveDuringPlay]
-        internal CinemachineVirtualCameraBase[] m_ChildCameras = null;
+        internal CinemachineVirtualCameraBase[] m_ChildCameras;
 
         /// <summary>This represents a single entry in the instrunction list of the BlendListCamera.</summary>
         [Serializable]
@@ -93,6 +93,16 @@ namespace Cinemachine
             }
         }
 
+        void Reset()
+        {
+            m_LookAt = null;
+            m_Follow = null;
+            m_ShowDebugText = false;
+            m_Loop = false;
+            m_Instructions = null;
+            m_ChildCameras = null;
+        }
+        
         /// <summary>Get the current "best" child virtual camera, that would be chosen
         /// if the State Driven Camera were active.</summary>
         public ICinemachineCamera LiveChild { set; get; }

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -853,7 +853,7 @@ namespace Cinemachine
                     cam.lensShift = state.Lens.LensShift;
                     cam.orthographic = state.Lens.Orthographic;
                     cam.usePhysicalProperties = state.Lens.IsPhysicalCamera;
-                    if (state.Lens.IsPhysicalCamera)
+                    if (state.Lens.IsPhysicalCamera && state.Lens.ModeOverride == LensSettings.OverrideModes.Physical)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -658,12 +658,13 @@ namespace Cinemachine
                         else
                         {
                             // Special case: if backing out of a blend-in-progress
-                            // with the same blend in reverse, adjust the belnd time
+                            // with the same blend in reverse, adjust the blend time
                             if (frame.blend.CamA == activeCamera
                                 && frame.blend.CamB == outGoingCamera
                                 && frame.blend.Duration <= blendDef.BlendTime)
                             {
-                                blendDef.m_Time = frame.blend.TimeInBlend;
+                                blendDef.m_Time = 
+                                    (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;
                             }
 
                             // Chain to existing blend

--- a/Runtime/Behaviours/CinemachineCameraOffset.cs
+++ b/Runtime/Behaviours/CinemachineCameraOffset.cs
@@ -8,6 +8,7 @@ using Cinemachine;
 [AddComponentMenu("")] // Hide in menu
 [ExecuteAlways]
 [HelpURL(Documentation.BaseURL + "api/Cinemachine.CinemachineCameraOffset.html")]
+[SaveDuringPlay]
 public class CinemachineCameraOffset : CinemachineExtension
 {
     /// <summary>

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -285,7 +285,9 @@ namespace Cinemachine
                 if (m_AvoidObstacles)
                 {
                     Vector3 displacement = Vector3.zero;
-                    displacement = PreserveLignOfSight(ref state, ref extra);
+                    displacement = PreserveLineOfSight(ref state, ref extra);
+                    extra.m_previousDisplacement = 
+                        Quaternion.Euler(state.PositionDampingBypass) * extra.m_previousDisplacement;
                     if (m_MinimumOcclusionTime > Epsilon)
                     {
                         float now = CinemachineCore.CurrentTime;
@@ -377,7 +379,7 @@ namespace Cinemachine
             }
         }
 
-        private Vector3 PreserveLignOfSight(ref CameraState state, ref VcamExtraState extra)
+        private Vector3 PreserveLineOfSight(ref CameraState state, ref VcamExtraState extra)
         {
             Vector3 displacement = Vector3.zero;
             if (state.HasLookAt && m_CollideAgainst != 0

--- a/Runtime/Behaviours/CinemachineRecomposer.cs
+++ b/Runtime/Behaviours/CinemachineRecomposer.cs
@@ -8,6 +8,7 @@ using Cinemachine;
 /// </summary>
 [AddComponentMenu("")] // Hide in menu
 [ExecuteAlways]
+[SaveDuringPlay]
 [HelpURL(Documentation.BaseURL + "manual/CinemachineRecomposer.html")]
 public class CinemachineRecomposer : CinemachineExtension
 {

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -97,7 +97,7 @@ namespace Cinemachine
             CameraDistance = 2.0f;
             Damping = new Vector3(0.1f, 0.5f, 0.3f);
 #if CINEMACHINE_PHYSICS
-            CameraCollisionFilter = 1;
+            CameraCollisionFilter = 0;
             CameraRadius = 0.2f;
 #else
             CameraRadius = 0.02f;
@@ -218,6 +218,11 @@ namespace Cinemachine
         Vector3 ResolveCollisions(Vector3 root, Vector3 tip, float cameraRadius)
         {
 #if CINEMACHINE_PHYSICS
+            if (CameraCollisionFilter.value == 0)
+            {
+                return tip;
+            }
+            
             var dir = tip - root;
             var len = dir.magnitude;
             dir /= len;

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -78,7 +78,7 @@ namespace Cinemachine
 
         // State info
         Vector3 m_PreviousFollowTargetPosition;
-        Vector3 m_DampingCorrection;
+        Vector3 m_DampingCorrection; // this is in local rig space
 
         void OnValidate()
         {
@@ -171,7 +171,7 @@ namespace Cinemachine
             var collidedHand = ResolveCollisions(root, hand, CameraRadius * 1.05f);
 
             // Place the camera at the correct distance from the hand
-            Vector3 camPos = hand - (targetForward * CameraDistance);
+            Vector3 camPos = hand - (targetForward * (CameraDistance - m_DampingCorrection.z));
             camPos = ResolveCollisions(collidedHand, camPos, CameraRadius);
 
             // Set state
@@ -210,7 +210,8 @@ namespace Cinemachine
         {
             var shoulderPivotReflected = Vector3.Reflect(ShoulderOffset, Vector3.right);
             var shoulderOffset = Vector3.Lerp(shoulderPivotReflected, ShoulderOffset, CameraSide);
-            shoulderOffset += m_DampingCorrection;
+            shoulderOffset.x += m_DampingCorrection.x;
+            shoulderOffset.y += m_DampingCorrection.y;
             shoulder = root + heading * shoulderOffset;
             hand = shoulder + targetRot * new Vector3(0, VerticalArmLength, 0);   
         }

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -462,7 +462,7 @@ namespace Cinemachine
 
             // Compute group bounds and adjust follow target for group framing
             ICinemachineTargetGroup group = AbstractFollowTargetGroup;
-            bool isGroupFraming = group != null && m_GroupFramingMode != FramingMode.None;
+            bool isGroupFraming = group != null && m_GroupFramingMode != FramingMode.None && !group.IsEmpty;
             if (isGroupFraming)
                 followTargetPosition = ComputeGroupBounds(group, ref curState);
 

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -364,6 +364,7 @@ namespace Cinemachine
         {
             base.ForceCameraPosition(pos, rot);
             m_PreviousCameraPosition = pos;
+            m_prevRotation = rot;
         }
         
         /// <summary>
@@ -388,7 +389,8 @@ namespace Cinemachine
         {
             if (fromCam != null && transitionParams.m_InheritPosition)
             {
-                transform.rotation = fromCam.State.RawOrientation;
+                m_PreviousCameraPosition = fromCam.State.RawPosition;
+                m_prevRotation = fromCam.State.RawOrientation;
                 InheritingPosition = true;
                 return true;
             }

--- a/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -421,15 +421,6 @@ namespace Cinemachine
             return pos;
         }
 
-        static string GetFullName(GameObject current)
-        {
-            if (current == null)
-                return "";
-            if (current.transform.parent == null)
-                return "/" + current.name;
-            return GetFullName(current.transform.parent.gameObject) + "/" + current.name;
-        }
-
         // Make sure this is calld only once per frame
         private float GetTargetHeading(float currentHeading, Quaternion targetOrientation)
         {

--- a/Runtime/Components/CinemachineTrackedDolly.cs
+++ b/Runtime/Components/CinemachineTrackedDolly.cs
@@ -308,7 +308,7 @@ namespace Cinemachine
                         return Quaternion.LookRotation(FollowTargetRotation * Vector3.forward, up);
                     break;
             }
-            return Quaternion.LookRotation(transform.rotation * Vector3.forward, up);
+            return Quaternion.LookRotation(VirtualCamera.transform.rotation * Vector3.forward, up);
         }
 
         private Vector3 AngularDamping

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -87,10 +87,10 @@ namespace Cinemachine
 
         /// <summary>
         /// This setting controls whether the Perspective/Ortho, IsPhysical, SensorSize, 
-        /// and GateFit are set in the Camera object, or are overidden here.
+        /// and GateFit are set in the Camera object, or are overridden here.
         /// </summary>
         [Tooltip("This setting controls whether the Perspective/Ortho, IsPhysical, SensorSize, "
-            + "and GateFit are set in the Camera object, or are overidden here.")]
+            + "and GateFit are set in the Camera object, or are overridden here.")]
         public OverrideModes ModeOverride;
 
         /// <summary>
@@ -270,6 +270,7 @@ namespace Cinemachine
             FarClipPlane = farClip;
             Dutch = dutch;
             m_SensorSize = new Vector2(1, 1);
+            GateFit = Camera.GateFitMode.Horizontal;
 
 #if CINEMACHINE_HDRP
             Iso = 200;

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -20,6 +20,7 @@ namespace Cinemachine.PostFX
     /// applying them to the current Post-Processing profile, provided that profile has a
     /// DepthOfField effect that is enabled.
     /// </summary>
+    [SaveDuringPlay]
     [AddComponentMenu("")] // Hide in menu
     public class CinemachinePostProcessing : CinemachineExtension 
     {

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -163,8 +163,7 @@ namespace Cinemachine.PostFX
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             // Set the focus after the camera has been fully positioned.
-            // GML todo: what about collider?
-            if (stage == CinemachineCore.Stage.Aim)
+            if (stage == CinemachineCore.Stage.Finalize)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 if (!IsValid)

--- a/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -160,8 +160,7 @@ namespace Cinemachine.PostFX
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             // Set the focus after the camera has been fully positioned.
-            // GML todo: what about collider?
-            if (stage == CinemachineCore.Stage.Aim)
+            if (stage == CinemachineCore.Stage.Finalize)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 if (!IsValid)


### PR DESCRIPTION
Backport of bugfixes from 2.8:

- Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
- Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
- Regression fix: CmPostProcessing and CmVolumeSettings components setting Depth of Field now works correctly with Framing Transposer. 
- Regression fix: 3rdPersonFollow kept player in view when Z damping was high.
- Bugfix: Reversing a blend in progress respects asymmetric blend times.
- Bugfix: SaveDuringPlay saved some components that did not have the SaveDuringPlay attribute.
- Regression fix: Entries in the custom blends editor in CM Brain inspector were not selectable.
- Bugfix: Cinemachine3rdPersonFollow handled collisions by default, now it is disabled by default.
- Bugfix: BlendListCamera inspector reset did not reset properly.
- Bugfix: Framing transposer did not handle empty groups.
- Regression fix: Physical camera properties were overwritten by vcams when "override mode: physical" was not selected.
