### PR TITLE
CMCL-311 POV recentering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New Sample scene: **2D fighters**, showing how to add/remove targets gradually to/from a TargetGroup based on some conditions (here, it is the y coord of the players).
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 - Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
+- Bugfix: POV recentering did not recenter correctly, when the Y axis was limited.
 
 
 ## [2.7.2] - 2021-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New Sample scene: **2D fighters**, showing how to add/remove targets gradually to/from a TargetGroup based on some conditions (here, it is the y coord of the players).
 - Bugfix: CinemachineCollider's displacement damping was being calculated in world space instead of camera space.
 - Bugfix: TrackedDolly sometimes introduced spurious rotations if Default Up and no Aim behaviour.
-- Bugfix: POV recentering did not recenter correctly, when the Y axis was limited.
+- Bugfix: POV recentering did not recenter correctly, when an axis was limited.
 
 
 ## [2.7.2] - 2021-02-15

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -159,23 +159,15 @@ namespace Cinemachine
                 if (parent != null)
                     fwd = parent.rotation * fwd;
                 var v = Quaternion.FromToRotation(Vector3.forward, fwd).eulerAngles;
-                return new Vector2(MapAngleTo180(v.y), MapAngleTo180(v.x));
+                return new Vector2(NormalizeAngle(v.y), NormalizeAngle(v.x));
             }
             return Vector2.zero;
         }
 
-        static float MapAngleTo180(float angle)
+        // Normalize angle value to [-180, 180] degrees.
+        static float NormalizeAngle(float angle)
         {
-            // map angle values from [-360, 360] to [-180, 180] degrees.
-            if (angle > 180f)
-            {
-                angle = -180f + (angle - 180f);
-            }
-            else if (angle < -180f)
-            {
-                angle = 180f + (angle + 180f);
-            }
-            return angle;
+            return ((angle + 180) % 360) - 180; 
         }
 
         /// <summary>

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -159,9 +159,23 @@ namespace Cinemachine
                 if (parent != null)
                     fwd = parent.rotation * fwd;
                 var v = Quaternion.FromToRotation(Vector3.forward, fwd).eulerAngles;
-                return new Vector2(v.y, v.x);
+                return new Vector2(MapAngleTo180(v.y), MapAngleTo180(v.x));
             }
             return Vector2.zero;
+        }
+
+        float MapAngleTo180(float angle)
+        {
+            // map angle values from [-360, 360] to [-180, 180] degrees.
+            if (angle > 180f)
+            {
+                angle = -180f + (angle - 180f);
+            }
+            else if (angle < -180f)
+            {
+                angle = 180f + (angle + 180f);
+            }
+            return angle;
         }
 
         /// <summary>

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -164,7 +164,7 @@ namespace Cinemachine
             return Vector2.zero;
         }
 
-        float MapAngleTo180(float angle)
+        static float MapAngleTo180(float angle)
         {
             // map angle values from [-360, 360] to [-180, 180] degrees.
             if (angle > 180f)


### PR DESCRIPTION
### Purpose of this PR

Useful notes on how to reproduce the issue in the JIRA ticket:
https://jira.unity3d.com/browse/CMCL-311

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

Low

### Comments to reviewers

@glabute 
I added the change (MapAngleTo180) to CinemachinePOV.cs to localize the fix. I did not see the bug arise for other classes using AxisState.ClampValue. However, it may be better to put this mapping function to AxisState.ClampValue call.

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
