### PR TITLE
Cleaned up editor tests

### DIFF
--- a/Tests/Editor/AxisStateTests.cs
+++ b/Tests/Editor/AxisStateTests.cs
@@ -1,95 +1,90 @@
-using UnityEngine;
-using UnityEngine.TestTools;
-using NUnit.Framework;
 using System.Collections;
+using NUnit.Framework;
 using Cinemachine;
 
-public class AxisStateTests
+namespace Tests.Editor
 {
-    struct TestAxisProvider : AxisState.IInputAxisProvider
+    public class AxisStateTests
     {
-        public float value;
-
-        public TestAxisProvider(float value)
+        struct TestAxisProvider : AxisState.IInputAxisProvider
         {
-            this.value = value;
+            public float value;
+
+            public TestAxisProvider(float value)
+            {
+                this.value = value;
+            }
+
+            public float GetAxisValue(int axis)
+            {
+                return value;
+            }
         }
-        
-        public float GetAxisValue(int axis)
+
+        static IEnumerable AxisStateTestCases
         {
-            return value;
+            get
+            {
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f).Returns(1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.5f).Returns(5.0f);
+                yield return new TestCaseData(-100f, 100f, false, 1f, 0.5f, 0.5f, false, 1.0f).Returns(1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 100.0f).Returns(10.0f);
+                yield return new TestCaseData(-13f, 5f, false, 10f, 0.5f, 0.5f, false, 100.0f).Returns(5.0f);
+                yield return new TestCaseData(-13f, 5f, true, 10f, 0.5f, 0.5f, false, 100.0f).Returns(-12.0f);
+
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 0.1f).Returns(-1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 0.5f).Returns(-5.0f);
+                yield return new TestCaseData(-100f, 100f, false, 1f, 0.5f, 0.5f, true, 1.0f).Returns(-1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 100.0f).Returns(-10.0f);
+                yield return new TestCaseData(-13f, 5f, false, 10f, 0.5f, 0.5f, true, 100.0f).Returns(-13.0f);
+                yield return new TestCaseData(-13f, 5f, true, 10f, 0.5f, 0.5f, true, 100.0f).Returns(4.0f);
+            }
         }
-    }
-    
-    static IEnumerable AxisStateTestCases
-    {
-        get
+
+        [Test, TestCaseSource(nameof(AxisStateTestCases))]
+        public float TestAxisState(float minValue, float maxValue, bool wrap,
+            float maxSpeed, float accelTime, float decelTime,
+            bool invert, float axisValue)
         {
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f).Returns(1.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.5f).Returns(5.0f);
-            yield return new TestCaseData(-100f, 100f, false, 1f, 0.5f, 0.5f, false, 1.0f).Returns(1.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 100.0f).Returns(10.0f);
-            yield return new TestCaseData(-13f, 5f, false, 10f, 0.5f, 0.5f, false, 100.0f).Returns(5.0f);
-            yield return new TestCaseData(-13f, 5f, true, 10f, 0.5f, 0.5f, false, 100.0f).Returns(-12.0f);
+            var axisState = new AxisState(minValue, maxValue, wrap, false, maxSpeed, accelTime, decelTime, null, invert);
+            axisState.SetInputAxisProvider(0, new TestAxisProvider(axisValue));
+            axisState.Validate();
 
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 0.1f).Returns(-1.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 0.5f).Returns(-5.0f);
-            yield return new TestCaseData(-100f, 100f, false, 1f, 0.5f, 0.5f, true, 1.0f).Returns(-1.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, true, 100.0f).Returns(-10.0f);
-            yield return new TestCaseData(-13f, 5f, false, 10f, 0.5f, 0.5f, true, 100.0f).Returns(-13.0f);
-            yield return new TestCaseData(-13f, 5f, true, 10f, 0.5f, 0.5f, true, 100.0f).Returns(4.0f);
+            var success = axisState.Update(1.0f);
+            Assert.IsTrue(success, "Update had no effect");
+
+            return axisState.Value;
         }
-    }
-    
-    [Test, TestCaseSource(nameof(AxisStateTestCases))]
-    public float TestAxisState(float minValue, float maxValue, bool wrap, 
-        float maxSpeed, float accelTime, float decelTime,
-        bool invert, float axisValue)
-    {
-        var axisState = new AxisState(minValue, maxValue, wrap, false, maxSpeed, accelTime, decelTime, null, invert);
-        axisState.SetInputAxisProvider(0, new TestAxisProvider(axisValue));
-        axisState.Validate();
-        
-        var success = axisState.Update(1.0f);
-        Assert.IsTrue(success, "Update had no effect");
 
-        return axisState.Value;
-    }
-
-    static IEnumerable RecenteringTestCases
-    {
-        get
+        static IEnumerable RecenteringTestCases
         {
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, true, 0.01f).Returns(0.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, true, 5f).Returns(0.180375189f);
+            get
+            {
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, true, 0.01f, 0.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, true, 5f, 0.180375189f);
 
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, false, 0.01f).Returns(1.0f);
-            yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, false, 5f).Returns(1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, false, 0.01f, 1.0f);
+                yield return new TestCaseData(-100f, 100f, false, 10f, 0.5f, 0.5f, false, 0.1f, false, 5f, 1.0f);
 
+            }
         }
-    }
 
-    [Test, TestCaseSource(nameof(RecenteringTestCases))]
-    public float TestRecentering(float minValue, float maxValue, bool wrap,
-        float maxSpeed, float accelTime, float decelTime, bool invert, float axisValue,
-        bool enabled, float recenteringTime)
-    {
-        var axisState = new AxisState(minValue, maxValue, false, false, maxSpeed, accelTime, decelTime, null, invert);
-        axisState.SetInputAxisProvider(0, new TestAxisProvider(axisValue));
-        axisState.Validate();
+        [Test, TestCaseSource(nameof(RecenteringTestCases))]
+        public void TestRecentering(float minValue, float maxValue, bool wrap,
+            float maxSpeed, float accelTime, float decelTime, bool invert, float axisValue,
+            bool enabled, float recenteringTime, float expectedValue)
+        {
+            var axisState = new AxisState(minValue, maxValue, false, false, maxSpeed, accelTime, decelTime, null, invert);
+            axisState.SetInputAxisProvider(0, new TestAxisProvider(axisValue));
+            axisState.Validate();
 
-        var success = axisState.Update(1.0f);
-        Assert.IsTrue(success, "Update had no effect");
+            var success = axisState.Update(1.0f);
+            Assert.IsTrue(success, "Update had no effect");
 
-        var recentering = new AxisState.Recentering(enabled, 0.0f, recenteringTime);
-        recentering.DoRecentering(ref axisState, 10.0f, 0.0f);
+            var recentering = new AxisState.Recentering(enabled, 0.0f, recenteringTime);
+            recentering.DoRecentering(ref axisState, 10.0f, 0.0f);
 
-        return axisState.Value < Cinemachine.Utility.UnityVectorExtensions.Epsilon ? 0f : axisState.Value;
-    }
-
-    [TearDown]
-    public static void TearDown()
-    {
-        Cinemachine.CinemachineCore.CurrentTimeOverride = -1;
+            Assert.That(axisState.Value, Is.EqualTo(expectedValue).Within(Cinemachine.Utility.UnityVectorExtensions.Epsilon));
+        }
     }
 }

--- a/Tests/Editor/DampingTests.cs
+++ b/Tests/Editor/DampingTests.cs
@@ -1,39 +1,38 @@
-﻿using UnityEngine;
-using UnityEngine.TestTools;
-using NUnit.Framework;
-using System.Collections;
+﻿using NUnit.Framework;
 
-[TestFixture]
-public class DampingTests
+namespace Tests.Editor
 {
-    [Test]
-	public void DampFloat()
+    [TestFixture]
+    public class DampingTests
     {
-        const float dampTime = 10f;
-        const float initial = 100f;
-        float[] fixedFactor = new float[3] { 0.79f, 0f, 1.07f };
-        for (int f = 0; f < fixedFactor.Length; ++f)
+        [Test]
+        public void DampFloat()
         {
-            float t = 0;
-            float r = Cinemachine.Utility.Damper.Damp(initial, dampTime, t);
-            Assert.AreEqual(0, r);
-            Assert.Less(r, initial);
-            const int iterations = 10;
-            for (int i = 0; i < iterations; ++i)
+            const float dampTime = 10f;
+            const float initial = 100f;
+            float[] fixedFactor = new float[3] {0.79f, 0f, 1.07f};
+            for (int f = 0; f < fixedFactor.Length; ++f)
             {
-                t += dampTime / iterations;
-                float fdt = fixedFactor[f] * t;
-                string msg = "i = " + i + ", t = " + t + ", fdt = " + fdt;
-                if (i != iterations-1)
-                    Assert.Less(t, dampTime, msg);
-                else
-                    t = dampTime;
-                float r2 = Cinemachine.Utility.Damper.Damp(initial, dampTime, t);
-                Assert.Less(r, r2, msg);
-                r = r2;
+                float t = 0;
+                float r = Cinemachine.Utility.Damper.Damp(initial, dampTime, t);
+                Assert.That(r, Is.EqualTo(0f));
+                Assert.That(r, Is.LessThan(initial));
+                const int iterations = 10;
+                for (int i = 0; i < iterations; ++i)
+                {
+                    t += dampTime / iterations;
+                    float fdt = fixedFactor[f] * t;
+                    string msg = $"i = {i}, t = {t}, fdt = {fdt}";
+                    if (i != iterations - 1)
+                        Assert.That(t, Is.LessThan(dampTime), msg);
+                    else
+                        t = dampTime;
+                    float r2 = Cinemachine.Utility.Damper.Damp(initial, dampTime, t);
+                    Assert.That(r, Is.LessThan(r2), msg);
+                    r = r2;
+                }
+                //Assert.AreEqual(initial * (1 - MathHelpers.kNegligibleResidual), r, "f = " + f);
             }
-            //Assert.AreEqual(initial * (1 - MathHelpers.kNegligibleResidual), r, "f = " + f);
         }
-	}
+    }
 }
-

--- a/Tests/Editor/ScriptableObjectUtilityTests.cs
+++ b/Tests/Editor/ScriptableObjectUtilityTests.cs
@@ -2,21 +2,24 @@ using NUnit.Framework;
 using Cinemachine.Editor;
 using System.IO;
 
-[TestFixture]   
-public class ScriptableObjectUtilityTests
+namespace Tests.Editor
 {
-    [Test]
-    public void CinemachineInstallPathIsValid()
+    [TestFixture]
+    public class ScriptableObjectUtilityTests
     {
-        var pathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineInstallPath, "Editor/EditorResources/cm_logo_sm.png");
-        Assert.That(File.Exists(pathToCmLogo));
-    }
+        [Test]
+        public void CinemachineInstallPathIsValid()
+        {
+            var pathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineInstallPath, "Editor/EditorResources/cm_logo_sm.png");
+            Assert.That(File.Exists(pathToCmLogo));
+        }
 
-    [Test]
-    public void CinemachineInstallRelativePathIsValid()
-    {
-        var relativePathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineRealativeInstallPath, "Editor/EditorResources/cm_logo_sm.png");
-        var pathToCmLogo = Path.GetFullPath(relativePathToCmLogo);
-        Assert.That(File.Exists(pathToCmLogo));
+        [Test]
+        public void CinemachineInstallRelativePathIsValid()
+        {
+            var relativePathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineRealativeInstallPath, "Editor/EditorResources/cm_logo_sm.png");
+            var pathToCmLogo = Path.GetFullPath(relativePathToCmLogo);
+            Assert.That(File.Exists(pathToCmLogo));
+        }
     }
 }

--- a/Tests/Editor/UnityVectorExtensionTests.cs
+++ b/Tests/Editor/UnityVectorExtensionTests.cs
@@ -1,243 +1,123 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using System.Runtime.Serialization.Json;
+using UnityEngine;
 using NUnit.Framework;
 using Cinemachine.Utility;
-using Assert = UnityEngine.Assertions.Assert;
+using UnityEditor;
+using UnityEngine.TestTools.Utils;
 
-public class UnityVectorExtensionTests
+//using Assert = UnityEngine.Assertions.Assert;
+
+namespace Tests.Editor
 {
-    [Test]
-	public void FindIntersectionTests()
+    public class UnityVectorExtensionTests
     {
+        public enum IntersectionResult
         {
-            var l1_p1 = new Vector2(0, 1);
-            var l1_p2 = new Vector2(0, -1);
-            var l2_p1 = new Vector2(-1, 0);
-            var l2_p2 = new Vector2(1, 0);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
+            Zero,
+            Infinity,
+            l1_p1,
+            l1_p2,
+            l2_p1,
+            l2_p2
         }
+        
+        private static object[] IntersectionTestCases =
         {
-            var l1_p1 = new Vector2(0, 1);
-            var l1_p2 = new Vector2(0, 0);
-            var l2_p1 = new Vector2(-1, 0);
-            var l2_p2 = new Vector2(1, 0);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
-        }
+            // l1_p1, l1_p2, l2_p1, l2_p2, expectedIntersectionType, expectedIntersectionResult
+            new object[] {new Vector2(0, 1), new Vector2(0, -1), new Vector2(-1, 0), new Vector2(1, 0), 2, IntersectionResult.Zero},
+            new object[] {new Vector2(0, 1), new Vector2(0, 0), new Vector2(-1, 0), new Vector2(1, 0), 2, IntersectionResult.Zero},
+            new object[] {new Vector2(0, 2), new Vector2(0, 1), new Vector2(-1, 0), new Vector2(1, 0), 1, IntersectionResult.Zero},
+            new object[] {new Vector2(0, 2), new Vector2(0, 1), new Vector2(1, 2), new Vector2(1, 1), 0, IntersectionResult.Infinity},
+            new object[] {new Vector2(1, 2), new Vector2(1, 1), new Vector2(1, -2), new Vector2(1, -1), 3, IntersectionResult.Infinity},
+            new object[] {new Vector2(1, 2), new Vector2(1, -2), new Vector2(1, 3), new Vector2(1, 1), 4, IntersectionResult.Infinity},
+            new object[] {new Vector2(1, 2), new Vector2(1, -2), new Vector2(1, 2), new Vector2(1, -2), 4, IntersectionResult.Infinity},
+            new object[] {new Vector2(1, 2), new Vector2(1, -2), new Vector2(1, -2), new Vector2(1, 2), 4, IntersectionResult.Infinity},
+            new object[] {new Vector2(0, 1), new Vector2(0, 1), new Vector2(1, 0), new Vector2(1, 0), 4, IntersectionResult.Infinity},
+            new object[] {new Vector2(0, 0), new Vector2(2, 0), new Vector2(0, 1), new Vector2(1, 0), 2, IntersectionResult.l2_p2},
+            new object[] {new Vector2(0, 0), new Vector2(2, 0), new Vector2(1, 0), new Vector2(0, 1), 2, IntersectionResult.l2_p1},
+            // Parallel segments touching at one point
+            new object[] {new Vector2(0, 3), new Vector2(0, 5), new Vector2(0, 5), new Vector2(0, 9), 4, IntersectionResult.l2_p1},
+            new object[] {new Vector2(0, 5), new Vector2(0, 3), new Vector2(0, 5), new Vector2(0, 9), 4, IntersectionResult.l2_p1},
+            new object[] {new Vector2(0, 3), new Vector2(0, 5), new Vector2(0, 9), new Vector2(0, 5), 4, IntersectionResult.l2_p2},
+            new object[] {new Vector2(0, 5), new Vector2(0, 3), new Vector2(0, 9), new Vector2(0, 5), 4, IntersectionResult.l2_p2}
+        };
+        
+        [Test, TestCaseSource(nameof(IntersectionTestCases))]
+        public void FindIntersectionTest(Vector2 l1_p1, Vector2 l1_p2, Vector2 l2_p1, Vector2 l2_p2, 
+            int expectedIntersectionType, IntersectionResult expectedIntersectionResult)
         {
-            var l1_p1 = new Vector2(0, 2);
-            var l1_p2 = new Vector2(0, 1);
-            var l2_p1 = new Vector2(-1, 0);
-            var l2_p2 = new Vector2(1, 0);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2,
                 out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 1);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
-        }
-        {
-            var l1_p1 = new Vector2(0, 2);
-            var l1_p2 = new Vector2(0, 1);
-            var l2_p1 = new Vector2(1, 2);
-            var l2_p2 = new Vector2(1, 1);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 0);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(1, 2);
-            var l1_p2 = new Vector2(1, 1);
-            var l2_p1 = new Vector2(1, -2);
-            var l2_p2 = new Vector2(1, -1);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 3);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(1, 2);
-            var l1_p2 = new Vector2(1, -2);
-            var l2_p1 = new Vector2(1, 3);
-            var l2_p2 = new Vector2(1, 1);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(1, 2);
-            var l1_p2 = new Vector2(1, -2);
-            var l2_p1 = new Vector2(1, 2);
-            var l2_p2 = new Vector2(1, -2);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(1, 2);
-            var l1_p2 = new Vector2(1, -2);
-            var l2_p1 = new Vector2(1, -2);
-            var l2_p2 = new Vector2(1, 2);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(0, 1);
-            var l1_p2 = new Vector2(0, 1);
-            var l2_p1 = new Vector2(1, 0);
-            var l2_p2 = new Vector2(1, 0);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
-        }
-        {
-            var l1_p1 = new Vector2(0, 0);
-            var l1_p2 = new Vector2(2, 0);
-            var l2_p1 = new Vector2(0, 1);
-            var l2_p2 = new Vector2(1, 0);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
-        }
-        {
-            var l1_p1 = new Vector2(0, 0);
-            var l1_p2 = new Vector2(2, 0);
-            var l2_p1 = new Vector2(1, 0);
-            var l2_p2 = new Vector2(0, 1);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
+            Assert.That(intersectionType, Is.EqualTo(expectedIntersectionType));
+            switch (expectedIntersectionResult)
+            {
+                case IntersectionResult.Zero:
+                    Assert.That(intersection, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+                    break;
+                case IntersectionResult.Infinity:
+                    Assert.That(float.IsInfinity(intersection.x), Is.True);
+                    Assert.That(float.IsInfinity(intersection.y), Is.True);
+                    break;
+                case IntersectionResult.l1_p1:
+                    Assert.That(intersection, Is.EqualTo(l1_p1).Using(Vector2EqualityComparer.Instance));
+                    break;
+                case IntersectionResult.l1_p2:
+                    Assert.That(intersection, Is.EqualTo(l1_p2).Using(Vector2EqualityComparer.Instance));
+                    break;
+                case IntersectionResult.l2_p1:
+                    Assert.That(intersection, Is.EqualTo(l2_p1).Using(Vector2EqualityComparer.Instance));
+                    break;
+                case IntersectionResult.l2_p2:
+                    Assert.That(intersection, Is.EqualTo(l2_p2).Using(Vector2EqualityComparer.Instance));
+                    break;
+            }
         }
 
-        // Parallel segments touching at one point
+        private static object[] AngleTestCases =
         {
-            var l1_p1 = new Vector2(0, 3);
-            var l1_p2 = new Vector2(0, 5);
-            var l2_p1 = new Vector2(0, 5);
-            var l2_p2 = new Vector2(0, 9);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
-        }
-        {
-            var l1_p1 = new Vector2(0, 5);
-            var l1_p2 = new Vector2(0, 3);
-            var l2_p1 = new Vector2(0, 5);
-            var l2_p2 = new Vector2(0, 9);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
-        }
-        {
-            var l1_p1 = new Vector2(0, 3);
-            var l1_p2 = new Vector2(0, 5);
-            var l2_p1 = new Vector2(0, 9);
-            var l2_p2 = new Vector2(0, 5);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
-        }
-        {
-            var l1_p1 = new Vector2(0, 5);
-            var l1_p2 = new Vector2(0, 3);
-            var l2_p1 = new Vector2(0, 9);
-            var l2_p2 = new Vector2(0, 5);
-            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
-                out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 4);
-            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
-        }
-    }
+            new object[] {Vector2.left, 90f, true},
+            new object[] {Vector2.right, 90f, true},
+            new object[] {new Vector2(-0.0001f, 1f), 0.00572958f, false},
+            new object[] {new Vector2(0.0001f, 1f), 0.00572958f, false}
+        };
 
-    static bool AreApproximatelyEqual(Vector2 v1, Vector2 v2)
-    {
-        return Mathf.Abs(v2.x - v1.x) < 1e-5f && Mathf.Abs(v2.y - v1.y) < 1e-5f;
-    }
+        [Test, TestCaseSource(nameof(AngleTestCases))]
+        public void TestAngle(Vector2 v2, float expectedAngle, bool compareWithBuiltIn)
+        {
+            Vector3 v1 = Vector3.up;
+            float angle = UnityVectorExtensions.Angle(v1, v2);
+            Assert.That(angle, Is.EqualTo(expectedAngle).Within(UnityVectorExtensions.Epsilon));
+            if (compareWithBuiltIn)
+            {
+                float angle2 = Vector2.Angle(v1, v2);
+                Assert.That(angle2, Is.EqualTo(angle).Within(UnityVectorExtensions.Epsilon));
+            }
+        }
 
-    [Test]
-    public void TestAngle()
-    {
+        private static object[] SignedAngleTestCases =
+        {
+            new object[] {Vector2.left, 90f, true},
+            new object[] {Vector2.right, -90f, true},
+            new object[] {new Vector2(-0.0001f, 1f), 0.00572958f, false},
+            new object[] {new Vector2(0.0001f, 1f), -0.00572958f, false}
+        };
+
+        [Test, TestCaseSource(nameof(SignedAngleTestCases))]
+        public void TestSignedAngle(Vector2 v2, float expectedAngle, bool compareWithBuiltIn)
         {
             Vector3 v1 = Vector3.up;
-            Vector2 v2 = Vector3.left;
-            float angle = UnityVectorExtensions.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, 90f);
-            float angle2 = Vector2.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, angle2);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = Vector3.right;
-            float angle = UnityVectorExtensions.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, 90f);
-            float angle2 = Vector2.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, angle2);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = new Vector3(-0.0001f, 1, 0);
-            float angle = UnityVectorExtensions.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, 0.00572958f);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = new Vector3(0.0001f, 1, 0);
-            float angle = UnityVectorExtensions.Angle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, 0.00572958f);
-        }
-    }
-    
-    [Test]
-    public void TestSignedAngle()
-    {
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = Vector3.left;
             float angle = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.forward);
-            Assert.AreApproximatelyEqual(angle, 90f);
-            float angle2 = Vector2.SignedAngle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, angle2);
+            Assert.That(angle, Is.EqualTo(expectedAngle).Within(UnityVectorExtensions.Epsilon));
+            
+            if (compareWithBuiltIn)
+            {
+                float angle2 = Vector2.SignedAngle(v1, v2);
+                Assert.That(angle2, Is.EqualTo(angle).Within(UnityVectorExtensions.Epsilon));
+            }
+
             float angle3 = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.back);
-            Assert.AreApproximatelyEqual(angle, -angle3);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = Vector3.right;
-            float angle = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.forward);
-            Assert.AreApproximatelyEqual(angle, -90f);
-            float angle2 = Vector2.SignedAngle(v1, v2);
-            Assert.AreApproximatelyEqual(angle, angle2);
-            float angle3 = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.back);
-            Assert.AreApproximatelyEqual(angle, -angle3);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = new Vector3(-0.0001f, 1, 0);
-            float angle = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.forward);
-            Assert.AreApproximatelyEqual(angle, 0.00572958f);
-            float angle3 = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.back);
-            Assert.AreApproximatelyEqual(angle, -angle3);
-        }
-        {
-            Vector3 v1 = Vector3.up;
-            Vector2 v2 = new Vector3(0.0001f, 1, 0);
-            float angle = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.forward);
-            Assert.AreApproximatelyEqual(angle, -0.00572958f);
-            float angle3 = UnityVectorExtensions.SignedAngle(v1, v2, Vector3.back);
-            Assert.AreApproximatelyEqual(angle, -angle3);
+            Assert.That(angle3, Is.EqualTo(-angle).Within(UnityVectorExtensions.Epsilon));
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

* use Assert.That instead of boolean expressions
* use parameterized tests where possible to avoid copypasta
* enclose in Tests.Editor namespace

### Testing status

- [X] Added an automated test
- [X] Passed all automated tests

### Notes to reviewers

"Why the f did you do make all of these changes"

Assert.That gives better messages when tests fail. I was also able to remove some vector comparison code that already exists in the test framework.

Parameterized tests make each test case show up individually in NUnit (and fail independently) and better shows the number of tests. At some point we'll be "graded" on how many tests we have so this is a cheap way to boost our score. It also removed a lot of code duplication.

Namespaces because good practices. Enable the "ignore whitespace" option in Github's diff to hide the noise.
