### PR TITLE
[CMCL-399] fixes bad merge in Runtime/CinemachineVolumeSettingsEditor.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.6.10] - 2021-08-19
+- Bugfix: Compilation error when using HDRP or LWRP
+
 ## [2.6.9] - 2021-08-02
 - Bugfix: Freelook prefabs won't get corrupted after editing the Prefab via its instances.
 - Bugfix: 3rdPersonFollow works with Aim components now. 

--- a/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -4,7 +4,7 @@
     using UnityEngine.Rendering;
     using UnityEditor.Rendering;
     using System.Collections.Generic;
-    #if CINEMACHINE_HDRP_7_3_1
+    #if CINEMACHINE_HDRP_7_0_0
         using UnityEngine.Rendering.HighDefinition;
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
@@ -84,8 +84,8 @@ namespace Cinemachine.PostFX.Editor
                 bool valid = false;
                 DepthOfField dof;
                 if (Target.m_Profile != null && Target.m_Profile.TryGet(out dof))
-                {
 #if CINEMACHINE_LWRP_7_0_0 && !CINEMACHINE_HDRP
+                {
                     valid = dof.active && dof.focusDistance.overrideState
                         && dof.mode.overrideState && dof.mode == DepthOfFieldMode.Bokeh;
                 }

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -23,7 +23,7 @@ namespace Cinemachine
         public static readonly int kStreamingVersion = 20170927;
 
         /// <summary>Human-readable Cinemachine Version</summary>
-        public static readonly string kVersionString = "2.6.9";
+        public static readonly string kVersionString = "2.6.10";
 
         /// <summary>
         /// Stages in the Cinemachine Component pipeline, used for

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -3,22 +3,22 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "2.6.9"
+            "PackageVersion": "2.6.10"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.6.9"
+            "PackageVersion": "2.6.10"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.6.9"
+            "PackageVersion": "2.6.10"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.6.9"
+            "PackageVersion": "2.6.10"
         }
     ],
     "WarningExceptions": []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.6.9",
+    "version": "2.6.10",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nIMPORTANT NOTE: If you are upgrading from the Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR

CMCL-399

Somehow an opening brace moved up one line, above an #ifdef, resulting in a compile error when using LWRP/HDRP. We don't have any tests that explicitly test SRPs and those lines aren't compiled when no SRP is installed.

Also, an #ifdef for HDRP was referencing the wrong version, resulting in an additional error.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested against HDRP and URP

TBD: have automated tests run against SRPs


### Package version

- [x] Updated package version
