### PR TITLE
CMCL-366 async scene load/unload causes jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate.
 - Collider2D inspector: added warning when collider is of the wrong type.
 - Added ability to directly set the active blend in CinemachineBrain.
+- Bugfix: async scene load/unload could cause jitter.
 
 
 ## [2.8.0-pre.1] - 2021-04-21

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -203,6 +203,8 @@ namespace Cinemachine
         private static ICinemachineCamera mSoloCamera;
         private Coroutine mPhysicsCoroutine;
 
+        private int m_LastFrameUpdated;
+
         private void OnEnable()
         {
             // Make sure there is a first stack frame
@@ -232,11 +234,20 @@ namespace Cinemachine
             StopCoroutine(mPhysicsCoroutine);
         }
 
-        void OnSceneLoaded(Scene scene, LoadSceneMode mode) { if (mFrameStack.Count > 0) ManualUpdate(); }
-        void OnSceneUnloaded(Scene scene) { if (mFrameStack.Count > 0) ManualUpdate(); }
-
+        void OnSceneLoaded(Scene scene, LoadSceneMode mode) 
+        { 
+            if (Time.frameCount == m_LastFrameUpdated && mFrameStack.Count > 0)
+                ManualUpdate();
+        }
+        void OnSceneUnloaded(Scene scene)
+        {
+            if (Time.frameCount == m_LastFrameUpdated && mFrameStack.Count > 0)
+                ManualUpdate();
+        }
+        
         private void Start()
         {
+            m_LastFrameUpdated = -1;
             UpdateVirtualCameras(CinemachineCore.UpdateFilter.Late, -1f);
         }
 
@@ -333,6 +344,8 @@ namespace Cinemachine
         /// </summary>
         public void ManualUpdate()
         {
+            m_LastFrameUpdated = Time.frameCount;
+
             float deltaTime = GetEffectiveDeltaTime(false);
             if (!Application.isPlaying || m_BlendUpdateMethod != BrainUpdateMethod.FixedUpdate)
                 UpdateFrame0(deltaTime);


### PR DESCRIPTION
### Purpose of this PR

fix CMCL-366

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

