### PR TITLE
Fix CMCL-433 - Group Framing accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: removed GC allocs in UpdateTargetCache.
 - Bugfix: async scene load/unload could cause jitter.
 - Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
+- Bugfix: Improve accuracy of Group Framing.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Editor/Editors/CinemachineTargetGroupEditor.cs
+++ b/Editor/Editors/CinemachineTargetGroupEditor.cs
@@ -114,5 +114,15 @@ namespace Cinemachine.Editor
                     elemProp.FindPropertyRelative(() => def.weight).floatValue = 1;
                 };
         }
+
+#if false // enable for debugging
+        [DrawGizmo(GizmoType.Active | GizmoType.InSelectionHierarchy, typeof(CinemachineTargetGroup))]
+        private static void DrawGroupComposerGizmos(CinemachineTargetGroup target, GizmoType selectionType)
+        {
+                Gizmos.color = Color.yellow;
+                var sphere = target.Sphere;
+                Gizmos.DrawWireSphere(sphere.position, sphere.radius);
+        }
+#endif
     }
 }

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -660,19 +660,21 @@ namespace Cinemachine
         static Bounds GetScreenSpaceGroupBoundingBox(
             ICinemachineTargetGroup group, ref Vector3 pos, Quaternion orientation)
         {
-            Matrix4x4 observer = Matrix4x4.TRS(pos, orientation, Vector3.one);
-            Vector2 minAngles, maxAngles, zRange;
-            group.GetViewSpaceAngularBounds(observer, out minAngles, out maxAngles, out zRange);
+            var observer = Matrix4x4.TRS(pos, orientation, Vector3.one);
+            group.GetViewSpaceAngularBounds(observer, out var minAngles, out var maxAngles, out var zRange);
+            var shift = (minAngles + maxAngles) / 2;
 
-            Quaternion q = Quaternion.identity.ApplyCameraRotation((minAngles + maxAngles) / 2, Vector3.up);
-            Vector3 localPosAdustment = q * new Vector3(0, 0, (zRange.y + zRange.x)/2);
-            localPosAdustment.z = 0;
-            pos = observer.MultiplyPoint3x4(localPosAdustment);
+            var q = Quaternion.identity.ApplyCameraRotation(new Vector2(-shift.x, shift.y), Vector3.up);
+            pos = q * new Vector3(0, 0, (zRange.y + zRange.x)/2);
+            pos.z = 0;
+            pos = observer.MultiplyPoint3x4(pos);
             observer = Matrix4x4.TRS(pos, orientation, Vector3.one);
             group.GetViewSpaceAngularBounds(observer, out minAngles, out maxAngles, out zRange);
 
-            float zSize = zRange.y - zRange.x;
-            float z = zRange.x + (zSize / 2);
+            // For width and height (in camera space) of the bounding box, we use the values at the center of the box.
+            // This is an arbitrary choice.  The gizmo drawer will take this into account when displaying
+            // the frustum bounds of the group
+            var d = zRange.y + zRange.x;
             Vector2 angles = new Vector2(89.5f, 89.5f);
             if (zRange.x > 0)
             {
@@ -680,8 +682,9 @@ namespace Cinemachine
                 angles = Vector2.Min(angles, new Vector2(89.5f, 89.5f));
             }
             angles *= Mathf.Deg2Rad;
-            return new Bounds(new Vector3(0, 0, z),
-                new Vector3(Mathf.Tan(angles.y) * z * 2, Mathf.Tan(angles.x) * z * 2, zSize));
+            return new Bounds(
+                new Vector3(0, 0, d/2),
+                new Vector3(Mathf.Tan(angles.y) * d, Mathf.Tan(angles.x) * d, zRange.y - zRange.x));
         }
     }
 }

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -539,6 +539,17 @@ namespace Cinemachine
             }
         }
 
+#if UNITY_EDITOR
+        [UnityEditor.Callbacks.DidReloadScripts]
+        static void OnScriptReload()
+        {
+            var vcams = Resources.FindObjectsOfTypeAll(
+                typeof(CinemachineVirtualCameraBase)) as CinemachineVirtualCameraBase[];
+            foreach (var vcam in vcams)
+                vcam.LookAtTargetChanged = vcam.FollowTargetChanged = true;
+        }
+#endif
+
         /// <summary>
         /// Locate the first component that implements AxisState.IInputAxisProvider.
         /// </summary>
@@ -778,8 +789,8 @@ namespace Cinemachine
         protected void UpdateTargetCache()
         {
             var target = ResolveFollow(Follow);
-            FollowTargetChanged = target != m_CachedFollowTarget;
-            if (target != m_CachedFollowTarget)
+            FollowTargetChanged |= target != m_CachedFollowTarget;
+            if (FollowTargetChanged)
             {
                 m_CachedFollowTarget = target;
                 m_CachedFollowTargetVcam = null;
@@ -791,8 +802,8 @@ namespace Cinemachine
                 }
             }
             target = ResolveLookAt(LookAt);
-            LookAtTargetChanged = target != m_CachedLookAtTarget;
-            if (target != m_CachedLookAtTarget)
+            LookAtTargetChanged |= target != m_CachedLookAtTarget;
+            if (LookAtTargetChanged)
             {
                 m_CachedLookAtTarget = target;
                 m_CachedLookAtTargetVcam = null;


### PR DESCRIPTION
### Purpose of this PR

Fix CMCL-433 - Group Framing was inaccurate.  Visible in Framing transposer when target is a Group, and in GroupComposer.  Most visible when camera is angled.  Jira issue has sample scene and repro instructions.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

