### PR TITLE
Freelook prefab children are no longer visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Reversing a blend in progress respects asymmetric blend times.
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 - Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
+- Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 
 
 ## [2.8.0-exp.1] - 2021-03-31

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -184,6 +184,9 @@ namespace Cinemachine
             base.OnEnable();
             InvalidateRigCache();
             UpdateInputAxisProvider();
+#if UNITY_EDITOR
+            SetFlagsForHiddenChildren();
+#endif
         }
 
         /// <summary>
@@ -836,7 +839,7 @@ namespace Cinemachine
         }
         
 #if UNITY_EDITOR
-        private void SetFlagsForHiddenChildren(GameObject gameObject)
+        private void SetFlagsForHiddenChildren(GameObject _ = null)
         {
             for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
                 if (m_Rigs[i] != null)

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -157,6 +157,10 @@ namespace Cinemachine
             m_Lens.Validate();
 
             InvalidateRigCache();
+            
+#if UNITY_EDITOR
+            SetFlagsForHiddenChildren();
+#endif
         }
 
         /// <summary>Get a child rig</summary>
@@ -172,15 +176,6 @@ namespace Cinemachine
         public static string[] RigNames { get { return new string[] { "TopRig", "MiddleRig", "BottomRig" }; } }
 
         bool mIsDestroyed = false;
-
-#if UNITY_EDITOR
-        private void Awake()
-        {
-            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
-            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
-            SetFlagsForHiddenChildren();
-        }
-#endif
 
         /// <summary>Updates the child rig cache</summary>
         protected override void OnEnable()

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using Cinemachine.Utility;
 using UnityEngine.Serialization;
 using System;
-using UnityEditor;
 
 namespace Cinemachine
 {
@@ -136,8 +135,8 @@ namespace Cinemachine
         {
             base.OnValidate();
 #if UNITY_EDITOR
-            PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
-            PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
+            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
+            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
 #endif
 
             // Upgrade after a legacy deserialize
@@ -840,7 +839,6 @@ namespace Cinemachine
 #if UNITY_EDITOR
         private void SetFlagsForHiddenChildren(GameObject gameObject)
         {
-            // Debug.Log("PrefabInstanceUpdated:"+go.name);
             for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
                 if (m_Rigs[i] != null)
                     CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -159,7 +159,9 @@ namespace Cinemachine
             InvalidateRigCache();
             
 #if UNITY_EDITOR
-            SetFlagsForHiddenChildren();
+            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
+                if (m_Rigs[i] != null)
+                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
 #endif
         }
 
@@ -609,7 +611,6 @@ namespace Cinemachine
                     DestroyRigs();
                     m_Rigs = CreateRigs(copyFrom);
                 }
-                SetFlagsForHiddenChildren();
             }
 #endif
 
@@ -835,14 +836,5 @@ namespace Cinemachine
                 m_CachedTension = m_SplineCurvature;
             }
         }
-        
-#if UNITY_EDITOR
-        private void SetFlagsForHiddenChildren(GameObject _ = null)
-        {
-            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
-                if (m_Rigs[i] != null)
-                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
-        }
-#endif
     }
 }

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -588,7 +588,6 @@ namespace Cinemachine
                     }
                 }
             }
-            
             return newRigs;
         }
 

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using Cinemachine.Utility;
 using UnityEngine.Serialization;
 using System;
+using UnityEditor;
 
 namespace Cinemachine
 {
@@ -134,6 +135,10 @@ namespace Cinemachine
         protected override void OnValidate()
         {
             base.OnValidate();
+#if UNITY_EDITOR
+            PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
+            PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
+#endif
 
             // Upgrade after a legacy deserialize
             if (m_LegacyHeadingBias != float.MaxValue)
@@ -479,8 +484,8 @@ namespace Cinemachine
         CameraState m_State = CameraState.Default;          // Current state this frame
 
         /// Serialized in order to support copy/paste
-        [SerializeField][HideInInspector][NoSaveDuringPlay] private CinemachineVirtualCamera[] m_Rigs
-            = new CinemachineVirtualCamera[3];
+        [SerializeField][HideInInspector][NoSaveDuringPlay]
+        private CinemachineVirtualCamera[] m_Rigs = new CinemachineVirtualCamera[3];
 
         void InvalidateRigCache() { mOrbitals = null; }
         CinemachineOrbitalTransposer[] mOrbitals = null;
@@ -584,6 +589,7 @@ namespace Cinemachine
                     }
                 }
             }
+            
             return newRigs;
         }
 
@@ -606,9 +612,6 @@ namespace Cinemachine
                     m_Rigs = CreateRigs(copyFrom);
                 }
             }
-            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
-                if (m_Rigs[i] != null)
-                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
 #endif
 
             // Early out if we're up to date
@@ -833,5 +836,15 @@ namespace Cinemachine
                 m_CachedTension = m_SplineCurvature;
             }
         }
+        
+#if UNITY_EDITOR
+        private void SetFlagsForHiddenChildren(GameObject gameObject)
+        {
+            // Debug.Log("PrefabInstanceUpdated:"+go.name);
+            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
+                if (m_Rigs[i] != null)
+                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
+        }
+#endif
     }
 }

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -173,6 +173,15 @@ namespace Cinemachine
 
         bool mIsDestroyed = false;
 
+#if UNITY_EDITOR
+        private void Awake()
+        {
+            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
+            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
+            SetFlagsForHiddenChildren();
+        }
+#endif
+
         /// <summary>Updates the child rig cache</summary>
         protected override void OnEnable()
         {
@@ -180,11 +189,6 @@ namespace Cinemachine
             base.OnEnable();
             InvalidateRigCache();
             UpdateInputAxisProvider();
-#if UNITY_EDITOR
-            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
-            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
-            SetFlagsForHiddenChildren();
-#endif
         }
 
         /// <summary>
@@ -610,6 +614,7 @@ namespace Cinemachine
                     DestroyRigs();
                     m_Rigs = CreateRigs(copyFrom);
                 }
+                SetFlagsForHiddenChildren();
             }
 #endif
 

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -134,10 +134,6 @@ namespace Cinemachine
         protected override void OnValidate()
         {
             base.OnValidate();
-#if UNITY_EDITOR
-            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
-            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
-#endif
 
             // Upgrade after a legacy deserialize
             if (m_LegacyHeadingBias != float.MaxValue)
@@ -185,6 +181,8 @@ namespace Cinemachine
             InvalidateRigCache();
             UpdateInputAxisProvider();
 #if UNITY_EDITOR
+            UnityEditor.PrefabUtility.prefabInstanceUpdated -= SetFlagsForHiddenChildren;
+            UnityEditor.PrefabUtility.prefabInstanceUpdated += SetFlagsForHiddenChildren;
             SetFlagsForHiddenChildren();
 #endif
         }


### PR DESCRIPTION
### Purpose of this PR

User reported some problems with freelook prefabs, when applying prefab modifications (Override -> Apply All).

1. The children can become visible. 
2. Data is lost.

I could reproduce #1, but not #2. 
I think #2 is a user error. I think this is what happens:
They modify parameter X on prefab instance A, then they modify parameter X on prefab instance B, and then they try to override all prefabs with Override -> Apply All from prefab instance B.
Instance A is not modified in this case, but this is the expected behaviour.

#1 is fixed by adding the HideChildren functionality to the prefab override callback.

https://forum.unity.com/threads/cinemachine-freelook-prefabs-seem-to-become-corrupted.532989/#post-7079488

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Low

### Comments to reviewers

I deleted SetChildrenFlag from UpdateRigCache. The reason is that I don't see a reason for setting the flags there. However, it is possible I overlooked something, and there is a case where this is needed.

### Package version

- [ ] Updated package version
