### PR TITLE
Backports for 2.6.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+*.md		@sebastienduverne
+QAReport.md	@metalpat @sebastienduverne
+*.cs		@glabute @gaborkb

--- a/.yamato/package-promotion.yml
+++ b/.yamato/package-promotion.yml
@@ -2,6 +2,9 @@ test_editors:
   - version: 2018.4
   - version: 2019.4
   - version: 2020.3
+  - version: 2021.1
+  - version: 2021.2
+  - version: trunk
 test_platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -1,5 +1,4 @@
 test_editors:
-  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
@@ -23,10 +22,10 @@ test_platforms:
     flavor: b1.large
 
 validation_editors:
-  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 validation_platforms:
   - name: ubuntu

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -25,7 +25,6 @@ validation_editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
-  - version: 2021.2
   - version: trunk
 validation_platforms:
   - name: ubuntu

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -1,7 +1,9 @@
 test_editors:
+  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 test_platforms:
   - name: win
@@ -22,9 +24,11 @@ test_platforms:
     flavor: b1.large
 
 validation_editors:
+  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 validation_platforms:
   - name: ubuntu

--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -1,5 +1,4 @@
 all_editors:
-  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
@@ -23,9 +22,11 @@ all_platforms:
     flavor: b1.large
 
 test_editors:
-  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
+  - version: 2021.1
+  - version: 2021.2
+  - version: trunk
 test_platforms:
   - name: ubuntu
     type: Unity::VM

--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -89,7 +89,7 @@ test_trigger:
   triggers:
     branches:
       only:
-      - "master"
+      - "/^(master)|(release[/]\\d+[.]\\d+)$/"
     pull_requests:
       - targets:
           only:

--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -25,7 +25,6 @@ test_editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
-  - version: 2021.2
   - version: trunk
 test_platforms:
   - name: ubuntu
@@ -38,7 +37,7 @@ validation_editors:
 validation_platforms:
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:stable 
     flavor: b1.large
 ---
 

--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -1,7 +1,9 @@
 all_editors:
+  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 all_platforms:
   - name: win
@@ -22,9 +24,11 @@ all_platforms:
     flavor: b1.large
 
 test_editors:
+  - version: 2018.4
   - version: 2019.4
   - version: 2020.3
   - version: 2021.1
+  - version: 2021.2
   - version: trunk
 test_platforms:
   - name: ubuntu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineVolumeSettings inspector was making the game view flicker.
 - Bugfix: CinemachineVolumeSettings inspector displayed a misleading warning message with URP when focus tracking was enabled.
 - Bugfix: Rapidly toggling active cameras before the blends were finished did not use the correct blend time.
+- AimingRig sample scene updated with a better reactive crosshair design.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 - Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 - Bugfix: 3rdPersonFollow works with Aim components now. 
+- Bugfix: Blends between vcams, that are rotated so that their up vector is different from World up, are correct now.
 - Bugfix: 3rdPersonFollow's shoulder now changes smoothly with respect to world-up vector changes.
 - Bugfix: POV recentering did not always recenter correctly, when an axis range was limited.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [2.6.6-pre.1] - 2021-06-22
 - Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 - Bugfix: 3rdPersonFollow works with Aim components now. 
 - Bugfix: Blends between vcams, that are rotated so that their up vector is different from World up, are correct now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineVolumeSettings inspector displayed a misleading warning message with URP when focus tracking was enabled.
 - Bugfix: Rapidly toggling active cameras before the blends were finished did not use the correct blend time.
 - AimingRig sample scene updated with a better reactive crosshair design.
+- Added API accessor for Active Blend in Clearshot and StateDrivenCamera. 
+- Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: POV recentering did not always recenter correctly, when an axis range was limited.
 - Bugfix: CinemachineVolumeSettings inspector was making the game view flicker.
 - Bugfix: CinemachineVolumeSettings inspector displayed a misleading warning message with URP when focus tracking was enabled.
+- Bugfix: Rapidly toggling active cameras before the blends were finished did not use the correct blend time.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 - Bugfix: 3rdPersonFollow works with Aim components now. 
 - Bugfix: 3rdPersonFollow's shoulder now changes smoothly with respect to world-up vector changes.
+- Bugfix: POV recentering did not always recenter correctly, when an axis range was limited.
 
 
 ## [2.6.5] - 2021-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 - Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 - Bugfix: 3rdPersonFollow works with Aim components now. 
+- Bugfix: 3rdPersonFollow's shoulder now changes smoothly with respect to world-up vector changes.
+
 
 ## [2.6.5] - 2021-05-21
 - Bugfix: Framing transposer now handles empty groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- Bugfix: 3rdPersonFollow works with Aim components now.
+- Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
+- Bugfix: 3rdPersonFollow works with Aim components now. 
 
 ## [2.6.5] - 2021-05-21
 - Bugfix: Framing transposer now handles empty groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+- Bugfix: 3rdPersonFollow works with Aim components now.
+
 ## [2.6.5] - 2021-05-21
 - Bugfix: Framing transposer now handles empty groups
 - Bugfix: BlendListCamera inspector reset did not reset properly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Blends between vcams, that are rotated so that their up vector is different from World up, are correct now.
 - Bugfix: 3rdPersonFollow's shoulder now changes smoothly with respect to world-up vector changes.
 - Bugfix: POV recentering did not always recenter correctly, when an axis range was limited.
+- Bugfix: CinemachineVolumeSettings inspector was making the game view flicker.
+- Bugfix: CinemachineVolumeSettings inspector displayed a misleading warning message with URP when focus tracking was enabled.
+
 
 
 ## [2.6.5] - 2021-05-21

--- a/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -9,7 +9,7 @@
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
-#elif CINEMACHINE_LWRP_7_0_0
+#elif CINEMACHINE_LWRP_7_3_1
     using UnityEngine;
     using UnityEditor;
     using UnityEngine.Rendering;
@@ -20,7 +20,7 @@
 
 namespace Cinemachine.PostFX.Editor
 {
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_0_0
+#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
     [CustomEditor(typeof(CinemachineVolumeSettings))]
     public sealed class CinemachineVolumeSettingsEditor
         : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
@@ -77,7 +77,6 @@ namespace Cinemachine.PostFX.Editor
         public override void OnInspectorGUI()
         {
             BeginInspector();
-            DrawRemainingPropertiesInInspector();
 
             var focusMode = (CinemachineVolumeSettings.FocusTrackingMode)m_FocusTracking.intValue;
             if (focusMode != CinemachineVolumeSettings.FocusTrackingMode.None)
@@ -86,24 +85,37 @@ namespace Cinemachine.PostFX.Editor
                 DepthOfField dof;
                 if (Target.m_Profile != null && Target.m_Profile.TryGet(out dof))
                 {
-#if CINEMACHINE_LWRP_7_0_0 && !CINEMACHINE_HDRP
+#if CINEMACHINE_LWRP_7_3_1 && !CINEMACHINE_HDRP
                     valid = dof.active && dof.focusDistance.overrideState
-                        && dof.mode != DepthOfFieldMode.Off;
-#else
-                    valid = dof.active && dof.focusDistance.overrideState
-                        && dof.focusMode == DepthOfFieldMode.UsePhysicalCamera;
-#endif
+                        && dof.mode.overrideState && dof.mode == DepthOfFieldMode.Bokeh;
                 }
                 if (!valid)
                     EditorGUILayout.HelpBox(
-                        "Focus Tracking requires an active DepthOfField/FocusDistance effect "
-                            + "and FocusMode set to Physical Camera in the profile",
+                        "Focus Tracking requires an active Depth Of Field override in the profile "
+                            + "with Focus Distance activated and Mode activated and set to Bokeh",
                         MessageType.Warning);
+#else
+                {
+                    valid = dof.active && dof.focusDistance.overrideState
+                        && dof.focusMode.overrideState && dof.focusMode == DepthOfFieldMode.UsePhysicalCamera;
+                }
+                if (!valid)
+                    EditorGUILayout.HelpBox(
+                        "Focus Tracking requires an active Depth Of Field override in the profile "
+                            + "with Focus Distance activated and Focus Mode activated and set to Use Physical Camera",
+                        MessageType.Warning);
+#endif
             }
 
+            DrawRemainingPropertiesInInspector();
+
+            EditorGUI.BeginChangeCheck();
             DrawProfileInspectorGUI();
-            Target.InvalidateCachedProfile();
-            serializedObject.ApplyModifiedProperties();
+            if (EditorGUI.EndChangeCheck())
+            {
+                Target.InvalidateCachedProfile();
+                serializedObject.ApplyModifiedProperties();
+            }
         }
 
         void DrawProfileInspectorGUI()
@@ -178,7 +190,9 @@ namespace Cinemachine.PostFX.Editor
                     m_ComponentList.Clear(); // Asset wasn't null before, do some cleanup
 
                 EditorGUILayout.HelpBox(
-                    "Assign an existing Volume Profile by choosing an asset, or create a new one by clicking the \"New\" button.\nNew assets are automatically put in a folder next to your scene file. If your scene hasn't been saved yet they will be created at the root of the Assets folder.",
+                    "Assign an existing Volume Profile by choosing an asset, or create a new one by clicking the \"New\" button.\n"
+                    + "New assets are automatically put in a folder next to your scene file. If your scene hasn't "
+                    + "been saved yet they will be created at the root of the Assets folder.",
                     MessageType.Info);
             }
             else

--- a/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -4,12 +4,12 @@
     using UnityEngine.Rendering;
     using UnityEditor.Rendering;
     using System.Collections.Generic;
-    #if CINEMACHINE_HDRP_7_0_0
+    #if CINEMACHINE_HDRP_7_3_1
         using UnityEngine.Rendering.HighDefinition;
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_LWRP_7_0_0
     using UnityEngine;
     using UnityEditor;
     using UnityEngine.Rendering;
@@ -20,7 +20,7 @@
 
 namespace Cinemachine.PostFX.Editor
 {
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_0_0
     [CustomEditor(typeof(CinemachineVolumeSettings))]
     public sealed class CinemachineVolumeSettingsEditor
         : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
@@ -85,7 +85,7 @@ namespace Cinemachine.PostFX.Editor
                 DepthOfField dof;
                 if (Target.m_Profile != null && Target.m_Profile.TryGet(out dof))
                 {
-#if CINEMACHINE_LWRP_7_3_1 && !CINEMACHINE_HDRP
+#if CINEMACHINE_LWRP_7_0_0 && !CINEMACHINE_HDRP
                     valid = dof.active && dof.focusDistance.overrideState
                         && dof.mode.overrideState && dof.mode == DepthOfFieldMode.Bokeh;
                 }

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -9,7 +9,8 @@ namespace Cinemachine
 #if CINEMACHINE_PHYSICS
     /// <summary>
     /// An add-on module for Cinemachine Virtual Camera that forces the LookAt
-    /// point to the center of the screen, cancelling noise and other corrections.
+    /// point to the center of the screen, based on the Follow target's orientation,
+    /// cancelling noise and other corrections.
     /// This is useful for third-person style aim cameras that want a dead-accurate
     /// aim at all times, even in the presence of positional or rotational noise.
     /// </summary>
@@ -90,17 +91,18 @@ namespace Cinemachine
             }
         }
 
-        Vector3 GetLookAtPoint(ref CameraState state)
+        Vector3 GetLookAtPoint(Vector3 camPos)
         {
-            var fwd = state.CorrectedOrientation * Vector3.forward;
-            var camPos = state.CorrectedPosition;
             var aimDistance = AimDistance;
-
-            // We don't want to hit targets behind the player
             var player = VirtualCamera.Follow;
+            
+            // We don't want to hit targets behind the player
+            var fwd = Vector3.forward;
             if (player != null)
             {
-                var playerPos = Quaternion.Inverse(state.CorrectedOrientation) * (player.position - camPos);
+                var playerOrientation = player.transform.rotation;
+                fwd = playerOrientation * Vector3.forward;
+                var playerPos = Quaternion.Inverse(playerOrientation) * (player.position - camPos);
                 if (playerPos.z > 0)
                 {
                     camPos += fwd * playerPos.z;
@@ -109,8 +111,7 @@ namespace Cinemachine
             }
 
             aimDistance = Mathf.Max(1, aimDistance);
-            bool hasHit = RuntimeUtility.RaycastIgnoreTag(
-                new Ray(camPos, fwd), 
+            bool hasHit = RuntimeUtility.RaycastIgnoreTag(new Ray(camPos, fwd), 
                 out RaycastHit hitInfo, aimDistance, AimCollisionFilter, IgnoreTag);
             return hasHit ? hitInfo.point : camPos + fwd * aimDistance;
         }
@@ -130,7 +131,7 @@ namespace Cinemachine
             if (stage == CinemachineCore.Stage.Body)
             {
                 // Raycast to establish what we're actually aiming at
-                state.ReferenceLookAt = GetLookAtPoint(ref state);
+                state.ReferenceLookAt = GetLookAtPoint(state.CorrectedPosition);
             }
             if (stage == CinemachineCore.Stage.Finalize)
             {

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -636,8 +636,9 @@ namespace Cinemachine
                         {
                             // Special case: if backing out of a blend-in-progress
                             // with the same blend in reverse, adjust the blend time
-                            if (frame.blend.CamA == activeCamera
-                                && frame.blend.CamB == outGoingCamera
+                            if ((frame.blend.CamA == activeCamera 
+                                    || (frame.blend.CamA as BlendSourceVirtualCamera)?.Blend.CamB == activeCamera) 
+                                && frame.blend.CamB == outGoingCamera 
                                 && frame.blend.Duration <= blendDef.BlendTime)
                             {
                                 blendDef.m_Time = 

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -153,6 +153,12 @@ namespace Cinemachine
             m_Lens.Validate();
 
             InvalidateRigCache();
+            
+#if UNITY_EDITOR
+            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
+                if (m_Rigs[i] != null)
+                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
+#endif
         }
 
         /// <summary>Get a child rig</summary>
@@ -475,8 +481,8 @@ namespace Cinemachine
         CameraState m_State = CameraState.Default;          // Current state this frame
 
         /// Serialized in order to support copy/paste
-        [SerializeField][HideInInspector][NoSaveDuringPlay] private CinemachineVirtualCamera[] m_Rigs
-            = new CinemachineVirtualCamera[3];
+        [SerializeField][HideInInspector][NoSaveDuringPlay]
+        private CinemachineVirtualCamera[] m_Rigs = new CinemachineVirtualCamera[3];
 
         void InvalidateRigCache() { mOrbitals = null; }
         CinemachineOrbitalTransposer[] mOrbitals = null;
@@ -602,9 +608,6 @@ namespace Cinemachine
                     m_Rigs = CreateRigs(copyFrom);
                 }
             }
-            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
-                if (m_Rigs[i] != null)
-                    CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
 #endif
 
             // Early out if we're up to date

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -201,8 +201,8 @@ namespace Cinemachine
         Quaternion GetHeading(Vector3 targetForward, Vector3 up)
         {
             var planeForward = targetForward.ProjectOntoPlane(up);
-            var heading = UnityVectorExtensions.SignedAngle(Vector3.forward, planeForward, up);
-            return Quaternion.AngleAxis(heading, up);
+            planeForward = Vector3.Cross(up, Vector3.Cross(planeForward, up));
+            return Quaternion.LookRotation(planeForward, up);
         }
 
         void GetRawRigPositions(

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -177,7 +177,7 @@ namespace Cinemachine
 
             // Set state
             curState.RawPosition = camPos;
-            curState.RawOrientation = targetRot;
+            curState.RawOrientation = targetRot; // not necessary, but left in to avoid breaking scenes that depend on this
             curState.ReferenceUp = up;
         }
 

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -159,9 +159,15 @@ namespace Cinemachine
                 if (parent != null)
                     fwd = parent.rotation * fwd;
                 var v = Quaternion.FromToRotation(Vector3.forward, fwd).eulerAngles;
-                return new Vector2(v.y, v.x);
+                return new Vector2(NormalizeAngle(v.y), NormalizeAngle(v.x));
             }
             return Vector2.zero;
+        }
+
+        // Normalize angle value to [-180, 180] degrees.
+        static float NormalizeAngle(float angle)
+        {
+            return ((angle + 180) % 360) - 180; 
         }
 
         /// <summary>

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -371,6 +371,8 @@ namespace Cinemachine
                     if (angle > UnityVectorExtensions.Epsilon)
                         dirTarget = state.ReferenceLookAt - state.CorrectedPosition;
                 }
+                
+                
                 if (dirTarget.AlmostZero() 
                     || ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.IgnoreLookAtTarget) != 0)
                 {
@@ -392,15 +394,17 @@ namespace Cinemachine
                     else
                     {
                         // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
+                        var blendUp = Vector3.Slerp(
+                            stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
+                        newOrient = Quaternion.LookRotation(dirTarget, blendUp);
 
                         // Blend the desired offsets from center
                         Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, stateA.ReferenceUp);
+                                stateA.ReferenceLookAt - stateA.CorrectedPosition, blendUp);
                         Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, stateB.ReferenceUp);
+                                stateB.ReferenceLookAt - stateB.CorrectedPosition, blendUp);
                         newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
+                                Vector2.Lerp(deltaA, deltaB, adjustedT), blendUp);
                     }
                 }
             }

--- a/Runtime/Core/CinemachinePathBase.cs
+++ b/Runtime/Core/CinemachinePathBase.cs
@@ -294,7 +294,7 @@ namespace Cinemachine
         /// trigger a potentially costly regeneration of the path distance cache</summary>
         /// <param name="pos">The value to convert from, in native units</param>
         /// <param name="units">The units to convert to</param>
-        /// <returns>Tha path position, in the requested units</returns>
+        /// <returns>The path position, in the requested units</returns>
         public float FromPathNativeUnits(float pos, PositionUnits units)
         {
             if (units == PositionUnits.PathUnits)

--- a/Runtime/Core/CinemachinePathBase.cs
+++ b/Runtime/Core/CinemachinePathBase.cs
@@ -266,13 +266,12 @@ namespace Cinemachine
             return Mathf.Clamp(distance, 0, length);
         }
 
-        /// <summary>Get the path position (in native path units) corresponding to the psovided
-        /// value, in the units indicated.
+        /// <summary>Get the path position to native path units.
         /// If the distance cache is not valid, then calling this will
         /// trigger a potentially costly regeneration of the path distance cache</summary>
         /// <param name="pos">The value to convert from</param>
         /// <param name="units">The units in which pos is expressed</param>
-        /// <returns>The length of the path in native units, when sampled at this rate</returns>
+        /// <returns>The path position, in native units</returns>
         public float ToNativePathUnits(float pos, PositionUnits units)
         {
             if (units == PositionUnits.PathUnits)
@@ -290,12 +289,12 @@ namespace Cinemachine
             return MinPos + Mathf.Lerp(m_DistanceToPos[i], m_DistanceToPos[i+1], t);
         }
 
-        /// <summary>Get the path position (in path units) corresponding to this distance along the path.
+        /// <summary>Convert a path position from native path units to the desired units.
         /// If the distance cache is not valid, then calling this will
         /// trigger a potentially costly regeneration of the path distance cache</summary>
         /// <param name="pos">The value to convert from, in native units</param>
-        /// <param name="units">The units to convert toexpressed</param>
-        /// <returns>The length of the path in distance units, when sampled at this rate</returns>
+        /// <param name="units">The units to convert to</param>
+        /// <returns>Tha path position, in the requested units</returns>
         public float FromPathNativeUnits(float pos, PositionUnits units)
         {
             if (units == PositionUnits.PathUnits)

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Reticle control for when the aiming is inaccurate. Inaccuracy is shown by pulling apart the aim reticle.
+/// </summary>
+public class AimReticle : MonoBehaviour
+{
+    [Tooltip("Maximum radius of the aim reticle, when aiming is inaccurate. ")]
+    [Range(0, 100f)]
+    public float MaxRadius;
+
+    [Tooltip("The time is takes for the aim reticle to adjust, when inaccurate.")]
+    [Range(0, 1f)]
+    public float BlendTime;
+    
+    [Tooltip("Top piece of the aim reticle.")]
+    public Image Top;
+    [Tooltip("Bottom piece of the aim reticle.")]
+    public Image Bottom;
+    [Tooltip("Left piece of the aim reticle.")]
+    public Image Left;
+    [Tooltip("Right piece of the aim reticle.")]
+    public Image Right;
+    
+    [Tooltip("This 2D object will be positioned in the game view over the raycast hit point, if any, "
+        + "or will remain in the center of the screen if no hit point is detected.  "
+        + "May be null, in which case no on-screen indicator will appear. Same as Cinemachine3rdPersonAim's")]
+    public RectTransform AimTargetReticle;
+
+    void Reset()
+    {
+        MaxRadius = 30f;
+        BlendTime = 0.05f;
+    }
+    
+    float m_BlendVelocity;
+    float m_CurrentRadius;
+    void Update()
+    {
+        var screenCenterPoint = new Vector2(Screen.width * 0.5f, Screen.height * 0.5f);
+        float distanceFromCenter = 0;
+        if (AimTargetReticle != null)
+        {
+            var hitPoint = (Vector2) AimTargetReticle.position;
+            distanceFromCenter = (screenCenterPoint - hitPoint).magnitude;
+        }
+        m_CurrentRadius = Mathf.SmoothDamp(m_CurrentRadius, distanceFromCenter * 2f, ref m_BlendVelocity, BlendTime);
+        m_CurrentRadius = Mathf.Min(MaxRadius, m_CurrentRadius);
+
+        Left.rectTransform.position = screenCenterPoint + (Vector2.left * m_CurrentRadius);
+        Right.rectTransform.position = screenCenterPoint + (Vector2.right * m_CurrentRadius);
+        Top.rectTransform.position = screenCenterPoint + (Vector2.up * m_CurrentRadius);
+        Bottom.rectTransform.position = screenCenterPoint + (Vector2.down * m_CurrentRadius);
+    }
+}

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs.meta
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc7d68869689ce241999a4e22f40d026
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.unity
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.49641287, b: 0.5748173, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 364746025}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -197,6 +199,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &62958717
@@ -213,79 +216,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &172419705
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 172419706}
-  - component: {fileID: 172419708}
-  - component: {fileID: 172419707}
-  m_Layer: 5
-  m_Name: Player Hit Reticle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &172419706
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172419705}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 10.999993}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 266176018}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0007019043, y: 0.000030517578}
-  m_SizeDelta: {x: 15, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &172419707
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172419705}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 1a1da36a104725048b8d2388fb8d321d, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &172419708
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172419705}
-  m_CullTransparentMesh: 0
 --- !u!1 &226826961
 GameObject:
   m_ObjectHideFlags: 0
@@ -297,6 +227,7 @@ GameObject:
   - component: {fileID: 226826963}
   - component: {fileID: 226826962}
   - component: {fileID: 226826965}
+  - component: {fileID: 226826964}
   m_Layer: 0
   m_Name: CM Aiming Rig
   m_TagString: Untagged
@@ -330,7 +261,10 @@ MonoBehaviour:
     NearClipPlane: 0.1
     FarClipPlane: 5000
     Dutch: 0
+    ModeOverride: 0
     LensShift: {x: 0, y: 0}
+    GateFit: 0
+    m_SensorSize: {x: 2.3370473, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 1
@@ -347,14 +281,61 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 226826961}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10.5, y: 2.6230001, z: -2}
+  m_LocalPosition: {x: 10.3, y: 2.6230001, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 153900723451599077}
   - {fileID: 424502139}
-  - {fileID: 266176018}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &226826964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 226826961}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 546027855273aed40809fd72c01c960a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MinAngle: -90
+  MaxAngle: 90
+  DistanceScale:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0.5
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.49992627
+      value: 1.0041615
+      inSlope: 2.1330702
+      outSlope: 2.1330702
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 2
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!114 &226826965
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -372,107 +353,68 @@ MonoBehaviour:
     m_Bits: 1
   IgnoreTag: Player
   AimDistance: 200
-  AimTargetReticle: {fileID: 172419706}
---- !u!1 &266176017
-GameObject:
+  AimTargetReticle: {fileID: 260066437471993806}
+--- !u!850595691 &364746025
+LightingSettings:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 266176018}
-  - component: {fileID: 266176021}
-  - component: {fileID: 266176020}
-  - component: {fileID: 266176019}
-  m_Layer: 5
-  m_Name: Reticle Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &266176018
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 266176017}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 483716837}
-  - {fileID: 172419706}
-  m_Father: {fileID: 226826963}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &266176019
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 266176017}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &266176020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 266176017}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
---- !u!223 &266176021
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 266176017}
-  m_Enabled: 1
+  m_Name: Settings.lighting
   serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
+  m_GIWorkflowMode: 0
+  m_EnableBakedLightmaps: 1
+  m_EnableRealtimeLightmaps: 1
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 0
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_TextureCompression: 1
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 500
+  m_PVREnvironmentSampleCount: 500
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 1
+  m_PVREnvironmentMIS: 0
+  m_PVRFilteringMode: 2
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
 --- !u!1 &424502138
 GameObject:
   m_ObjectHideFlags: 3
@@ -504,7 +446,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 226826963}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &424502140
 MonoBehaviour:
@@ -519,7 +461,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Damping: {x: 0.1, y: 0.5, z: 0.3}
-  ShoulderOffset: {x: 0.5, y: -0.4, z: 0}
+  ShoulderOffset: {x: 0.3, y: -0.4, z: 0}
   VerticalArmLength: 0.4
   CameraSide: 1
   CameraDistance: 2
@@ -528,6 +470,8 @@ MonoBehaviour:
     m_Bits: 1
   IgnoreTag: Player
   CameraRadius: 0.2
+  DampingIntoCollision: 0
+  DampingFromCollision: 0
 --- !u!114 &424502142
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -588,79 +532,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &483716836
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 483716837}
-  - component: {fileID: 483716839}
-  - component: {fileID: 483716838}
-  m_Layer: 5
-  m_Name: Camera Reticle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &483716837
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 483716836}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 266176018}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 30, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &483716838
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 483716836}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 1a1da36a104725048b8d2388fb8d321d, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &483716839
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 483716836}
-  m_CullTransparentMesh: 0
 --- !u!1 &1134903599
 GameObject:
   m_ObjectHideFlags: 0
@@ -705,14 +576,22 @@ MonoBehaviour:
 
 
     The
-    secondary (inner) reticle shows what the player would hit if a shot were fired. 
+    secondary (red dot) reticle shows what the player would hit if a shot were fired. 
     This may be different from the outer reticle if a nearby obstacle obstructs the
-    player from seeing the object under the camera reticle.
+    player from seeing the object under the camera reticle. When the outer and inner
+    recticles are not on the same position, the outer reticle moves apart to show
+    that the aiming is inaccurate.
 
 
-    The dual reticle
-    behaviour can be disabled by setting the  Aim Target reticle field to null in
-    the 3rdPersonAim extension.'
+    The dual reticle behaviour can be disabled
+    by setting the Aim Target reticle field to null in the 3rdPersonAim extension.
+
+
+    Finally,
+    the (optional - enable it to see what it does) ThirdPersonFollowDistanceModifier
+    component modifies the camera distance as a function of vertical camera angle,
+    mimicking the 3-orbit setup of the FreeLook by using a simple curve to modify
+    the distance.'
 --- !u!4 &1134903601
 Transform:
   m_ObjectHideFlags: 0
@@ -735,6 +614,14 @@ PrefabInstance:
     m_TransformParent: {fileID: 436401188}
     m_Modifications:
     - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -745,6 +632,10 @@ PrefabInstance:
     - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
       propertyPath: m_LocalRotation.x
@@ -758,24 +649,11 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 3.24
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
 --- !u!4 &1508344078 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4519539146465710, guid: 0998cc0e377e9034c86e90787a3070b0, type: 3}
   m_PrefabInstance: {fileID: 1493626625}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1787124812
@@ -864,9 +742,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1787124812}
-  m_LocalRotation: {x: -0.000000032511643, y: -0.0000008669772, z: -2.8186853e-14,
-    w: 1}
-  m_LocalPosition: {x: 10.5, y: 2.6230001, z: -2}
+  m_LocalRotation: {x: -0.000000032511643, y: -0.0000007369306, z: -2.3958825e-14, w: 1}
+  m_LocalPosition: {x: 10.3, y: 2.6230001, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -916,7 +793,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1923080548}
   m_Layer: 0
-  m_Name: PlayerOriginPlaceholder
+  m_Name: GunOrigin
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3193,6 +3070,36 @@ Transform:
   m_Father: {fileID: 4902840864619486}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &37578809700473673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 854802718634979196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.509434, g: 0.509434, b: 0.509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!54 &54563483927136738
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -3253,10 +3160,12 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3352,3 +3261,821 @@ SkinnedMeshRenderer:
     m_Center: {x: 0.11729962, y: 0.015860312, z: -0.000000029802322}
     m_Extent: {x: 0.8884625, y: 0.16316557, z: 0.9052676}
   m_DirtyAABB: 0
+--- !u!224 &153900723451599077
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5945698690048479624}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 260066437471993806}
+  - {fileID: 5101484583889120993}
+  m_Father: {fileID: 226826963}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!224 &260066437471993806
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6521527274971629406}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 25.17281}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 153900723451599077}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0011174016, y: 0.0000349188}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &321541157406378396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5918418925356973809}
+  - component: {fileID: 4363211939207922225}
+  - component: {fileID: 3667669835920395874}
+  m_Layer: 5
+  m_Name: down (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &637442161210799948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4952681795414530779}
+  - component: {fileID: 4014649751475871793}
+  - component: {fileID: 8571848275073518753}
+  m_Layer: 5
+  m_Name: left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &854802718634979196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3526094740835135317}
+  - component: {fileID: 4447257011816210372}
+  - component: {fileID: 37578809700473673}
+  m_Layer: 5
+  m_Name: right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &955261071602531650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3566171088614978507}
+  - component: {fileID: 3848265181683058553}
+  - component: {fileID: 2999251759889599543}
+  m_Layer: 5
+  m_Name: top
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!223 &1119437525629235430
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5945698690048479624}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1150345619514393457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6521527274971629406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1277221849132012322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5101484583889120993}
+  - component: {fileID: 6578860596827590882}
+  - component: {fileID: 2706997423346291668}
+  m_Layer: 5
+  m_Name: AimReticle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &1335330183343951411
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6521527274971629406}
+  m_CullTransparentMesh: 1
+--- !u!222 &2021255456408659896
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8119565691434959016}
+  m_CullTransparentMesh: 1
+--- !u!114 &2706997423346291668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277221849132012322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc7d68869689ce241999a4e22f40d026, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxRadius: 30
+  BlendTime: 0.05
+  Top: {fileID: 2999251759889599543}
+  Bottom: {fileID: 4008273981425034797}
+  Left: {fileID: 8571848275073518753}
+  Right: {fileID: 37578809700473673}
+  AimTargetReticle: {fileID: 260066437471993806}
+--- !u!222 &2723113944719693837
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8603512015782432092}
+  m_CullTransparentMesh: 1
+--- !u!224 &2723711936400274817
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4034526899312248483}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3526094740835135317}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -10, y: 0}
+  m_SizeDelta: {x: 20, y: 3}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &2791953464807463032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4034526899312248483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.31832528, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2999251759889599543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955261071602531650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.509434, g: 0.509434, b: 0.509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &3526094740835135317
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 854802718634979196}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2723711936400274817}
+  m_Father: {fileID: 5101484583889120993}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 22, y: 5}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!224 &3566171088614978507
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955261071602531650}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3842700712863957352}
+  m_Father: {fileID: 5101484583889120993}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 22}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &3667669835920395874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 321541157406378396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.31832528, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &3842700712863957352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8119565691434959016}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3566171088614978507}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -10}
+  m_SizeDelta: {x: 3, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &3848265181683058553
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955261071602531650}
+  m_CullTransparentMesh: 1
+--- !u!114 &3853854406086243294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8119565691434959016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.31832528, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4008273981425034797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6200837970771541480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.509434, g: 0.509434, b: 0.509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &4014649751475871793
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 637442161210799948}
+  m_CullTransparentMesh: 1
+--- !u!1 &4034526899312248483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2723711936400274817}
+  - component: {fileID: 6560132240994850921}
+  - component: {fileID: 2791953464807463032}
+  m_Layer: 5
+  m_Name: right (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &4363211939207922225
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 321541157406378396}
+  m_CullTransparentMesh: 1
+--- !u!222 &4408724812352557914
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6200837970771541480}
+  m_CullTransparentMesh: 1
+--- !u!222 &4447257011816210372
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 854802718634979196}
+  m_CullTransparentMesh: 1
+--- !u!224 &4759813928997548577
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6200837970771541480}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5918418925356973809}
+  m_Father: {fileID: 5101484583889120993}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 22}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!224 &4952681795414530779
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 637442161210799948}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5337428573539602516}
+  m_Father: {fileID: 5101484583889120993}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 22, y: 5}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!224 &5101484583889120993
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277221849132012322}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4952681795414530779}
+  - {fileID: 3526094740835135317}
+  - {fileID: 3566171088614978507}
+  - {fileID: 4759813928997548577}
+  m_Father: {fileID: 153900723451599077}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &5337428573539602516
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8603512015782432092}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4952681795414530779}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 10, y: 0}
+  m_SizeDelta: {x: 20, y: 3}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &5538629405597886630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5945698690048479624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!224 &5918418925356973809
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 321541157406378396}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759813928997548577}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 10}
+  m_SizeDelta: {x: 3, y: 20}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &5945698690048479624
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 153900723451599077}
+  - component: {fileID: 1119437525629235430}
+  - component: {fileID: 5538629405597886630}
+  - component: {fileID: 8612951625482563961}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6200837970771541480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759813928997548577}
+  - component: {fileID: 4408724812352557914}
+  - component: {fileID: 4008273981425034797}
+  m_Layer: 5
+  m_Name: bottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6521527274971629406
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 260066437471993806}
+  - component: {fileID: 1335330183343951411}
+  - component: {fileID: 1150345619514393457}
+  m_Layer: 5
+  m_Name: adjustedReticle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &6560132240994850921
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4034526899312248483}
+  m_CullTransparentMesh: 1
+--- !u!222 &6578860596827590882
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277221849132012322}
+  m_CullTransparentMesh: 1
+--- !u!114 &7086134644202461365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8603512015782432092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.31832528, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8119565691434959016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3842700712863957352}
+  - component: {fileID: 2021255456408659896}
+  - component: {fileID: 3853854406086243294}
+  m_Layer: 5
+  m_Name: top (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &8571848275073518753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 637442161210799948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.509434, g: 0.509434, b: 0.509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8603512015782432092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5337428573539602516}
+  - component: {fileID: 2723113944719693837}
+  - component: {fileID: 7086134644202461365}
+  m_Layer: 5
+  m_Name: left (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &8612951625482563961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5945698690048479624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295

--- a/Tests/Runtime/CamerasBlendingTests.cs
+++ b/Tests/Runtime/CamerasBlendingTests.cs
@@ -60,7 +60,7 @@ public class CamerasBlendingTests
         targetVCam.Priority = 3;
         yield return null;
 
-        yield return new WaitForSeconds(BlendingTime);
+        yield return new WaitForSeconds(BlendingTime + 0.1f);
         Assert.IsTrue(!brain.IsBlending);
     }
     
@@ -84,7 +84,7 @@ public class CamerasBlendingTests
         yield return null;
         
         // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime * 0.2f);
+        yield return new WaitForSeconds(BlendingTime * 0.21f);
 
         Assert.IsTrue(!brain.IsBlending);
 
@@ -117,7 +117,7 @@ public class CamerasBlendingTests
         yield return null;
         
         // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime * 0.2f);
+        yield return new WaitForSeconds(BlendingTime * 0.21f);
 
         Assert.IsTrue(!brain.IsBlending);
     }
@@ -142,7 +142,7 @@ public class CamerasBlendingTests
         yield return null;
         
         // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime);
+        yield return new WaitForSeconds(BlendingTime + 0.01f);
 
         Assert.IsTrue(!brain.IsBlending);
     }

--- a/Tests/Runtime/CamerasBlendingTests.cs
+++ b/Tests/Runtime/CamerasBlendingTests.cs
@@ -1,0 +1,150 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Cinemachine;
+
+[TestFixture]   
+public class CamerasBlendingTests
+{
+    private Camera cam;
+    private CinemachineVirtualCamera sourceVCam;
+    private CinemachineVirtualCamera targetVCam;
+    private CinemachineBrain brain;
+    private GameObject followObject;
+
+    private const float BlendingTime = 1;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Camera
+        var cameraHolder = new GameObject("MainCamera");
+        cam = cameraHolder.AddComponent<Camera>();
+        brain = cameraHolder.AddComponent<CinemachineBrain>();
+
+        // Blending
+        brain.m_DefaultBlend = new CinemachineBlendDefinition(
+            CinemachineBlendDefinition.Style.Linear, 
+            BlendingTime);
+        
+        followObject = new GameObject("Follow Object");
+        
+        // Source vcam
+        var sourceVCamHolder = new GameObject("Source CM Vcam");
+        sourceVCam = sourceVCamHolder.AddComponent<CinemachineVirtualCamera>();
+        sourceVCam.Priority = 2;
+        sourceVCam.Follow = followObject.transform;
+
+        // target vcam
+        var targetVCamHolder = new GameObject("Target CM Vcam");
+        targetVCam = targetVCamHolder.AddComponent<CinemachineVirtualCamera>();
+        targetVCam.Priority = 1;
+        targetVCam.Follow = followObject.transform;
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        Object.Destroy(cam.gameObject);
+        Object.Destroy(sourceVCam.gameObject);
+        Object.Destroy(targetVCam.gameObject);
+        Object.Destroy(followObject);
+    }
+
+
+    [UnityTest]
+    public IEnumerator BlendingBetweenCameras()
+    {
+        
+        targetVCam.Priority = 3;
+        yield return null;
+
+        yield return new WaitForSeconds(BlendingTime);
+        Assert.IsTrue(!brain.IsBlending);
+    }
+    
+    [UnityTest]
+    public IEnumerator InterruptedBlendingBetweenCameras()
+    {
+        // Start blending
+        targetVCam.Priority = 3;
+        yield return null;
+
+        // Wait for 90% of blending duration
+        yield return new WaitForSeconds(BlendingTime * 0.9f);
+        
+        // Blend back to source
+        targetVCam.Priority = 1;
+        yield return null;
+        yield return new WaitForSeconds(BlendingTime * 0.1f);
+        
+        // Quickly blend to target again
+        targetVCam.Priority = 3;
+        yield return null;
+        
+        // We went 90%, then got 10% back, it means we are 20% away from the target
+        yield return new WaitForSeconds(BlendingTime * 0.2f);
+
+        Assert.IsTrue(!brain.IsBlending);
+
+        // Start blending
+        targetVCam.Priority = 3;
+        yield return null;
+
+        // Wait for 90% of blending duration
+        yield return new WaitForSeconds(BlendingTime * 0.9f);
+        
+        // Blend back to source
+        targetVCam.Priority = 1;
+        yield return null;
+        yield return new WaitForSeconds(BlendingTime * 0.1f);
+        
+        // Quickly blend to target again
+        targetVCam.Priority = 3;
+        yield return null;
+        
+        // We went 90%, then got 10% back, it means we are 20% away from the target - wait only 10% worth
+        yield return new WaitForSeconds(BlendingTime * 0.1f);
+
+        // Blend back to source
+        targetVCam.Priority = 1;
+        yield return null;
+        yield return new WaitForSeconds(BlendingTime * 0.1f);
+        
+        // Quickly blend to target again
+        targetVCam.Priority = 3;
+        yield return null;
+        
+        // We went 90%, then got 10% back, it means we are 20% away from the target
+        yield return new WaitForSeconds(BlendingTime * 0.2f);
+
+        Assert.IsTrue(!brain.IsBlending);
+    }
+    
+    [UnityTest]
+    public IEnumerator DoesInterruptedBlendingBetweenCamerasTakesDoubleTime()
+    {
+        // Start blending
+        targetVCam.Priority = 3;
+        yield return null;
+
+        // Wait for 90% of blending duration
+        yield return new WaitForSeconds(BlendingTime * 0.9f);
+        
+        // Blend back to source
+        targetVCam.Priority = 1;
+        yield return null;
+        yield return new WaitForSeconds(BlendingTime * 0.1f);
+        
+        // Quickly blend to target again
+        targetVCam.Priority = 3;
+        yield return null;
+        
+        // We went 90%, then got 10% back, it means we are 20% away from the target
+        yield return new WaitForSeconds(BlendingTime);
+
+        Assert.IsTrue(!brain.IsBlending);
+    }
+    
+}

--- a/Tests/Runtime/CamerasBlendingTests.cs.meta
+++ b/Tests/Runtime/CamerasBlendingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6868af9e141204bb492578e43ffb69f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -3,22 +3,22 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "2.6.5"
+            "PackageVersion": "2.6.6-pre.1"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.6.5"
+            "PackageVersion": "2.6.6-pre.1"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.6.5"
+            "PackageVersion": "2.6.6-pre.1"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.6.5"
+            "PackageVersion": "2.6.6-pre.1"
         }
     ],
     "WarningExceptions": []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.6.5",
+    "version": "2.6.6-pre.1",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nIMPORTANT NOTE: If you are upgrading from the Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],
@@ -20,8 +20,8 @@
             "path": "Samples~/Cinemachine Example Scenes"
         },
         {
-            "displayName": "Scrub Bubble support for Nested Timelines (experimental)",
-            "description": "Experimental feature.  Adds a Timeline extension to support Scrubb Bubble for nested timelines.  This extension will become obsolete when Timeline adds native support for the missing API",
+            "displayName": "Scrubbable support for Nested Timelines (experimental)",
+            "description": "Experimental feature. Adds a Timeline extension to support Scrubb Bubble for nested timelines.  This extension will become obsolete when Timeline adds native support for the missing API",
             "path": "Samples~/Nested Timeline Scrub Bubble"
         }
     ]


### PR DESCRIPTION
### Purpose of this PR

Backports these commits:
* cbe689c Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate. (#272)
* 6592fd5 increased wait time to fix failing test on Linux (#273)
* 8eaf7d2 changed docs owner to Seb
* b190d76 XML doc typos
* 94a5ed6 Nicer AimingRig scene (#264)
* 30a71c4 Blend condition bug (#263)
* d13297a Bugfix: CinemachineVolumeSettings inspector was making the game view flicker, and warning msg (#261)
* e808cef ReferenceUp is not correct in CameraState Lerp (#256)
* 6f53ae3 CMCL-311 POV recentering bug (#254)
* 9f7c8ee Dev/3rdperson heading fix (#247)
* 3a0a4c4 Freelook prefab children are no longer visible. (#241)
* 2fdff67 fixed yamato bug (#251)
* 4888deb added all editors to publish validation test (#248)
* bc2f6e6 PR236 changelog (#242)
* 278242f 3rdPerson refactor (#236)

These commits from 2.7 did not merge cleanly and were skipped:
* 1e9d03c add missing confiner2D warning (#270)
* 826c67b Fix up Mode Override help text and doc (#268)
* 4f2bab7 Add info icon to lens override mode help box
* 3f42a29 CMCL-332-VCam control of physical camera properties (#266)

### Testing status

- [X] Passed all automated tests
- [x] Manually tested 

### Samples status

- [x] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

- [X] Updated package version to 2.6.6-pre.1
