### PR TITLE
Bugfix: Virtual Cameras were not updating in Edit mode when Brain's B…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Rapidly toggling active cameras before the blends were finished did not use the correct blend time.
 - AimingRig sample scene updated with a better reactive crosshair design.
 - Added API accessor for Active Blend in Clearshot and StateDrivenCamera. 
-- Bugfix: Lens mode override was not working correctly in all cases
+- Bugfix: Lens mode override was not working correctly in all cases.
+- Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate.
 
 
 ## [2.8.0-pre.1] - 2021-04-21

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -334,7 +334,7 @@ namespace Cinemachine
         public void ManualUpdate()
         {
             float deltaTime = GetEffectiveDeltaTime(false);
-            if (m_BlendUpdateMethod != BrainUpdateMethod.FixedUpdate)
+            if (!Application.isPlaying || m_BlendUpdateMethod != BrainUpdateMethod.FixedUpdate)
                 UpdateFrame0(deltaTime);
 
             ComputeCurrentBlend(ref mCurrentLiveCameras, 0);
@@ -364,7 +364,7 @@ namespace Cinemachine
             }
 
             // Choose the active vcam and apply it to the Unity camera
-            if (m_BlendUpdateMethod != BrainUpdateMethod.FixedUpdate)
+            if (!Application.isPlaying || m_BlendUpdateMethod != BrainUpdateMethod.FixedUpdate)
                 ProcessActiveCamera(deltaTime);
         }
 


### PR DESCRIPTION
…lendUpdateMode was FixedUpdate.

Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate.
CMCL-341

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

