### PR TITLE
CMCL-320: 3rdPersonAim extension can now specify the ray start. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 - Bugfix: 3rdPersonFollow works with Aim components now. 
+- 3rdPersonAim extension can specify the start of the object detection ray.
 
 ## [2.8.0-pre.1] - 2021-04-21
 - Switching targets (Follow, LookAt) is smooth by default. For the old behaviour, set PreviousStateIsValid to false after changing the targets.

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -2,7 +2,6 @@
 #define CINEMACHINE_PHYSICS
 #endif
 
-using System;
 using UnityEngine;
 
 namespace Cinemachine
@@ -52,12 +51,12 @@ namespace Cinemachine
             + "May be null, in which case no on-screen indicator will appear")]
         public RectTransform AimTargetReticle;
 
-        private void OnValidate()
+        void OnValidate()
         {
             AimDistance = Mathf.Max(1, AimDistance);
         }
 
-        private void Reset()
+        void Reset()
         {
             AimCollisionFilter = 1;
             IgnoreTag = string.Empty;
@@ -88,11 +87,11 @@ namespace Cinemachine
                 if (AimTargetReticle != null && player != null)
                 {
                     // Adjust for actual player aim target (may be different due to offset)
-                    m_rayStart = RayStart != null ? RayStart.position : player.position;
+                    m_RayStart = RayStart != null ? RayStart.position : player.position;
                     var aimTarget = VirtualCamera.State.ReferenceLookAt;
-                    m_rayDirection = aimTarget - m_rayStart;
-                    if (RuntimeUtility.RaycastIgnoreTag(new Ray(m_rayStart, m_rayDirection), 
-                            out RaycastHit hitInfo, m_rayDirection.magnitude, AimCollisionFilter, IgnoreTag))
+                    m_RayDirection = aimTarget - m_RayStart;
+                    if (RuntimeUtility.RaycastIgnoreTag(new Ray(m_RayStart, m_RayDirection), 
+                            out RaycastHit hitInfo, m_RayDirection.magnitude, AimCollisionFilter, IgnoreTag))
                         aimTarget = hitInfo.point;
                     AimTargetReticle.position = brain.OutputCamera.WorldToScreenPoint(aimTarget);
                 }
@@ -152,12 +151,12 @@ namespace Cinemachine
             }
         }
 
-        Vector3 m_rayStart, m_rayDirection;
+        Vector3 m_RayStart, m_RayDirection;
 #if UNITY_EDITOR
         void OnDrawGizmosSelected()
         {
             Gizmos.color = Color.red;
-            Gizmos.DrawRay(m_rayStart, m_rayDirection); // draw object detection ray
+            Gizmos.DrawRay(m_RayStart, m_RayDirection); // draw object detection ray
         }
 #endif
     }

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -2,6 +2,7 @@
 #define CINEMACHINE_PHYSICS
 #endif
 
+using System;
 using UnityEngine;
 
 namespace Cinemachine
@@ -35,6 +36,13 @@ namespace Cinemachine
         /// <summary>How far to project the object detection ray.</summary>
         [Tooltip("How far to project the object detection ray")]
         public float AimDistance;
+
+        
+        /// <summary>Start of the object detection ray. If unset, then ray is shot from the follow target.
+        /// It is usually a good idea to set this to the tip of your gun.</summary>
+        [Tooltip("Start of the object detection ray. If unset, then ray is shot from the follow target. " +
+            "It is usually a good idea to set this to the tip of your gun.")]
+        public Transform RayStart;
 
         /// <summary>This 2D object will be positioned in the game view over the raycast hit point, 
         /// if any, or will remain in the center of the screen if no hit point is 
@@ -80,11 +88,11 @@ namespace Cinemachine
                 if (AimTargetReticle != null && player != null)
                 {
                     // Adjust for actual player aim target (may be different due to offset)
-                    var playerPos = player.position;
+                    m_rayStart = RayStart != null ? RayStart.position : player.position;
                     var aimTarget = VirtualCamera.State.ReferenceLookAt;
-                    var dir = aimTarget - playerPos;
-                    if (RuntimeUtility.RaycastIgnoreTag(new Ray(playerPos, dir), 
-                            out RaycastHit hitInfo, dir.magnitude, AimCollisionFilter, IgnoreTag))
+                    m_rayDirection = aimTarget - m_rayStart;
+                    if (RuntimeUtility.RaycastIgnoreTag(new Ray(m_rayStart, m_rayDirection), 
+                            out RaycastHit hitInfo, m_rayDirection.magnitude, AimCollisionFilter, IgnoreTag))
                         aimTarget = hitInfo.point;
                     AimTargetReticle.position = brain.OutputCamera.WorldToScreenPoint(aimTarget);
                 }
@@ -143,6 +151,15 @@ namespace Cinemachine
                 }
             }
         }
+
+        Vector3 m_rayStart, m_rayDirection;
+#if UNITY_EDITOR
+        void OnDrawGizmosSelected()
+        {
+            Gizmos.color = Color.red;
+            Gizmos.DrawRay(m_rayStart, m_rayDirection); // draw object detection ray
+        }
+#endif
     }
 #endif
 }


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-320

3rdPersonAim can specify ray start. Useful for setting the tip of the gun for more precise hit target calculation.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

0

### Comments to reviewers

### Package version

- [ ] Updated package version
