### PR TITLE
add versionDefines to runtime test assembly and guard tests 

### DIFF
--- a/Tests/Runtime/Cinemachine.RuntimeTests.asmdef
+++ b/Tests/Runtime/Cinemachine.RuntimeTests.asmdef
@@ -12,5 +12,22 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS_2D"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
+        }
+    ]
 }

--- a/Tests/Runtime/ClearShotTests.cs
+++ b/Tests/Runtime/ClearShotTests.cs
@@ -7,6 +7,7 @@ using UnityEngine.TestTools;
 
 namespace Tests.Runtime
 {
+#if CINEMACHINE_PHYSICS
     [TestFixture]
     public class ClearShotTests : CinemachineFixtureBase
     {
@@ -77,4 +78,5 @@ namespace Tests.Runtime
             Assert.That(m_ClearShot.LiveChild.Name, Is.EqualTo(expectedVcamName));
         }
     }
+#endif
 }

--- a/Tests/Runtime/Confiner2DUnitTests.cs
+++ b/Tests/Runtime/Confiner2DUnitTests.cs
@@ -9,6 +9,7 @@ using UnityEngine.TestTools.Utils;
 
 namespace Tests.Runtime
 {
+#if CINEMACHINE_PHYSICS_2D
     public class Confiner2DUnitTests : CinemachineFixtureBase
     {
         private Camera m_Cam;
@@ -126,4 +127,5 @@ namespace Tests.Runtime
             Assert.That((m_Vcam.State.CorrectedPosition - Vector3.down).sqrMagnitude, Is.LessThan(UnityVectorExtensions.Epsilon));
         }
     }
+#endif
 }

--- a/Tests/Runtime/StateDrivenCameraTests.cs
+++ b/Tests/Runtime/StateDrivenCameraTests.cs
@@ -10,6 +10,7 @@ using Cinemachine;
 
 namespace Tests.Runtime
 {
+#if CINEMACHINE_UNITY_ANIMATION
     [TestFixture]
     public class StateDrivenCameraTests : CinemachineFixtureBase
     {
@@ -71,4 +72,5 @@ namespace Tests.Runtime
             Assert.That(m_StateDrivenCamera.LiveChild.Name, Is.EqualTo(m_Vcam1.Name));
         }
     }
+#endif
 }


### PR DESCRIPTION
### Purpose of this PR

Guards tests that require functionality in modules so tests pass in isolation mode (no other packages loaded).

### Testing status

- [ ] Passed all automated tests

