### PR TITLE
CMCL-535: Expose displacement vector for confiner and confiner2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Input system should be read only once per render frame.
 - Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
 - Bugfix: Improve accuracy of Group Framing.
+- Added ability to get the displacement vector with which the confiner displaces the vcam.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -62,6 +62,11 @@ namespace Cinemachine
         [Range(0, 10)]
         public float m_Damping = 0;
         
+        /// <summary>
+        /// The amount with which the confiner displaces the vcam.
+        /// </summary>
+        public Vector3 m_Displacement { get; private set; }
+        
         /// <summary>See whether the virtual camera has been moved by the confiner</summary>
         /// <param name="vcam">The virtual camera in question.  This might be different from the
         /// virtual camera that owns the confiner, in the event that the camera has children</param>
@@ -139,21 +144,20 @@ namespace Cinemachine
             if (IsValid && stage == CinemachineCore.Stage.Body)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
-                Vector3 displacement;
                 if (m_ConfineScreenEdges && state.Lens.Orthographic)
-                    displacement = ConfineScreenEdges(vcam, ref state);
+                    m_Displacement = ConfineScreenEdges(vcam, ref state);
                 else
-                    displacement = ConfinePoint(state.CorrectedPosition);
+                    m_Displacement = ConfinePoint(state.CorrectedPosition);
 
                 if (m_Damping > 0 && deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
                 {
-                    Vector3 delta = displacement - extra.m_previousDisplacement;
+                    Vector3 delta = m_Displacement - extra.m_previousDisplacement;
                     delta = Damper.Damp(delta, m_Damping, deltaTime);
-                    displacement = extra.m_previousDisplacement + delta;
+                    m_Displacement = extra.m_previousDisplacement + delta;
                 }
-                extra.m_previousDisplacement = displacement;
-                state.PositionCorrection += displacement;
-                extra.confinerDisplacement = displacement.magnitude;
+                extra.m_previousDisplacement = m_Displacement;
+                state.PositionCorrection += m_Displacement;
+                extra.confinerDisplacement = m_Displacement.magnitude;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-535
Expose displacement vector for confiner and confiner2D.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
