### PR TITLE
CMCL-402 Input system should be read only once per render frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: POV did not properly handle overridden up.
 - Regression fix: removed GC allocs in UpdateTargetCache.
 - Bugfix: async scene load/unload could cause jitter.
+- Bugfix: Input system should be read only once per render frame.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -211,9 +211,21 @@ namespace Cinemachine
             m_LastUpdateFrame = Time.frameCount;
 
             // Cheating: we want the render frame time, not the fixed frame time
-            if (deltaTime >= 0 && m_LastUpdateTime != 0 && CinemachineCore.UniformDeltaTimeOverride < 0)
-                deltaTime = Time.time - m_LastUpdateTime;
-            m_LastUpdateTime = Time.time;
+            if (CinemachineCore.UniformDeltaTimeOverride < 0)
+            {
+                if (deltaTime >= 0 && m_LastUpdateTime != 0)
+                    deltaTime = Time.time - m_LastUpdateTime;
+                m_LastUpdateTime = Time.time;
+            }
+            else
+            {
+                // CinemachineCore.UpdateVirtualCamera can change deltaTime to catch up,
+                // but that should not happen when CinemachineCore.UniformDeltaTimeOverride is set.
+                deltaTime = CinemachineCore.UniformDeltaTimeOverride; 
+                // TODO: deltaTime should not be adjusted in CinemachineCore.UpdateVirtualCamera when
+                // TODO: CinemachineCore.UniformDeltaTimeOverride is set?
+            }
+            
 
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -226,7 +226,6 @@ namespace Cinemachine
                 // TODO: CinemachineCore.UniformDeltaTimeOverride is set?
             }
             
-
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);
             else if (!string.IsNullOrEmpty(m_InputAxisName))

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -211,7 +211,7 @@ namespace Cinemachine
             m_LastUpdateFrame = Time.frameCount;
 
             // Cheating: we want the render frame time, not the fixed frame time
-            if (deltaTime >= 0 && m_LastUpdateTime != 0)
+            if (deltaTime >= 0 && m_LastUpdateTime != 0 && CinemachineCore.UniformDeltaTimeOverride < 0)
                 deltaTime = Time.time - m_LastUpdateTime;
             m_LastUpdateTime = Time.time;
 

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -211,20 +211,11 @@ namespace Cinemachine
             m_LastUpdateFrame = Time.frameCount;
 
             // Cheating: we want the render frame time, not the fixed frame time
-            if (CinemachineCore.UniformDeltaTimeOverride < 0)
-            {
-                if (deltaTime >= 0 && m_LastUpdateTime != 0)
-                    deltaTime = Time.time - m_LastUpdateTime;
-                m_LastUpdateTime = Time.time;
-            }
-            else
-            {
-                // CinemachineCore.UpdateVirtualCamera can change deltaTime to catch up,
-                // but that should not happen when CinemachineCore.UniformDeltaTimeOverride is set.
+            if (CinemachineCore.UniformDeltaTimeOverride >= 0)
                 deltaTime = CinemachineCore.UniformDeltaTimeOverride; 
-                // TODO: deltaTime should not be adjusted in CinemachineCore.UpdateVirtualCamera when
-                // TODO: CinemachineCore.UniformDeltaTimeOverride is set?
-            }
+            else if (deltaTime >= 0 && m_LastUpdateTime != 0)
+                deltaTime = Time.time - m_LastUpdateTime;
+            m_LastUpdateTime = Time.time;
             
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);


### PR DESCRIPTION
### Purpose of this PR

CMCL-402 Input system should be read only once per render frame
### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low 

