### PR TITLE
Dev/3rdperson heading fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New Sample scene: **2D fighters**, showing how to add/remove targets gradually to/from a TargetGroup based on some conditions (here, it is the y coord of the players).
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 - Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
+- Bugfix: 3rdPersonFollow's shoulder now changes smoothly with respect to world-up vector changes.
 
 
 ## [2.7.2] - 2021-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Bugfix: 3rdPersonFollow works with Aim components now.
 
 ## [2.8.0-pre.1] - 2021-04-21
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, set PreviousStateIsValid to false after changing the targets.

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -231,8 +231,8 @@ namespace Cinemachine
         Quaternion GetHeading(Vector3 targetForward, Vector3 up)
         {
             var planeForward = targetForward.ProjectOntoPlane(up);
-            var heading = UnityVectorExtensions.SignedAngle(Vector3.forward, planeForward, up);
-            return Quaternion.AngleAxis(heading, up);
+            planeForward = Vector3.Cross(up, Vector3.Cross(planeForward, up));
+            return Quaternion.LookRotation(planeForward, up);
         }
 
         void GetRawRigPositions(


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-312
https://forum.unity.com/threads/possible-bug-with-cinemachine3rdpersonfollow-shoulderoffset-with-none-default-world-up.1103932/

3rdPersonFollow's GetHeading function was not smooth. Now it is.

To reproduce the problem, set world up override, and then slowly rotate the overriding gameObject along the X axis. There is a jump at 90 degrees. Other axes were ok.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
