### PR TITLE
Fix CMCL-406 bad blends if looking along world up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: POV did not properly handle overridden up.
 - Regression fix: removed GC allocs in UpdateTargetCache.
 - Bugfix: async scene load/unload could cause jitter.
+- Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -372,7 +372,6 @@ namespace Cinemachine
                         dirTarget = state.ReferenceLookAt - state.CorrectedPosition;
                 }
                 
-                
                 if (dirTarget.AlmostZero() 
                     || ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.IgnoreLookAtTarget) != 0)
                 {
@@ -382,20 +381,19 @@ namespace Cinemachine
                 }
                 else
                 {
+                    var blendUp = Vector3.Slerp(
+                        stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
+
                     // Rotate while preserving our lookAt target
-                    dirTarget = dirTarget.normalized;
-                    if ((dirTarget - state.ReferenceUp).AlmostZero()
-                        || (dirTarget + state.ReferenceUp).AlmostZero())
+                    if (Vector3.Cross(dirTarget, blendUp).AlmostZero())
                     {
                         // Looking up or down at the pole
                         newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                                stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
+                                stateA.RawOrientation, stateB.RawOrientation, t, blendUp);
                     }
                     else
                     {
                         // Put the target in the center
-                        var blendUp = Vector3.Slerp(
-                            stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
                         newOrient = Quaternion.LookRotation(dirTarget, blendUp);
 
                         // Blend the desired offsets from center

--- a/Runtime/Core/UnityVectorExtensions.cs
+++ b/Runtime/Core/UnityVectorExtensions.cs
@@ -294,23 +294,24 @@ namespace Cinemachine.Utility
         /// the up param</summary>
         /// <param name="qA">First direction</param>
         /// <param name="qB">Second direction</param>
-        /// <param name="t">Interpolation amoun t</param>
+        /// <param name="t">Interpolation amount</param>
         /// <param name="up">Defines the up direction.  Must have a length of 1.</param>
         /// <returns>Interpolated quaternion</returns>
         public static Quaternion SlerpWithReferenceUp(
             Quaternion qA, Quaternion qB, float t, Vector3 up)
         {
-            Vector3 dirA = (qA * Vector3.forward).ProjectOntoPlane(up);
-            Vector3 dirB = (qB * Vector3.forward).ProjectOntoPlane(up);
+            var dirA = (qA * Vector3.forward).ProjectOntoPlane(up);
+            var dirB = (qB * Vector3.forward).ProjectOntoPlane(up);
             if (dirA.AlmostZero() || dirB.AlmostZero())
                 return Quaternion.Slerp(qA, qB, t);
 
             // Work on the plane, in eulers
-            Quaternion qBase = Quaternion.LookRotation(dirA, up);
-            Quaternion qA1 = Quaternion.Inverse(qBase) * qA;
-            Quaternion qB1 = Quaternion.Inverse(qBase) * qB;
-            Vector3 eA = qA1.eulerAngles;
-            Vector3 eB = qB1.eulerAngles;
+            var qBase = Quaternion.LookRotation(dirA, up);
+            var qBaseInv = Quaternion.Inverse(qBase);
+            Quaternion qA1 = qBaseInv * qA;
+            Quaternion qB1 = qBaseInv * qB;
+            var eA = qA1.eulerAngles;
+            var eB = qB1.eulerAngles;
             return qBase * Quaternion.Euler(
                 Mathf.LerpAngle(eA.x, eB.x, t),
                 Mathf.LerpAngle(eA.y, eB.y, t),


### PR DESCRIPTION
### Purpose of this PR

Fix CMCL-406 - bad blends if looking along world up

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

