### PR TITLE
added all editors to publish validation tests

### DIFF
--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -3,6 +3,7 @@ test_editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: trunk
 test_platforms:
   - name: win
     type: Unity::VM
@@ -22,7 +23,11 @@ test_platforms:
     flavor: b1.large
 
 validation_editors:
+  - version: 2018.4
+  - version: 2019.4
   - version: 2020.3
+  - version: 2021.1
+  - version: trunk
 validation_platforms:
   - name: ubuntu
     type: Unity::VM


### PR DESCRIPTION
Attempting to fix this error:

[14:49:14.611 Information] [UPM-CI-UTILS] ERROR - It doesn't look like any tests were run on Unity editor version 2018.4 that's currently defined in the package manifest.