### PR TITLE
CMCL-332-VCam control of physical camera properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineVolumeSettings inspector was making the game view flicker.
 - Bugfix: CinemachineVolumeSettings inspector displayed a misleading warning message with URP when focus tracking was enabled.
 - Bugfix: Rapidly toggling active cameras before the blends were finished did not use the correct blend time.
+- Bugfix: Lens mode override was not working correctly in all cases
 
 
 ## [2.8.0-pre.1] - 2021-04-21

--- a/Documentation~/CinemachineVirtualCamera.md
+++ b/Documentation~/CinemachineVirtualCamera.md
@@ -35,8 +35,8 @@ At any time, each Virtual Camera may be in one of these states:
 | | _Orthographic Size_ | When using an orthographic camera, defines the half-height of the camera view, in world coordinates. Available when the Unity camera with the Cinemachine Brain component uses a Projection of Orthographic. |
 | | _Near Clip Plane_ | The closest point relative to the camera where drawing occurs. |
 | | _Far Clip Plane_ | The furthest point relative to the camera where drawing occurs. |
-| | _Mode Override_ | Controls whether the Perspective/Orth, SensorSize, and GateFit are set in the Camera object, or are overidden in the virtual camera component. |
-| __Dutch__ || Dutch angle. Tilts the Unity camera on the z-axis, in degrees. This property is unique to the Virtual Camera; there is no counterpart property in the Unity camera. |
+| | _Dutch_ | Dutch angle. Tilts the Unity camera on the z-axis, in degrees. This property is unique to the Virtual Camera; there is no counterpart property in the Unity camera. |
+| | _Mode Override_ | Normally, Perspective/Orthographic and Physical Camera are defned in the Camera component.  This setting makes it possible for a virtual camera to redefine these settings, thus changing the Camera mode.  Note: a mode override will remain after the virtual camera is deactivated.  If you set an override mode in any virtual camera, it is recommended to set an override mode in all virtual cameras. |
 | __Blend Hint__ || Provides hints for blending positions to and from the virtual camera. |
 | __Inherit Position__ || When enabled, whenever this virtual camera goes live, forces the initial position to be the same as the current position of the Unity Camera, if possible. |
 | __Extensions__ || Components that add extra behaviors to the Virtual Camera.  |

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -399,11 +399,18 @@ namespace Cinemachine.Editor
         static readonly GUIContent SensorSizeLabel = new GUIContent("Sensor Size", 
             "Actual size of the image sensor (in mm), used to "
             + "convert between focal length and field of vue.");
+        static readonly GUIContent AdvancedLabel = new GUIContent("Advanced");
+        static readonly GUIContent OverrideHelpText = new GUIContent(
+            "Overriding the lens mode will change the lens "
+            + "mode of the Camera when this virtual camera is activated.  The change will remain after the "
+            + "virtual camera is deactivated.  If you set an override mode in any virtual camera, it is recommended "
+            + "to set an override mode in all virtual cameras.");
 
         bool IsOrtho;
         bool IsPhysical;
         Vector2 SensorSize;
         bool UseHorizontalFOV;
+        static bool s_AdvancedExpanded;
         SerializedProperty ModeOverrideProperty;
 
     #if CINEMACHINE_HDRP
@@ -508,7 +515,6 @@ namespace Cinemachine.Editor
 
                 EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.NearClipPlane));
                 EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.FarClipPlane));
-                EditorGUILayout.PropertyField(ModeOverrideProperty);
 
                 if (IsPhysical)
                 {
@@ -565,6 +571,14 @@ namespace Cinemachine.Editor
 #endif
                 }
                 EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_LensSettingsDef.Dutch));
+                s_AdvancedExpanded = EditorGUILayout.Foldout(s_AdvancedExpanded, AdvancedLabel);
+                if (s_AdvancedExpanded)
+                {
+                    ++EditorGUI.indentLevel;
+                    EditorGUILayout.HelpBox(OverrideHelpText);
+                    EditorGUILayout.PropertyField(ModeOverrideProperty);
+                    --EditorGUI.indentLevel;
+                }
                 --EditorGUI.indentLevel;
             }
             property.serializedObject.ApplyModifiedProperties();

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -874,7 +874,8 @@ namespace Cinemachine
                     cam.lensShift = state.Lens.LensShift;
                     cam.orthographic = state.Lens.Orthographic;
                     cam.usePhysicalProperties = state.Lens.IsPhysicalCamera;
-                    if (state.Lens.IsPhysicalCamera)
+                    if (state.Lens.IsPhysicalCamera && (state.Lens.ModeOverride == LensSettings.OverrideModes.None 
+                        || state.Lens.ModeOverride == LensSettings.OverrideModes.Physical))
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -874,7 +874,7 @@ namespace Cinemachine
                     cam.lensShift = state.Lens.LensShift;
                     cam.orthographic = state.Lens.Orthographic;
                     cam.usePhysicalProperties = state.Lens.IsPhysicalCamera;
-                    if (state.Lens.IsPhysicalCamera && state.Lens.ModeOverride == LensSettings.OverrideModes.Physical)
+                    if (state.Lens.IsPhysicalCamera)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -873,30 +873,28 @@ namespace Cinemachine
                     cam.fieldOfView = state.Lens.FieldOfView;
                     cam.lensShift = state.Lens.LensShift;
                     cam.orthographic = state.Lens.Orthographic;
-                    cam.usePhysicalProperties = state.Lens.IsPhysicalCamera;
-                    if (state.Lens.IsPhysicalCamera && (state.Lens.ModeOverride == LensSettings.OverrideModes.None 
-                        || state.Lens.ModeOverride == LensSettings.OverrideModes.Physical))
+                    bool isPhysical = state.Lens.ModeOverride == LensSettings.OverrideModes.None 
+                        ? cam.usePhysicalProperties : state.Lens.IsPhysicalCamera;
+                    cam.usePhysicalProperties = isPhysical;
+                    if (isPhysical && state.Lens.IsPhysicalCamera)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
 #if CINEMACHINE_HDRP
-                        if (state.Lens.IsPhysicalCamera)
-                        {
     #if UNITY_2019_2_OR_NEWER
-                            cam.TryGetComponent<HDAdditionalCameraData>(out var hda);
+                        cam.TryGetComponent<HDAdditionalCameraData>(out var hda);
     #else
-                            var hda = cam.GetComponent<HDAdditionalCameraData>();
+                        var hda = cam.GetComponent<HDAdditionalCameraData>();
     #endif
-                            if (hda != null)
-                            {
-                                hda.physicalParameters.iso = state.Lens.Iso;
-                                hda.physicalParameters.shutterSpeed = state.Lens.ShutterSpeed;
-                                hda.physicalParameters.aperture = state.Lens.Aperture;
-                                hda.physicalParameters.bladeCount = state.Lens.BladeCount;
-                                hda.physicalParameters.curvature = state.Lens.Curvature;
-                                hda.physicalParameters.barrelClipping = state.Lens.BarrelClipping;
-                                hda.physicalParameters.anamorphism = state.Lens.Anamorphism;
-                            }
+                        if (hda != null)
+                        {
+                            hda.physicalParameters.iso = state.Lens.Iso;
+                            hda.physicalParameters.shutterSpeed = state.Lens.ShutterSpeed;
+                            hda.physicalParameters.aperture = state.Lens.Aperture;
+                            hda.physicalParameters.bladeCount = state.Lens.BladeCount;
+                            hda.physicalParameters.curvature = state.Lens.Curvature;
+                            hda.physicalParameters.barrelClipping = state.Lens.BarrelClipping;
+                            hda.physicalParameters.anamorphism = state.Lens.Anamorphism;
                         }
 #endif
                     }

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -221,11 +221,17 @@ namespace Cinemachine
             {
                 m_OrthoFromCamera = camera.orthographic;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
+                m_SensorSize = camera.sensorSize;
+                GateFit = camera.gateFit;
             }
             if (IsPhysicalCamera)
             {
-                if (camera != null)
+                // If uninitialized, do an initial pull from the camera
+                if (camera != null && m_SensorSize == Vector2.zero)
+                {
                     m_SensorSize = camera.sensorSize;
+                    GateFit = camera.gateFit;
+                }
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR

Fix regression bug. Physical property overwrites only work in overwrite mode.
The bug was introduced by me here: https://github.com/Unity-Technologies/com.unity.cinemachine/pull/224/files

Also: move override mode to Advanced section in UX, with a helpbox describing the gotcha.
Updated documentation.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status
- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [x] Updated documentation

### Samples status

### Technical risk
low

### Comments to reviewers

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
