### PR TITLE
bugfix CMCL-375 redux: POV custom up works even if vcam parent

### DIFF
--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -134,8 +134,7 @@ namespace Cinemachine
             Transform parent = VirtualCamera.transform.parent;
             if (parent != null)
                 rot = parent.rotation * rot;
-            else
-                rot = Quaternion.FromToRotation(Vector3.up, curState.ReferenceUp) * rot;
+            rot = Quaternion.FromToRotation(Vector3.up, curState.ReferenceUp) * rot;
             curState.RawOrientation = rot;
         }
 

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -526,7 +526,7 @@ namespace Cinemachine
 
         /// <summary>Call this to notify all virtual camewras that may be tracking a target
         /// that the target's position has suddenly warped to somewhere else, so that
-        /// so that the virtual cameras can update their internal state to make the camera
+        /// the virtual cameras can update their internal state to make the camera
         /// warp seamlessy along with the target.
         /// 
         /// All virtual cameras are iterated so this call will work no matter how many 


### PR DESCRIPTION
### Purpose of this PR

CMCL-375: custom reference up needs to apply even if vcam has a parent.  Previous fix was imcomplete.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

I don't think it's necessary to update the changelog again, there is already an entry for this issue.

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Uploaded new test project to the Jira ticket to show the issue
