### PR TITLE
Dev/cmcl 271 lens override

### DIFF
--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -479,10 +479,6 @@ namespace Cinemachine.Editor
                 return default(T);
         }
         
-        // TODO: KGB - refactor this
-        // - Mode Override should be moved to the top of the foldout as it affects other fields
-        // - Camera native lens mode should be cached so it can be restored after the last override ends.
-        // Right now it is left in an overridden state
         public void DrawLensSettingsInInspector(SerializedProperty property)
         {
             Rect rect = EditorGUILayout.GetControlRect(true);

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -479,6 +479,10 @@ namespace Cinemachine.Editor
                 return default(T);
         }
         
+        // TODO: KGB - refactor this
+        // - Mode Override should be moved to the top of the foldout as it affects other fields
+        // - Camera native lens mode should be cached so it can be restored after the last override ends.
+        // Right now it is left in an overridden state
         public void DrawLensSettingsInInspector(SerializedProperty property)
         {
             Rect rect = EditorGUILayout.GetControlRect(true);
@@ -502,13 +506,14 @@ namespace Cinemachine.Editor
             else
             {
                 ++EditorGUI.indentLevel;
+                
+                EditorGUILayout.PropertyField(ModeOverrideProperty);
 
                 rect = EditorGUILayout.GetControlRect(true);
                 DrawLensFocusInInspector(rect, property);
 
                 EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.NearClipPlane));
                 EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.FarClipPlane));
-                EditorGUILayout.PropertyField(ModeOverrideProperty);
 
                 if (IsPhysical)
                 {

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -452,7 +452,7 @@ namespace Cinemachine.Editor
                     UseHorizontalFOV = true;
 #endif
                 // It's possible that the lens isn't synched with its camera - fix that here
-                if (ModeOverrideProperty.intValue == (int)LensSettings.OverrideModes.None)
+                if (ModeOverrideProperty.intValue == (int)LensSettings.OverrideModes.InheritFromCamera)
                 {
                     IsOrtho = camera.orthographic;
                     IsPhysical = camera.usePhysicalProperties;
@@ -552,7 +552,7 @@ namespace Cinemachine.Editor
 
                         DrawSensorSizeInInspector(property);
                         EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.LensShift));
-                        if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None)
+                        if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.InheritFromCamera)
                             EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.GateFit));
 
                         --EditorGUI.indentLevel;
@@ -560,7 +560,7 @@ namespace Cinemachine.Editor
 #else
                     DrawSensorSizeInInspector(property);
                     EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.LensShift));
-                    if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None)
+                    if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.InheritFromCamera)
                         EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.GateFit));
 #endif
                 }
@@ -574,7 +574,7 @@ namespace Cinemachine.Editor
 
         void DrawSensorSizeInInspector(SerializedProperty property)
         {
-            if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None)
+            if (ModeOverrideProperty.intValue != (int)LensSettings.OverrideModes.InheritFromCamera)
             {
                 property = property.FindPropertyRelative("m_SensorSize");
                 var rect = EditorGUILayout.GetControlRect(true);

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -88,6 +88,9 @@ namespace Cinemachine
             + "Unity camera when the vcam is active.")]
         public LensSettings m_Lens = LensSettings.Default;
 
+        LensSettings.OverrideModes m_OverrideModeCache = LensSettings.OverrideModes.InheritFromCamera;
+        LensSettings m_LensCache = LensSettings.Default;
+
         /// <summary> Collection of parameters that influence how this virtual camera transitions from
         /// other virtual cameras </summary>
         public TransitionParams m_Transitions;
@@ -171,6 +174,7 @@ namespace Cinemachine
         override protected void OnEnable()
         {
             base.OnEnable();
+
             m_State = PullStateFromVirtualCamera(Vector3.up, ref m_Lens);
             InvalidateComponentPipeline();
 
@@ -470,7 +474,18 @@ namespace Cinemachine
             LookAtTargetAttachment = 1;
 
             // Initialize the camera state, in case the game object got moved in the editor
-            CameraState state = PullStateFromVirtualCamera(worldUp, ref m_Lens);
+            if (m_Lens.ModeOverride == LensSettings.OverrideModes.InheritFromCamera &&
+                m_OverrideModeCache == LensSettings.OverrideModes.InheritFromCamera)
+            {
+                m_LensCache = m_Lens; // save camera lens state
+            }
+            CameraState state = PullStateFromVirtualCamera(Vector3.up, ref m_Lens);
+            if (m_Lens.ModeOverride == LensSettings.OverrideModes.InheritFromCamera &&
+                m_OverrideModeCache != LensSettings.OverrideModes.InheritFromCamera)
+            {
+                m_State.Lens = m_Lens = m_LensCache; // restore original camera lens state
+            }
+            m_OverrideModeCache = m_Lens.ModeOverride;
 
             Transform lookAtTarget = LookAt;
             if (lookAtTarget != mCachedLookAtTarget)

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -75,7 +75,7 @@ namespace Cinemachine
         {
             /// <summary> Perspective/Ortho, IsPhysical, SensorSize, and GateFit 
             /// will not be changed in Unity Camera.  This is the default setting.</summary>
-            None = 0,
+            InheritFromCamera = 0,
             /// <summary>Orthographic projection mode will be pushed to the Unity Camera</summary>
             Orthographic,
             /// <summary>Perspective projection mode will be pushed to the Unity Camera</summary>
@@ -101,7 +101,7 @@ namespace Cinemachine
         public bool Orthographic 
         { 
             get { return ModeOverride == OverrideModes.Orthographic
-                || ModeOverride == OverrideModes.None && m_OrthoFromCamera; } 
+                || ModeOverride == OverrideModes.InheritFromCamera && m_OrthoFromCamera; } 
 
             /// Obsolete: do not use
             set { m_OrthoFromCamera = value; ModeOverride = value 
@@ -131,7 +131,7 @@ namespace Cinemachine
         public bool IsPhysicalCamera 
         { 
             get { return ModeOverride == OverrideModes.Physical 
-                || ModeOverride == OverrideModes.None && m_PhysicalFromCamera; } 
+                || ModeOverride == OverrideModes.InheritFromCamera && m_PhysicalFromCamera; } 
 
             /// Obsolete: do not use
             set { m_PhysicalFromCamera = value; ModeOverride = value 
@@ -217,7 +217,7 @@ namespace Cinemachine
         {
             m_OrthoFromCamera = false;
             m_PhysicalFromCamera = false;
-            if (camera != null && ModeOverride == OverrideModes.None)
+            if (camera != null && ModeOverride == OverrideModes.InheritFromCamera)
             {
                 m_OrthoFromCamera = camera.orthographic;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
@@ -241,7 +241,7 @@ namespace Cinemachine
         /// <param name="lens">The LensSettings from which we will take the info</param>
         public void SnapshotCameraReadOnlyProperties(ref LensSettings lens)
         {
-            if (ModeOverride == OverrideModes.None)
+            if (ModeOverride == OverrideModes.InheritFromCamera)
             {
                 m_OrthoFromCamera = lens.Orthographic;
                 m_SensorSize = lens.m_SensorSize;


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-271

What should happen when we have more vcams? If they both modify the camera lens properties in Inherit From Camera mode, then they will have different "original" cached state. 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
