### PR TITLE
CMCL-372: OnTargetObjectWarped did not work properly for 3rdPersonFolow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Virtual Cameras were not updating in Edit mode when Brain's BlendUpdateMode was FixedUpdate.
 - Collider2D inspector: added warning when collider is of the wrong type.
 - Added ability to directly set the active blend in CinemachineBrain.
+- Bugfix: OnTargetObjectWarped() did not work properly for 3rdPersonFollow.
 
 
 ## [2.8.0-pre.1] - 2021-04-21

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -168,6 +168,20 @@ namespace Cinemachine
             }
         }
 
+        /// <summary>This is called to notify the us that a target got warped,
+        /// so that we can update its internal state to make the camera
+        /// also warp seamlessy.</summary>
+        /// <param name="target">The object that was warped</param>
+        /// <param name="positionDelta">The amount the target's position changed</param>
+        public override void OnTargetObjectWarped(Transform target, Vector3 positionDelta)
+        {
+            base.OnTargetObjectWarped(target, positionDelta);
+            if (target == FollowTarget)
+            {
+                m_PreviousFollowTargetPosition += positionDelta;
+            }
+        }
+        
         void PositionCamera(ref CameraState curState, float deltaTime)
         {
             var up = curState.ReferenceUp;


### PR DESCRIPTION
### Purpose of this PR

CMCL-372: OnTargetObjectWarped did not work properly for 3rdPersonFolow

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Use this script to test:
[code]using System.Collections;
using System.Collections.Generic;
using UnityEngine;
using Cinemachine;

public class CameraTPTest : MonoBehaviour
{
    public CinemachineVirtualCamera VCam;
    public float Speed = 10f;
 
    private void LateUpdate()
    {
        transform.position = transform.position + (Vector3.forward * Speed * Time.deltaTime);
        if (transform.position.magnitude > 20f)
        {
            Vector3 delta = -transform.position;
            transform.position = Vector3.zero;
            VCam.OnTargetObjectWarped(transform, delta);
        }
    }
}[/code]

