### PR TITLE
Added tests for FreeLook

### DIFF
--- a/Tests/Runtime/CameraPositionTests.cs
+++ b/Tests/Runtime/CameraPositionTests.cs
@@ -4,116 +4,105 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using Cinemachine;
 
-public class CameraPositionTests
+namespace Tests.Runtime
 {
-    private Camera cam;
-    private CinemachineVirtualCamera vcam;
-    private GameObject followObject; 
-
-    [SetUp]
-    public void Setup()
+    public class CameraPositionTests : CinemachineFixtureBase
     {
-        var cameraHolder = new GameObject("MainCamera");
-        cam = cameraHolder.AddComponent<Camera>();
-        cameraHolder.AddComponent<CinemachineBrain>();
-        var vcamHolder = new GameObject("CM Vcam");
-        vcam = vcamHolder.AddComponent<CinemachineVirtualCamera>();
-        vcam.Priority = 100;
-        followObject = new GameObject("Follow Object");
+        private CinemachineVirtualCamera vcam;
+        private GameObject followObject;
 
-        CinemachineCore.UniformDeltaTimeOverride = 0.1f;
+        [SetUp]
+        public override void SetUp()
+        {
+            CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain));
+            vcam = CreateGameObject("CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            vcam.Priority = 100;
+            followObject = CreateGameObject("Follow Object");
+            
+            base.SetUp();
+        }
+
+        [UnityTest]
+        public IEnumerator DoNothing()
+        {
+            vcam.Follow = followObject.transform;
+            Vector3 oldPos = vcam.transform.position;
+            followObject.transform.position += new Vector3(2, 2, 2);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == oldPos);
+        }
+
+        [UnityTest]
+        public IEnumerator ThirdPerson()
+        {
+            vcam.AddCinemachineComponent<Cinemachine3rdPersonFollow>();
+            vcam.Follow = followObject.transform;
+            followObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+        }
+
+        [UnityTest]
+        public IEnumerator FramingTransposer()
+        {
+            CinemachineFramingTransposer component = vcam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_CameraDistance = 1f;
+            vcam.Follow = followObject.transform;
+            followObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == new Vector3(10, 0, -component.m_CameraDistance));
+        }
+
+        [UnityTest]
+        public IEnumerator HardLockToTarget()
+        {
+            vcam.AddCinemachineComponent<CinemachineHardLockToTarget>();
+            vcam.Follow = followObject.transform;
+            followObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+        }
+
+        [UnityTest]
+        public IEnumerator OrbTransposer()
+        {
+            CinemachineOrbitalTransposer component = vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_FollowOffset = new Vector3(0, 0, 0);
+            vcam.Follow = followObject.transform;
+            followObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+        }
+
+        [UnityTest]
+        public IEnumerator TrackedDolly()
+        {
+            vcam.AddCinemachineComponent<CinemachineTrackedDolly>();
+            vcam.Follow = followObject.transform;
+            Vector3 oldPos = vcam.transform.position;
+            followObject.transform.position += new Vector3(2, 2, 2);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == oldPos);
+        }
+
+        [UnityTest]
+        public IEnumerator Transposer()
+        {
+            CinemachineTransposer component = vcam.AddCinemachineComponent<CinemachineTransposer>();
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_FollowOffset = new Vector3(0, 0, 0);
+            vcam.Follow = followObject.transform;
+            followObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+        }
     }
-
-    [TearDown]
-    public void Teardown()
-    {
-        Object.Destroy(cam.gameObject);
-        Object.Destroy(vcam.gameObject);
-
-        CinemachineCore.UniformDeltaTimeOverride = -1f;
-    }
-
-    [UnityTest]
-    public IEnumerator DoNothing()
-    {
-        vcam.Follow = followObject.transform;
-        Vector3 oldPos = vcam.transform.position;
-        followObject.transform.position += new Vector3(2, 2, 2);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == oldPos);
-    }
-
-    [UnityTest]
-    public IEnumerator ThirdPerson()
-    {
-        vcam.AddCinemachineComponent<Cinemachine3rdPersonFollow>();
-        vcam.Follow = followObject.transform;
-        followObject.transform.position += new Vector3(10, 0, 0);
-        yield return null; 
-        Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
-    }
-
-    [UnityTest]
-    public IEnumerator FramingTransposer()
-    {
-        CinemachineFramingTransposer component = vcam.AddCinemachineComponent<CinemachineFramingTransposer>();
-        component.m_XDamping = 0;
-        component.m_YDamping = 0;
-        component.m_ZDamping = 0;
-        component.m_CameraDistance = 1f;
-        vcam.Follow = followObject.transform;
-        followObject.transform.position += new Vector3(10, 0, 0);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == new Vector3(10, 0, -component.m_CameraDistance));
-    }
-
-    [UnityTest]
-    public IEnumerator HardLockToTarget()
-    {
-        vcam.AddCinemachineComponent<CinemachineHardLockToTarget>();
-        vcam.Follow = followObject.transform;
-        followObject.transform.position += new Vector3(10, 0, 0);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
-    }
-
-    [UnityTest]
-    public IEnumerator OrbTransposer()
-    {
-        CinemachineOrbitalTransposer component = vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
-        component.m_XDamping = 0;
-        component.m_YDamping = 0;
-        component.m_ZDamping = 0;
-        component.m_FollowOffset = new Vector3(0, 0, 0);
-        vcam.Follow = followObject.transform;
-        followObject.transform.position += new Vector3(10, 0, 0);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
-    }
-
-    [UnityTest]
-    public IEnumerator TrackedDolly()
-    {
-        vcam.AddCinemachineComponent<CinemachineTrackedDolly>();
-        vcam.Follow = followObject.transform;
-        Vector3 oldPos = vcam.transform.position;
-        followObject.transform.position += new Vector3(2, 2, 2);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == oldPos);
-    }
-
-    [UnityTest]
-    public IEnumerator Transposer()
-    {
-        CinemachineTransposer component = vcam.AddCinemachineComponent<CinemachineTransposer>();
-        component.m_XDamping = 0;
-        component.m_YDamping = 0;
-        component.m_ZDamping = 0;
-        component.m_FollowOffset = new Vector3(0, 0, 0);
-        vcam.Follow = followObject.transform;
-        followObject.transform.position += new Vector3(10, 0, 0);
-        yield return null;
-        Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
-    }
-
 }

--- a/Tests/Runtime/CameraPositionTests.cs
+++ b/Tests/Runtime/CameraPositionTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Cinemachine;
+using UnityEngine.TestTools.Utils;
 
 namespace Tests.Runtime
 {
@@ -29,7 +30,7 @@ namespace Tests.Runtime
             Vector3 oldPos = vcam.transform.position;
             followObject.transform.position += new Vector3(2, 2, 2);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == oldPos);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(oldPos).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -39,7 +40,7 @@ namespace Tests.Runtime
             vcam.Follow = followObject.transform;
             followObject.transform.position += new Vector3(10, 0, 0);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(followObject.transform.position).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -53,7 +54,7 @@ namespace Tests.Runtime
             vcam.Follow = followObject.transform;
             followObject.transform.position += new Vector3(10, 0, 0);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == new Vector3(10, 0, -component.m_CameraDistance));
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(new Vector3(10, 0, -component.m_CameraDistance)).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -63,7 +64,7 @@ namespace Tests.Runtime
             vcam.Follow = followObject.transform;
             followObject.transform.position += new Vector3(10, 0, 0);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(followObject.transform.position).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -77,7 +78,7 @@ namespace Tests.Runtime
             vcam.Follow = followObject.transform;
             followObject.transform.position += new Vector3(10, 0, 0);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(followObject.transform.position).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -88,7 +89,7 @@ namespace Tests.Runtime
             Vector3 oldPos = vcam.transform.position;
             followObject.transform.position += new Vector3(2, 2, 2);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == oldPos);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(oldPos).Using(Vector3EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -102,7 +103,7 @@ namespace Tests.Runtime
             vcam.Follow = followObject.transform;
             followObject.transform.position += new Vector3(10, 0, 0);
             yield return null;
-            Assert.IsTrue(vcam.State.FinalPosition == followObject.transform.position);
+            Assert.That(vcam.State.FinalPosition, Is.EqualTo(followObject.transform.position).Using(Vector3EqualityComparer.Instance));
         }
     }
 }

--- a/Tests/Runtime/CamerasBlendingTests.cs
+++ b/Tests/Runtime/CamerasBlendingTests.cs
@@ -3,204 +3,189 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Cinemachine;
+using Tests.Runtime;
 
-[TestFixture]   
-public class CamerasBlendingTests
+namespace Tests.Runtime
 {
-    private Camera cam;
-    private CinemachineVirtualCamera sourceVCam;
-    private CinemachineVirtualCamera targetVCam;
-    private CinemachineBrain brain;
-    private GameObject followObject;
-
-    private const float BlendingTime = 1;
-
-    [SetUp]
-    public void Setup()
+    [TestFixture]
+    public class CamerasBlendingTests : CinemachineFixtureBase
     {
-        // Camera
-        var cameraHolder = new GameObject("MainCamera");
-        cam = cameraHolder.AddComponent<Camera>();
-        brain = cameraHolder.AddComponent<CinemachineBrain>();
+        private const float BlendingTime = 1;
 
-        // Blending
-        brain.m_DefaultBlend = new CinemachineBlendDefinition(
-            CinemachineBlendDefinition.Style.Linear, 
-            BlendingTime);
-        
-        followObject = new GameObject("Follow Object");
-        
-        // Source vcam
-        var sourceVCamHolder = new GameObject("Source CM Vcam");
-        sourceVCam = sourceVCamHolder.AddComponent<CinemachineVirtualCamera>();
-        sourceVCam.Priority = 2;
-        sourceVCam.Follow = followObject.transform;
+        private CinemachineBrain brain;
+        private CinemachineVirtualCamera targetVCam;
 
-        // target vcam
-        var targetVCamHolder = new GameObject("Target CM Vcam");
-        targetVCam = targetVCamHolder.AddComponent<CinemachineVirtualCamera>();
-        targetVCam.Priority = 1;
-        targetVCam.Follow = followObject.transform;
+        [SetUp]
+        public override void SetUp()
+        {
+            // Camera
+            var cameraHolder = CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain));
+            brain = cameraHolder.GetComponent<CinemachineBrain>();
 
-        CinemachineCore.UniformDeltaTimeOverride = 0.1f;
-    }
+            // Blending
+            brain.m_DefaultBlend = new CinemachineBlendDefinition(
+                CinemachineBlendDefinition.Style.Linear,
+                BlendingTime);
 
-    [TearDown]
-    public void Teardown()
-    {
-        Object.Destroy(cam.gameObject);
-        Object.Destroy(sourceVCam.gameObject);
-        Object.Destroy(targetVCam.gameObject);
-        Object.Destroy(followObject);
+            var followObject = CreateGameObject("Follow Object");
 
-        CinemachineCore.UniformDeltaTimeOverride = -1f;
-    }
+            // Source vcam
+            var sourceVCam = CreateGameObject("Source CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            sourceVCam.Priority = 2;
+            sourceVCam.Follow = followObject.transform;
 
+            // target vcam
+            targetVCam = CreateGameObject("Target CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            targetVCam.Priority = 1;
+            targetVCam.Follow = followObject.transform;
 
-    [UnityTest]
-    public IEnumerator BlendingBetweenCameras()
-    {
-        
-        targetVCam.Priority = 3;
-        yield return null;
+            base.SetUp();
+        }
 
-        yield return new WaitForSeconds(BlendingTime + 0.01f);
-        Assert.IsTrue(!brain.IsBlending);
-    }
-    
-    [UnityTest]
-    public IEnumerator InterruptedBlendingBetweenCameras()
-    {
-        // Start blending
-        targetVCam.Priority = 3;
-        yield return null;
+        [UnityTest]
+        public IEnumerator BlendingBetweenCameras()
+        {
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Wait for 90% of blending duration
-        yield return new WaitForSeconds(BlendingTime * 0.9f);
-        
-        // Blend back to source
-        targetVCam.Priority = 1;
-        yield return null;
-        yield return new WaitForSeconds(BlendingTime * 0.1f);
-        
-        // Quickly blend to target again
-        targetVCam.Priority = 3;
-        yield return null;
-        
-        // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime * 0.21f);
+            yield return new WaitForSeconds(BlendingTime + 0.01f);
+            Assert.IsTrue(!brain.IsBlending);
+        }
 
-        Assert.IsTrue(!brain.IsBlending);
+        [UnityTest]
+        public IEnumerator InterruptedBlendingBetweenCameras()
+        {
+            // Start blending
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Start blending
-        targetVCam.Priority = 3;
-        yield return null;
+            // Wait for 90% of blending duration
+            yield return new WaitForSeconds(BlendingTime * 0.9f);
 
-        // Wait for 90% of blending duration
-        yield return new WaitForSeconds(BlendingTime * 0.9f);
-        
-        // Blend back to source
-        targetVCam.Priority = 1;
-        yield return null;
-        yield return new WaitForSeconds(BlendingTime * 0.1f);
-        
-        // Quickly blend to target again
-        targetVCam.Priority = 3;
-        yield return null;
-        
-        // We went 90%, then got 10% back, it means we are 20% away from the target - wait only 10% worth
-        yield return new WaitForSeconds(BlendingTime * 0.1f);
+            // Blend back to source
+            targetVCam.Priority = 1;
+            yield return null;
+            yield return new WaitForSeconds(BlendingTime * 0.1f);
 
-        // Blend back to source
-        targetVCam.Priority = 1;
-        yield return null;
-        yield return new WaitForSeconds(BlendingTime * 0.1f);
-        
-        // Quickly blend to target again
-        targetVCam.Priority = 3;
-        yield return null;
-        
-        // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime * 0.21f);
+            // Quickly blend to target again
+            targetVCam.Priority = 3;
+            yield return null;
 
-        Assert.IsTrue(!brain.IsBlending);
-    }
-    
-    [UnityTest]
-    public IEnumerator DoesInterruptedBlendingBetweenCamerasTakesDoubleTime()
-    {
-        // Start blending
-        targetVCam.Priority = 3;
-        yield return null;
+            // We went 90%, then got 10% back, it means we are 20% away from the target
+            yield return new WaitForSeconds(BlendingTime * 0.21f);
 
-        // Wait for 90% of blending duration
-        yield return new WaitForSeconds(BlendingTime * 0.9f);
-        
-        // Blend back to source
-        targetVCam.Priority = 1;
-        yield return null;
-        yield return new WaitForSeconds(BlendingTime * 0.1f);
-        
-        // Quickly blend to target again
-        targetVCam.Priority = 3;
-        yield return null;
-        
-        // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime + 0.01f);
+            Assert.IsTrue(!brain.IsBlending);
 
-        Assert.IsTrue(!brain.IsBlending);
-    }
-    
-    [UnityTest]
-    public IEnumerator SetActiveBlend()
-    {
-        // Start blending
-        targetVCam.Priority = 3;
+            // Start blending
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Wait 5 frames
-        yield return null;
-        yield return null;
-        yield return null;
-        yield return null;
-        yield return null;
+            // Wait for 90% of blending duration
+            yield return new WaitForSeconds(BlendingTime * 0.9f);
 
-        var blend = brain.ActiveBlend;
-        float percentComplete = blend.TimeInBlend / blend.Duration;
+            // Blend back to source
+            targetVCam.Priority = 1;
+            yield return null;
+            yield return new WaitForSeconds(BlendingTime * 0.1f);
 
-        // Freeze the blend
-        blend.TimeInBlend -= CinemachineCore.UniformDeltaTimeOverride;
-        brain.ActiveBlend = blend;
+            // Quickly blend to target again
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Wait a frame and check that TimeInBlend is the same
-        yield return null;
-        blend = brain.ActiveBlend;
-        Assert.That(percentComplete == blend.TimeInBlend / blend.Duration);
+            // We went 90%, then got 10% back, it means we are 20% away from the target - wait only 10% worth
+            yield return new WaitForSeconds(BlendingTime * 0.1f);
 
-        // Force the blend to complete
-        blend.Duration = 0;
-        brain.ActiveBlend = blend;
+            // Blend back to source
+            targetVCam.Priority = 1;
+            yield return null;
+            yield return new WaitForSeconds(BlendingTime * 0.1f);
 
-        // Wait a frame and check that blend is finished
-        yield return null;
-        Assert.That(brain.ActiveBlend == null);
+            // Quickly blend to target again
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Blend back to source
-        targetVCam.Priority = 1;
+            // We went 90%, then got 10% back, it means we are 20% away from the target
+            yield return new WaitForSeconds(BlendingTime * 0.21f);
 
-        // Wait 5 frames
-        yield return null;
-        yield return null;
-        yield return null;
-        yield return null;
-        yield return null;
-        blend = brain.ActiveBlend;
-        Assert.That(percentComplete == blend.TimeInBlend / blend.Duration);
+            Assert.IsTrue(!brain.IsBlending);
+        }
 
-        // Kill the blend
-        brain.ActiveBlend = null;
+        [UnityTest]
+        public IEnumerator DoesInterruptedBlendingBetweenCamerasTakesDoubleTime()
+        {
+            // Start blending
+            targetVCam.Priority = 3;
+            yield return null;
 
-        // Wait a frame and check that blend is finished
-        yield return null;
-        Assert.That(brain.ActiveBlend == null);
+            // Wait for 90% of blending duration
+            yield return new WaitForSeconds(BlendingTime * 0.9f);
+
+            // Blend back to source
+            targetVCam.Priority = 1;
+            yield return null;
+            yield return new WaitForSeconds(BlendingTime * 0.1f);
+
+            // Quickly blend to target again
+            targetVCam.Priority = 3;
+            yield return null;
+
+            // We went 90%, then got 10% back, it means we are 20% away from the target
+            yield return new WaitForSeconds(BlendingTime + 0.01f);
+
+            Assert.IsTrue(!brain.IsBlending);
+        }
+
+        [UnityTest]
+        public IEnumerator SetActiveBlend()
+        {
+            // Start blending
+            targetVCam.Priority = 3;
+
+            // Wait 5 frames
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+
+            var blend = brain.ActiveBlend;
+            float percentComplete = blend.TimeInBlend / blend.Duration;
+
+            // Freeze the blend
+            blend.TimeInBlend -= CinemachineCore.UniformDeltaTimeOverride;
+            brain.ActiveBlend = blend;
+
+            // Wait a frame and check that TimeInBlend is the same
+            yield return null;
+            blend = brain.ActiveBlend;
+            Assert.That(percentComplete == blend.TimeInBlend / blend.Duration);
+
+            // Force the blend to complete
+            blend.Duration = 0;
+            brain.ActiveBlend = blend;
+
+            // Wait a frame and check that blend is finished
+            yield return null;
+            Assert.That(brain.ActiveBlend == null);
+
+            // Blend back to source
+            targetVCam.Priority = 1;
+
+            // Wait 5 frames
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+            blend = brain.ActiveBlend;
+            Assert.That(percentComplete == blend.TimeInBlend / blend.Duration);
+
+            // Kill the blend
+            brain.ActiveBlend = null;
+
+            // Wait a frame and check that blend is finished
+            yield return null;
+            Assert.That(brain.ActiveBlend == null);
+        }
     }
 }

--- a/Tests/Runtime/CamerasBlendingTests.cs
+++ b/Tests/Runtime/CamerasBlendingTests.cs
@@ -49,7 +49,7 @@ namespace Tests.Runtime
             yield return null;
 
             yield return new WaitForSeconds(BlendingTime + 0.01f);
-            Assert.IsTrue(!brain.IsBlending);
+            Assert.That(brain.IsBlending, Is.False);
         }
 
         [UnityTest]
@@ -74,7 +74,7 @@ namespace Tests.Runtime
             // We went 90%, then got 10% back, it means we are 20% away from the target
             yield return new WaitForSeconds(BlendingTime * 0.21f);
 
-            Assert.IsTrue(!brain.IsBlending);
+            Assert.That(brain.IsBlending, Is.False);
 
             // Start blending
             targetVCam.Priority = 3;
@@ -107,7 +107,7 @@ namespace Tests.Runtime
             // We went 90%, then got 10% back, it means we are 20% away from the target
             yield return new WaitForSeconds(BlendingTime * 0.21f);
 
-            Assert.IsTrue(!brain.IsBlending);
+            Assert.That(brain.IsBlending, Is.False);
         }
 
         [UnityTest]
@@ -132,7 +132,7 @@ namespace Tests.Runtime
             // We went 90%, then got 10% back, it means we are 20% away from the target
             yield return new WaitForSeconds(BlendingTime + 0.01f);
 
-            Assert.IsTrue(!brain.IsBlending);
+            Assert.That(brain.IsBlending, Is.False);
         }
 
         [UnityTest]

--- a/Tests/Runtime/CinemachineFixtureBase.cs
+++ b/Tests/Runtime/CinemachineFixtureBase.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Cinemachine;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.Runtime
+{
+    public class CinemachineFixtureBase
+    {
+        private List<GameObject> m_GameObjectsToDestroy = new List<GameObject>();
+        
+        internal GameObject CreateGameObject(string name, params System.Type[] components)
+        {
+            var go = new GameObject();
+            m_GameObjectsToDestroy.Add(go);
+            go.name = name;
+        
+            foreach(var c in components)
+                if (c.IsSubclassOf(typeof(Component)))
+                    go.AddComponent(c);
+        
+            return go;
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            // force a uniform deltaTime, otherwise tests will be unstable
+            CinemachineCore.UniformDeltaTimeOverride = 0.1f;
+        }
+        
+        [TearDown]
+        public virtual void TearDown()
+        {
+            foreach (var go in m_GameObjectsToDestroy)
+                UnityEngine.Object.Destroy(go);
+
+            m_GameObjectsToDestroy.Clear();
+            
+            CinemachineCore.UniformDeltaTimeOverride = -1f;
+        }
+
+    }
+}

--- a/Tests/Runtime/CinemachineFixtureBase.cs.meta
+++ b/Tests/Runtime/CinemachineFixtureBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d55eb8ce57dc4a73a25400be00c73dd9
+timeCreated: 1624656047

--- a/Tests/Runtime/Confiner2DUnitTests.cs
+++ b/Tests/Runtime/Confiner2DUnitTests.cs
@@ -5,200 +5,125 @@ using Cinemachine.Utility;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.TestTools.Utils;
 
-public class Confiner2DUnitTests
+namespace Tests.Runtime
 {
-    [SetUp]
-    public void SetUp()
+    public class Confiner2DUnitTests : CinemachineFixtureBase
     {
-        CinemachineCore.UniformDeltaTimeOverride = 0.1f;
-    }
+        private Camera cam;
+        private CinemachineVirtualCamera vcam;
+        private CinemachineConfiner2D confiner2D;
 
-    [TearDown]
-    public void TearDown()
-    {
-        CinemachineCore.UniformDeltaTimeOverride = 1f;
-    }
-    
-    [UnityTest]
-    public IEnumerator Test_SimpleSquareConfiner_OrderIndependent_PolygonCollider2D()
-    {
-        CreateCameraAndAddVcam(out Camera cam, out CinemachineVirtualCamera vcam);
-        var confiner2D = vcam.gameObject.AddComponent<CinemachineConfiner2D>();
-        vcam.AddExtension(confiner2D);
-        cam.orthographic = true;
-        vcam.m_Lens.OrthographicSize = UnityVectorExtensions.Epsilon;
-        
-        var go = new GameObject("PolygonCollider2DHolder");
-        var polygonCollider2D = go.AddComponent<PolygonCollider2D>();
-        confiner2D.m_BoundingShape2D = polygonCollider2D;
-        confiner2D.m_Damping = 0;
-        confiner2D.m_MaxWindowSize = 0;
-        { // clockwise
-            polygonCollider2D.points = new[]
-            {
-                Vector2.left,
-                Vector2.up,
-                Vector2.right,
-                Vector2.down,
-            };
-            confiner2D.InvalidateCache();
+        [SetUp]
+        public override void SetUp()
+        {
+            cam = CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain)).GetComponent<Camera>();
+            var vcamHolder = CreateGameObject("CM Vcam", typeof(CinemachineVirtualCamera), typeof(CinemachineConfiner2D));
+            vcam = vcamHolder.GetComponent<CinemachineVirtualCamera>();
+            confiner2D = vcamHolder.GetComponent<CinemachineConfiner2D>();
+            vcam.Priority = 100;
+            cam.orthographic = true;
+            vcam.AddExtension(confiner2D);
+
+            vcam.m_Lens.OrthographicSize = UnityVectorExtensions.Epsilon;
+
+            base.SetUp();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            vcam.m_Lens.OrthographicSize = 1;
             
+            base.TearDown();
+        }
+
+        private static IEnumerable ColliderTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new[] {Vector2.left, Vector2.up, Vector2.right, Vector2.down}).SetName("Clockwise").Returns(null);
+                yield return new TestCaseData(new[] {Vector2.left, Vector2.down, Vector2.right, Vector2.up}).SetName("Counter-Clockwise").Returns(null);
+            }
+        }
+
+        [UnityTest, TestCaseSource(nameof(ColliderTestCases))]
+        public IEnumerator Test_SimpleSquareConfiner_OrderIndependent_PolygonCollider2D(Vector2[] testPoints)
+        {
+            var polygonCollider2D = CreateGameObject("PolygonCollider2DHolder", typeof(PolygonCollider2D)).GetComponent<PolygonCollider2D>();
+            confiner2D.m_BoundingShape2D = polygonCollider2D;
+            confiner2D.m_Damping = 0;
+            confiner2D.m_MaxWindowSize = 0;
+
+            // clockwise
+            polygonCollider2D.points = testPoints;
+            
+            confiner2D.InvalidateCache();
+
             vcam.transform.position = Vector3.zero;
             yield return null; // wait one frame
-            Assert.IsTrue(vcam.State.CorrectedPosition == Vector3.zero);
+            Assert.That(vcam.State.CorrectedPosition, Is.EqualTo(Vector3.zero).Using(Vector3EqualityComparer.Instance));
 
             vcam.transform.position = Vector2.left * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.up * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.right * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.down * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude < UnityVectorExtensions.Epsilon);
+            Assert.That((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
         }
 
-        { // counter clockwise
-            polygonCollider2D.points = new[]
-            {
-                Vector2.left,
-                Vector2.down,
-                Vector2.right,
-                Vector2.up,
-            };
+        [UnityTest, TestCaseSource(nameof(ColliderTestCases))]
+        public IEnumerator Test_SimpleSquareConfiner_OrderIndependent_CompositeCollider2D(Vector2[] testPoints)
+        {
+            var compositeHolder = CreateGameObject("CompositeCollider2DHolder", typeof(Rigidbody2D), typeof(CompositeCollider2D));
+            var rigidbody2D = compositeHolder.GetComponent<Rigidbody2D>();
+            rigidbody2D.bodyType = RigidbodyType2D.Kinematic;
+            rigidbody2D.isKinematic = true;
+            rigidbody2D.simulated = false;
+            var compositeCollider2D = compositeHolder.GetComponent<CompositeCollider2D>();
+            compositeCollider2D.geometryType = CompositeCollider2D.GeometryType.Polygons;
+
+            var polyHolder = CreateGameObject("PolygonCollider2DHolder", typeof(PolygonCollider2D));
+            polyHolder.transform.parent = compositeHolder.transform;
+            var polygonCollider2D = polyHolder.GetComponent<PolygonCollider2D>();
+            polygonCollider2D.usedByComposite = true;
+            confiner2D.m_BoundingShape2D = compositeCollider2D;
+            confiner2D.m_Damping = 0;
+            confiner2D.m_MaxWindowSize = 0;
             
+            // clockwise
+            polygonCollider2D.points = testPoints;
             confiner2D.InvalidateCache();
-            
+
             vcam.transform.position = Vector3.zero;
             yield return null; // wait one frame
-            Assert.IsTrue(vcam.State.CorrectedPosition == Vector3.zero);
+            Assert.That(vcam.State.CorrectedPosition, Is.EqualTo(Vector3.zero).Using(Vector3EqualityComparer.Instance));
 
             vcam.transform.position = Vector2.left * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.up * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.right * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
+            Assert.That((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
+
             vcam.transform.position = Vector2.down * 2f;
             yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude < UnityVectorExtensions.Epsilon);
+            Assert.That((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
         }
-        
-        vcam.m_Lens.OrthographicSize = 1;
-    }
-
-    [UnityTest]
-    public IEnumerator Test_SimpleSquareConfiner_OrderIndependent_CompositeCollider2D()
-    {
-        CreateCameraAndAddVcam(out Camera cam, out CinemachineVirtualCamera vcam);
-        var confiner2D = vcam.gameObject.AddComponent<CinemachineConfiner2D>();
-        vcam.AddExtension(confiner2D);
-        cam.orthographic = true;
-        vcam.m_Lens.OrthographicSize = UnityVectorExtensions.Epsilon;
-        
-        var compositeHolder = new GameObject("CompositeCollider2DHolder");
-        var rigidbody2D = compositeHolder.AddComponent<Rigidbody2D>();
-        rigidbody2D.bodyType = RigidbodyType2D.Kinematic;
-        rigidbody2D.isKinematic = true;
-        rigidbody2D.simulated = false;
-        var compositeCollider2D = compositeHolder.AddComponent<CompositeCollider2D>();
-        compositeCollider2D.geometryType = CompositeCollider2D.GeometryType.Polygons;
-
-        var polyHolder = new GameObject("PolygonCollider2DHolder");
-        polyHolder.transform.parent = compositeHolder.transform;
-        var polygonCollider2D = polyHolder.AddComponent<PolygonCollider2D>();
-        polygonCollider2D.usedByComposite = true;
-        confiner2D.m_BoundingShape2D = compositeCollider2D;
-        confiner2D.m_Damping = 0;
-        confiner2D.m_MaxWindowSize = 0;
-        { // clockwise
-            polygonCollider2D.points = new[]
-            {
-                Vector2.left,
-                Vector2.up,
-                Vector2.right,
-                Vector2.down,
-            };
-            confiner2D.InvalidateCache();
-            
-            vcam.transform.position = Vector3.zero;
-            yield return null; // wait one frame
-            Assert.IsTrue(vcam.State.CorrectedPosition == Vector3.zero);
-
-            vcam.transform.position = Vector2.left * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.up * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.right * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.down * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude < UnityVectorExtensions.Epsilon);
-        }
-
-        { // counter clockwise
-            polygonCollider2D.points = new[]
-            {
-                Vector2.left,
-                Vector2.down,
-                Vector2.right,
-                Vector2.up,
-            };
-            
-            confiner2D.InvalidateCache();
-            
-            vcam.transform.position = Vector3.zero;
-            yield return null; // wait one frame
-            Assert.IsTrue(vcam.State.CorrectedPosition == Vector3.zero);
-
-            vcam.transform.position = Vector2.left * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.left).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.up * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.up).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.right * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.right).sqrMagnitude < UnityVectorExtensions.Epsilon);
-            
-            vcam.transform.position = Vector2.down * 2f;
-            yield return null; // wait one frame
-            Assert.IsTrue((vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude < UnityVectorExtensions.Epsilon);
-        }
-        
-        vcam.m_Lens.OrthographicSize = 1;
-    }
-    
-    
-    private void CreateCameraAndAddVcam(out Camera cam, out CinemachineVirtualCamera vcam)
-    {
-        var cameraHolder = new GameObject("MainCamera");
-        cam = cameraHolder.AddComponent<Camera>();
-        cameraHolder.AddComponent<CinemachineBrain>();
-        
-        var vcamHolder = new GameObject("CM Vcam");
-        vcam = vcamHolder.AddComponent<CinemachineVirtualCamera>();
-        vcam.Priority = 100;
     }
 }

--- a/Tests/Runtime/FreeLookTests.cs
+++ b/Tests/Runtime/FreeLookTests.cs
@@ -94,13 +94,13 @@ public class FreeLookTests
             yield return new TestCaseData(-10f, 0.5f, new Vector3(-2.598455f, 2.766761f, -1.500219f)).SetName("Left X Center Y").Returns(null);
             yield return new TestCaseData(-10f, 0.75f, new Vector3(-2.58138f, 2.899473f, -1.49036f)).SetName("Left X Top Y").Returns(null);
 
-            yield return new TestCaseData(0f, 0.4f, new Vector3(0f, 2.713465f, -3.00477f)).SetName("Center X Bottom Y").Returns(null);
+            yield return new TestCaseData(0f, 0.25f, new Vector3(0f, 2.633411f, -3.007236f)).SetName("Center X Bottom Y").Returns(null);
             yield return new TestCaseData(0f, 0.5f, new Vector3(0f, 2.766761f, -3.000437f)).SetName("Center X Center Y").Returns(null);
-            yield return new TestCaseData(0f, 0.6f, new Vector3(0f, 2.819954f, -2.994039f)).SetName("Center X Top Y").Returns(null);
+            yield return new TestCaseData(0f, 0.75f, new Vector3(0f, 2.899473f, -2.980721f)).SetName("Center X Top Y").Returns(null);
 
-            yield return new TestCaseData(10f, 0.4f, new Vector3(2.602207f, 2.713465f, -1.502385f)).SetName("Right X Bottom Y").Returns(null);
+            yield return new TestCaseData(10f, 0.25f, new Vector3(2.604343f, 2.633411f, -1.503618f)).SetName("Right X Bottom Y").Returns(null);
             yield return new TestCaseData(10f, 0.5f, new Vector3(2.598455f, 2.766761f, -1.500219f)).SetName("Right X Center Y").Returns(null);
-            yield return new TestCaseData(10f, 0.6f, new Vector3(2.592913f, 2.819954f, -1.497019f)).SetName("Right X Top Y").Returns(null);
+            yield return new TestCaseData(10f, 0.75f, new Vector3(2.58138f, 2.899473f, -1.49036f)).SetName("Right X Top Y").Returns(null);
         }
     }
 

--- a/Tests/Runtime/FreeLookTests.cs
+++ b/Tests/Runtime/FreeLookTests.cs
@@ -1,0 +1,120 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine.TestTools;
+
+using Cinemachine;
+using UnityEditor.VersionControl;
+using Object = System.Object;
+
+[TestFixture]
+public class FreeLookTests
+{
+    private const float Epsilon = 0.001f;
+
+    private List<GameObject> m_GameObjectsToDestroy = new List<GameObject>();
+    private GameObject CreateGameObject(string name, params System.Type[] components)
+    {
+        var go = new GameObject();
+        m_GameObjectsToDestroy.Add(go);
+        go.name = name;
+        
+        foreach(var c in components)
+            if (c.IsSubclassOf(typeof(Component)))
+                go.AddComponent(c);
+        
+        return go;
+    }
+
+    class TestAxisProvider : AxisState.IInputAxisProvider
+    {
+        private float x, y;
+
+        public TestAxisProvider()
+        {
+            x = 0f;
+            y = 0f;
+        }
+        
+        public void SetAxisValues(float x, float y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+        
+        public float GetAxisValue(int axis)
+        {
+            return axis == 0 ? x : y;
+        }
+    }
+
+    private CinemachineFreeLook m_FreeLook;
+    private TestAxisProvider m_AxisProvider;
+    
+    [SetUp]
+    public void SetUp()
+    {
+        CreateGameObject("Camera", typeof(Camera), typeof(CinemachineBrain));
+
+        // create a "character"
+        var character = CreateGameObject("Character").GetComponent<Transform>();
+        character.position.Set(0f, 0f, 0f);
+        var body = CreateGameObject("Body").GetComponent<Transform>();
+        body.position.Set(0f, 0f, 0f);
+        body.parent = character;
+        var head = CreateGameObject("Head").GetComponent<Transform>();
+        head.position.Set(0f, 1f, 0f);
+        head.parent = body;
+        
+        // Create a free-look camera 
+        m_FreeLook = CreateGameObject("CinemachineFreeLook", typeof(CinemachineFreeLook)).GetComponent<CinemachineFreeLook>();
+        m_AxisProvider = new TestAxisProvider();
+        m_FreeLook.m_XAxis.SetInputAxisProvider(0, m_AxisProvider);
+        m_FreeLook.m_YAxis.SetInputAxisProvider(1, m_AxisProvider);
+        m_FreeLook.Follow = body;
+        m_FreeLook.LookAt = head;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var go in m_GameObjectsToDestroy)
+            UnityEngine.Object.Destroy(go);
+
+        m_GameObjectsToDestroy.Clear();
+    }
+    
+    private static IEnumerable FreeLookTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(-45f, 0.0f, new Vector3(2.5f, 2.5f, -1.6f)).SetName("Left X Bottom Y").Returns(null);
+            yield return new TestCaseData(-45f, 0.5f, new Vector3(-1.4f, 4.0f, 2.0f)).SetName("Left X Center Y").Returns(null);
+            yield return new TestCaseData(-45f, 1.0f, new Vector3(-0.9f, 4.5f, 1.5f)).SetName("Left X Top Y").Returns(null);
+
+            yield return new TestCaseData(0f, 0f, new Vector3(1.3f, 4.5f, -1.2f)).SetName("Center X Bottom Y").Returns(null);
+            yield return new TestCaseData(0f, 0.5f, new Vector3(0f, 2.5f, -3.0f)).SetName("Center X Center Y").Returns(null);
+            yield return new TestCaseData(0f, 1.0f, new Vector3(0f, 4.5f, -1.8f)).SetName("Center X Top Y").Returns(null);
+
+            yield return new TestCaseData(45f, 0f, new Vector3(0f, 4.5f, -1.8f)).SetName("Right X Bottom Y").Returns(null);
+            yield return new TestCaseData(45f, 0.5f, new Vector3(-2.5f, 2.5f, -1.7f)).SetName("Right X Center Y").Returns(null);
+            yield return new TestCaseData(45f, 1.0f, new Vector3(-1.3f, 4.5f, -1.1f)).SetName("Right X Top Y").Returns(null);
+        }
+    }
+
+    [UnityTest, TestCaseSource(nameof(FreeLookTestCases))]
+    public IEnumerator TestAxisStateChangeMovesCamera(float axisX, float axisY, Vector3 expectedPosition)
+    {
+        m_AxisProvider.SetAxisValues(axisX, axisY);
+
+        yield return new WaitForSeconds(1.0f);
+
+        Assert.That(m_FreeLook.transform.position, Is.EqualTo(expectedPosition).Within(Epsilon));
+        // Assert.That(m_FreeLook.transform.position.x, Is.EqualTo(expectedPosition.x).Within(Epsilon));
+        // Assert.That(m_FreeLook.transform.position.y, Is.EqualTo(expectedPosition.y).Within(Epsilon));
+        // Assert.That(m_FreeLook.transform.position.z, Is.EqualTo(expectedPosition.z).Within(Epsilon));
+    }
+}

--- a/Tests/Runtime/FreeLookTests.cs
+++ b/Tests/Runtime/FreeLookTests.cs
@@ -107,7 +107,7 @@ public class FreeLookTests
     [UnityTest, TestCaseSource(nameof(FreeLookTestCases))]
     public IEnumerator TestAxisStateChangeMovesCamera(float axisX, float axisY, Vector3 expectedPosition)
     {
-        // apply a constant force
+        // apply a constant "force"
         m_AxisProvider.SetAxisValues(axisX, axisY);
 
         // wait two frames (constant deltaTime forced in SetUp)

--- a/Tests/Runtime/FreeLookTests.cs
+++ b/Tests/Runtime/FreeLookTests.cs
@@ -13,8 +13,6 @@ namespace Tests.Runtime
     [TestFixture]
     public class FreeLookTests : CinemachineFixtureBase
     {
-        private static readonly Vector3EqualityComparer s_Comparer = new Vector3EqualityComparer(0.000001f);
-
         class TestAxisProvider : AxisState.IInputAxisProvider
         {
             private float x, y;
@@ -95,7 +93,7 @@ namespace Tests.Runtime
             yield return null;
 
             // check the resulting position of the freelook
-            Assert.That(m_FreeLook.transform.position, Is.EqualTo(expectedPosition).Using(s_Comparer),
+            Assert.That(m_FreeLook.transform.position, Is.EqualTo(expectedPosition).Using(Vector3EqualityComparer.Instance),
                 $"Actual was: ({m_FreeLook.transform.position.x}f, {m_FreeLook.transform.position.y}f, {m_FreeLook.transform.position.z}f)");
         }
     }

--- a/Tests/Runtime/FreeLookTests.cs.meta
+++ b/Tests/Runtime/FreeLookTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f3d09d5307bf4a3eb101982e7efbf6e4
+timeCreated: 1624560904

--- a/Tests/Runtime/StateDrivenCameraTests.cs
+++ b/Tests/Runtime/StateDrivenCameraTests.cs
@@ -8,73 +8,67 @@ using UnityEngine.TestTools;
 
 using Cinemachine;
 
-[TestFixture]
-public class StateDrivenCameraTests
+namespace Tests.Runtime
 {
-    private GameObject CreateGameObject(string name, params System.Type[] components)
+    [TestFixture]
+    public class StateDrivenCameraTests : CinemachineFixtureBase
     {
-        var go = new GameObject();
-        go.name = name;
-        
-        foreach(var c in components)
-            if (c.IsSubclassOf(typeof(Component)))
-                go.AddComponent(c);
-        
-        return go;
-    }
+        private CinemachineStateDrivenCamera stateDrivenCamera;
+        private Animator animator;
+        private CinemachineVirtualCamera vcam1, vcam2;
 
-    private CinemachineStateDrivenCamera m_StateDrivenCamera;
-    private Animator m_Animator;
-    private CinemachineVirtualCamera m_Vcam1, m_Vcam2;
-    
-    [SetUp]
-    public void SetUp()
-    {
-        CreateGameObject("Camera", typeof(Camera), typeof(CinemachineBrain));
+        [SetUp]
+        public override void SetUp()
+        {
+            CreateGameObject("Camera", typeof(Camera), typeof(CinemachineBrain));
 
-        // Create a minimal character controller
-        var character = CreateGameObject("Character", typeof(Animator));
-        var controller = AssetDatabase.LoadMainAssetAtPath("Packages/com.unity.cinemachine/Tests/Runtime/TestController.controller") as AnimatorController;
-        character.GetComponent<Animator>().runtimeAnimatorController = controller;
+            // Create a minimal character controller
+            var character = CreateGameObject("Character", typeof(Animator));
+            var controller = AssetDatabase.LoadMainAssetAtPath("Packages/com.unity.cinemachine/Tests/Runtime/TestController.controller") as AnimatorController;
+            character.GetComponent<Animator>().runtimeAnimatorController = controller;
 
-        // Create a state-driven camera with two vcams 
-        var stateDrivenCamera = CreateGameObject("CM StateDrivenCamera", typeof(CinemachineStateDrivenCamera)).GetComponent<CinemachineStateDrivenCamera>();
-        stateDrivenCamera.m_AnimatedTarget = character.GetComponent<Animator>();
-        
-        var vcam1 = CreateGameObject("Vcam1", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
-        var vcam2 = CreateGameObject("Vcam1", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
-        vcam1.gameObject.transform.SetParent(stateDrivenCamera.gameObject.transform);
-        vcam2.gameObject.transform.SetParent(stateDrivenCamera.gameObject.transform);
+            // Create a state-driven camera with two vcams 
+            var stateDrivenCamera = CreateGameObject("CM StateDrivenCamera", typeof(CinemachineStateDrivenCamera)).GetComponent<CinemachineStateDrivenCamera>();
+            stateDrivenCamera.m_AnimatedTarget = character.GetComponent<Animator>();
 
-        // Map states to vcams
-        stateDrivenCamera.m_Instructions = new[] {
+            var vcam1 = CreateGameObject("Vcam1", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            var vcam2 = CreateGameObject("Vcam1", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            vcam1.gameObject.transform.SetParent(stateDrivenCamera.gameObject.transform);
+            vcam2.gameObject.transform.SetParent(stateDrivenCamera.gameObject.transform);
+
+            // Map states to vcams
+            stateDrivenCamera.m_Instructions = new[]
+            {
                 new CinemachineStateDrivenCamera.Instruction() {m_FullHash = controller.layers[0].stateMachine.states[0].GetHashCode(), m_VirtualCamera = vcam1},
                 new CinemachineStateDrivenCamera.Instruction() {m_FullHash = controller.layers[0].stateMachine.states[1].GetHashCode(), m_VirtualCamera = vcam2}
             };
 
-        m_StateDrivenCamera = stateDrivenCamera;
-        m_Animator = character.GetComponent<Animator>();
-        m_Vcam1 = vcam1;
-        m_Vcam2 = vcam2;
-    }
-    
-    [UnityTest]
-    public IEnumerator Test_StateDrivenCamera_Follows_State()
-    {
-        yield return null; // wait one frame
+            this.stateDrivenCamera = stateDrivenCamera;
+            animator = character.GetComponent<Animator>();
+            this.vcam1 = vcam1;
+            this.vcam2 = vcam2;
 
-        Assert.That(m_StateDrivenCamera.LiveChild.Name, Is.EqualTo(m_Vcam1.Name));
+            base.SetUp();
+        }
 
-        m_Animator.SetTrigger("DoTransitionToState2");
+        [UnityTest]
+        public IEnumerator Test_StateDrivenCamera_Follows_State()
+        {
+            yield return null; // wait one frame
 
-        yield return null; // wait one frame
+            Assert.That(stateDrivenCamera.LiveChild.Name, Is.EqualTo(vcam1.Name));
 
-        Assert.That(m_StateDrivenCamera.LiveChild.Name, Is.EqualTo(m_Vcam2.Name));
+            animator.SetTrigger("DoTransitionToState2");
 
-        m_Animator.SetTrigger(("DoTransitionToState1"));
+            yield return null; // wait one frame
 
-        yield return null; // wait one frame
-        
-        Assert.That(m_StateDrivenCamera.LiveChild.Name, Is.EqualTo(m_Vcam1.Name));
+            Assert.That(stateDrivenCamera.LiveChild.Name, Is.EqualTo(vcam2.Name));
+
+            animator.SetTrigger(("DoTransitionToState1"));
+
+            yield return null; // wait one frame
+
+            Assert.That(stateDrivenCamera.LiveChild.Name, Is.EqualTo(vcam1.Name));
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

CMCL-346

Added tests for CinemachineFreeLook

### Testing status

- [X] Added an automated test
- [x] Passed all automated tests

### Comments to reviewers

"why the f did you make all of these changes?!?!"

Cinemachine depends on the global state of the scene, so tests were unstable depending on which order they ran in. To fix this I added a base class with a method for creating gameobjects that cleans them up in a Teardown. I also force a constant deltatime in this class's setup (and clear it in the teardown).

While I was at it, I switched the Asserts to use modern NUnit practices (Assert.That gives better messages when tests fail).

I also moved the tests to their own namespace as a general good practice.


