### PR TITLE
CMCL-489: Use off-the-shelf Github action to enforce PR titles start with CMCL-\d+

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -21,6 +21,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Enforce Jira Issue Key in Pull Request Title
-        uses: mjmvisser/enforce-pr-title-style-action@v1
+        uses: mjmvisser/enforce-pr-title-style-action@v2
         with:
           projectKey: CMCL

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,7 +6,7 @@ name: Validate PR Title
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
-    branches: [ master ]
+    types: [ opened, edited, reopened, synchronize ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -21,6 +21,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Enforce Jira Issue Key in Pull Request Title
-        uses: ryanvade/enforce-pr-title-style-action@v1
+        uses: mjmvisser/enforce-pr-title-style-action@v1
         with:
           projectKey: CMCL

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,26 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Validate PR Title
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "validate"
+  validate:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Enforce Jira Issue Key in Pull Request Title
+        uses: ryanvade/enforce-pr-title-style-action@v1
+        with:
+          projectKey: CMCL


### PR DESCRIPTION
Hey devs, part of doing backports is finding the connected JIRA issue so I can add the backport to the Fix Version/s field (or find the appropriate backport and add it there). We've gotten pretty good at putting the JIRA issue in the PR (thank you!) but I'd like to go one step further and put it in the PR title.

Right now, I have to:
find the PR # in merge commit
open the PR
find the JIRA in the description and click it

If we put the JIRA issue right in the title, it will be in the commit message for the merge and I'll be able to just click it directly.

I figured out how to add a Github Action that checks the PR title and fails if it doesn't match a regex (actual regex: `(^CMCL-){1}(\\d)+(:)?(\\s)+(.)+ `). Basically you need your PR title to look like this:  

`CMCL-1000: Effectively prevent side fumbling by fitting an ambifacient lunar waneshaft`

(The colon is optional)