### PR TITLE
ReferenceUp is not correct in CameraState Lerp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 - Bugfix: 3rdPersonFollow works with Aim components now. 
+- Bugfix: Blends between vcams, that are rotated so that their up vector is different from World up, are correct now.
 
 ## [2.8.0-pre.1] - 2021-04-21
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, set PreviousStateIsValid to false after changing the targets.

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -393,17 +393,17 @@ namespace Cinemachine
                     else
                     {
                         // Put the target in the center
-                        var blendUp = 
-                            Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
+                        var blendUp = Vector3.Slerp(
+                            stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
                         newOrient = Quaternion.LookRotation(dirTarget, blendUp);
 
                         // Blend the desired offsets from center
                         Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, stateA.ReferenceUp);
+                                stateA.ReferenceLookAt - stateA.CorrectedPosition, blendUp);
                         Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, stateB.ReferenceUp);
+                                stateB.ReferenceLookAt - stateB.CorrectedPosition, blendUp);
                         newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
+                                Vector2.Lerp(deltaA, deltaB, adjustedT), blendUp);
                     }
                 }
             }

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -299,7 +299,7 @@ namespace Cinemachine
                 else
                     state.Lens = stateA.Lens;
             }
-            state.ReferenceUp = Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
+            state.ReferenceUp = Vector3.Slerp(stateA.ReferenceUp, stateB.ReferenceUp, t);
             state.ShotQuality = Mathf.Lerp(stateA.ShotQuality, stateB.ShotQuality, t);
 
             state.PositionCorrection = ApplyPosBlendHint(
@@ -393,7 +393,9 @@ namespace Cinemachine
                     else
                     {
                         // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
+                        var blendUp = 
+                            Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
+                        newOrient = Quaternion.LookRotation(dirTarget, blendUp);
 
                         // Blend the desired offsets from center
                         Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -299,7 +299,7 @@ namespace Cinemachine
                 else
                     state.Lens = stateA.Lens;
             }
-            state.ReferenceUp = Vector3.Slerp(stateA.ReferenceUp, stateB.ReferenceUp, t);
+            state.ReferenceUp = Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
             state.ShotQuality = Mathf.Lerp(stateA.ShotQuality, stateB.ShotQuality, t);
 
             state.PositionCorrection = ApplyPosBlendHint(
@@ -370,6 +370,8 @@ namespace Cinemachine
                     if (angle > UnityVectorExtensions.Epsilon)
                         dirTarget = state.ReferenceLookAt - state.CorrectedPosition;
                 }
+                
+                
                 if (dirTarget.AlmostZero() 
                     || ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.IgnoreLookAtTarget) != 0)
                 {


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-315

I am not sure about the fix. I am a bit afraid that somewhere something expects the Lerp result to have a ReferenceUp that is the same as Brain World up. 

The State Lerp code clearly expects the reference up to be dependent on the orientation of the vcam.
`state.ReferenceUp = Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);`

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested. But not extensively. Tested with different cinemachine body and aim components and with a couple of different rotations.

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

Low, but see Purpose of PR

### Comments to reviewers

I am not sure about the fix. I am a bit afraid that somewhere something expects the Lerp result to have a ReferenceUp that is the same as Brain World up. 

The State Lerp code clearly expects the reference up to be dependent on the orientation of the vcam.
`state.ReferenceUp = Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);`

### Package version

- [ ] Updated package version
