### PR TITLE
added extra wait time to account for floating point inaccuracy

### DIFF
--- a/Tests/Runtime/CamerasBlendingTests.cs
+++ b/Tests/Runtime/CamerasBlendingTests.cs
@@ -64,7 +64,7 @@ public class CamerasBlendingTests
         targetVCam.Priority = 3;
         yield return null;
 
-        yield return new WaitForSeconds(BlendingTime + 0.1f);
+        yield return new WaitForSeconds(BlendingTime + 0.2f);
         Assert.IsTrue(!brain.IsBlending);
     }
     
@@ -88,7 +88,7 @@ public class CamerasBlendingTests
         yield return null;
         
         // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime * 0.21f);
+        yield return new WaitForSeconds(BlendingTime * 0.3f);
 
         Assert.IsTrue(!brain.IsBlending);
 
@@ -146,7 +146,7 @@ public class CamerasBlendingTests
         yield return null;
         
         // We went 90%, then got 10% back, it means we are 20% away from the target
-        yield return new WaitForSeconds(BlendingTime + 0.01f);
+        yield return new WaitForSeconds(BlendingTime + 0.2f);
 
         Assert.IsTrue(!brain.IsBlending);
     }


### PR DESCRIPTION
Still failing on 2021.1 in package isolation tests. My theory is that when all of the package isolation tests run, time suffers from inaccuracies due to floating point.