### PR TITLE
CMCL-570: Refactored menu based creation to be consistent with the rest of Unity

### DIFF
--- a/Editor/Editors/CinemachineFreeLookEditor.cs
+++ b/Editor/Editors/CinemachineFreeLookEditor.cs
@@ -136,7 +136,7 @@ namespace Cinemachine
                     = (CinemachineFreeLook vcam, string name, CinemachineVirtualCamera copyFrom) =>
                     {
                         // Create a new rig with default components
-                        GameObject go = InspectorUtility.CreateGameObject(name);
+                        GameObject go = ObjectFactory.CreateGameObject(name);
                         Undo.RegisterCreatedObjectUndo(go, "created rig");
                         Undo.SetTransformParent(go.transform, vcam.transform, "parenting rig");
                         CinemachineVirtualCamera rig = Undo.AddComponent<CinemachineVirtualCamera>(go);

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -16,8 +16,8 @@ namespace Cinemachine.Editor
         VcamStageEditorPipeline m_PipelineSet = new VcamStageEditorPipeline();
         Vector3 m_PreviousPosition;
 
-        [MenuItem("CONTEXT/CinemachineVirtualCamera/Adopt Current Camera Settings")]
-        static void AdoptCurrentCameraSettings(MenuCommand command)
+        [MenuItem("CONTEXT/CinemachineVirtualCamera/Adopt Game View Camera Settings")]
+        static void AdoptGameViewCameraSettings(MenuCommand command)
         {
             var vcam = command.context as CinemachineVirtualCamera;
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(vcam);
@@ -33,7 +33,7 @@ namespace Cinemachine.Editor
         static void AdoptSceneViewCameraSettings(MenuCommand command)
         {
             var vcam = command.context as CinemachineVirtualCamera;
-            CinemachineMenu.CopySceneViewLook(vcam);
+            vcam.m_Lens = CinemachineMenu.MatchSceneViewCamera(vcam.transform);
         }
         
         protected override void OnEnable()

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -33,7 +33,7 @@ namespace Cinemachine.Editor
         static void AdoptSceneViewCameraSettings(MenuCommand command)
         {
             var vcam = command.context as CinemachineVirtualCamera;
-            CinemachineMenu.SetVcamFromSceneView(vcam);
+            CinemachineMenu.CopySceneViewLook(vcam);
         }
         
         protected override void OnEnable()
@@ -154,7 +154,7 @@ namespace Cinemachine.Editor
                     (CinemachineVirtualCamera vcam, string name, CinemachineComponentBase[] copyFrom) =>
                     {
                         // Create a new pipeline
-                        GameObject go =  InspectorUtility.CreateGameObject(name);
+                        GameObject go =  ObjectFactory.CreateGameObject(name);
                         Undo.RegisterCreatedObjectUndo(go, "created pipeline");
                         bool partOfPrefab = PrefabUtility.IsPartOfAnyPrefab(vcam.gameObject);
                         if (!partOfPrefab)

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -147,7 +147,7 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_GameObjectMenuPriority)]
         static void Create2DCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
+            CinemachineEditorAnalytics.SendCreateEvent("2D Camera");
             var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(
                 "Virtual Camera", command.context as GameObject, true);
             vcam.m_Lens = MatchSceneViewCamera(vcam.transform);

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -77,6 +77,7 @@ namespace Cinemachine.Editor
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
         }
 
+#if CINEMACHINE_PHYSICS
         [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_GameObjectMenuPriority)]
         static void CreateClearShotVirtualCamera(MenuCommand command)
         {
@@ -86,10 +87,9 @@ namespace Cinemachine.Editor
 
             // We give the camera a child as an example setup
             var childVcam = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
-#if CINEMACHINE_PHYSICS
             Undo.AddComponent<CinemachineCollider>(childVcam.gameObject).m_AvoidObstacles = false;
-#endif
         }
+#endif
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]
         static void CreateDollyCameraWithPath(MenuCommand command)

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -1,18 +1,16 @@
-#if !UNITY_2019_3_OR_NEWER
-#define CINEMACHINE_PHYSICS
-#define CINEMACHINE_UNITY_ANIMATION
-#endif
-
 using UnityEngine;
 using UnityEditor;
-using System;
 
 namespace Cinemachine.Editor
 {
     internal static class CinemachineMenu
     {
-        // Assets Menu
-        const string m_CinemachineAssetsRootMenu = "Assets/Create/Cinemachine/";
+        private const string m_CinemachineAssetsRootMenu = "Assets/Create/Cinemachine/";
+        private const string m_CinemachineGameObjectRootMenu = "GameObject/Cinemachine/";
+        private const int m_GameObjectMenuPriority = 11; // Right after Camera.
+
+
+        // Assets Menu.
 
         [MenuItem(m_CinemachineAssetsRootMenu + "BlenderSettings")]
         static void CreateBlenderSettingAsset()
@@ -21,337 +19,231 @@ namespace Cinemachine.Editor
         }
 
         [MenuItem(m_CinemachineAssetsRootMenu + "NoiseSettings")]
-        static void CreateNoiseSettingAsset()
+        private static void CreateNoiseSettingAsset()
         {
             ScriptableObjectUtility.Create<NoiseSettings>();
         }
 
         [MenuItem(m_CinemachineAssetsRootMenu + "Fixed Signal Definition")]
-        static void CreateFixedSignalDefinition()
+        private static void CreateFixedSignalDefinition()
         {
             ScriptableObjectUtility.Create<CinemachineFixedSignal>();
         }
-        
-        // GameObject Menu
-        const string m_CinemachineGameObjectRootMenu = "GameObject/Cinemachine/";
-        const int m_MenuPriority = 11; // right after Camera
-        
-        static void SetParentToMenuContextObject(GameObject child, MenuCommand command)
+
+        // GameObject Menu.
+
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Virtual Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateVirtualCamera(MenuCommand command)
         {
-            var go = command.context as GameObject;
-            if (go != null)
-                Undo.SetTransformParent(child.transform, go.transform, "set parent");
-            Selection.activeObject = child;
+            CreateDefaultVirtualCamera(parentObject: command.context as GameObject, select: true);
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Virtual Camera", false, m_MenuPriority)]
-        static void CreateVirtualCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Free Look Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateFreeLookCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
-            var go = InternalCreateVirtualCamera(
-                "CM vcam", false, typeof(CinemachineComposer), typeof(CinemachineTransposer)).gameObject;
-            SetParentToMenuContextObject(go, command);
+            CreateCinemachineGameObject<CinemachineFreeLook>("Free Look Camera", command.context as GameObject);
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "FreeLook Camera", false, m_MenuPriority)]
-        static void CreateFreeLookCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateBlendListCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("FreeLook Camera");
-            CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineFreeLook), "CM FreeLook"),
-                    typeof(CinemachineFreeLook));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-        }
+            var blendListCamera  = CreateCinemachineGameObject<CinemachineBlendListCamera>("Blend List Camera", command.context as GameObject);
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_MenuPriority)]
-        static void CreateBlendListCamera(MenuCommand command)
-        {
-            CinemachineEditorAnalytics.SendCreateEvent("Blend List Camera");
-            CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineBlendListCamera), "CM BlendListCamera"),
-                    typeof(CinemachineBlendListCamera));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create Blend List camera");
-            var vcam = go.GetComponent<CinemachineBlendListCamera>();
+            // We give the camera a couple of children as an example of setup.
+            CinemachineVirtualCamera childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            CinemachineVirtualCamera childVirtualCamera2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            childVirtualCamera2.m_Lens.FieldOfView = 10;
 
-            // Give it a couple of children
-            var child1 = CreateDefaultVirtualCamera();
-            Undo.SetTransformParent(child1.transform, go.transform, "create BlendListCam child");
-            var child2 = CreateDefaultVirtualCamera();
-            child2.m_Lens.FieldOfView = 10;
-            Undo.SetTransformParent(child2.transform, go.transform, "create BlendListCam child");
-
-            // Set up initial instruction set
-            vcam.m_Instructions = new CinemachineBlendListCamera.Instruction[2];
-            vcam.m_Instructions[0].m_VirtualCamera = child1;
-            vcam.m_Instructions[0].m_Hold = 1f;
-            vcam.m_Instructions[1].m_VirtualCamera = child2;
-            vcam.m_Instructions[1].m_Blend.m_Style = CinemachineBlendDefinition.Style.EaseInOut;
-            vcam.m_Instructions[1].m_Blend.m_Time = 2f;
+            // Set up initial instruction set.
+            blendListCamera.m_Instructions = new CinemachineBlendListCamera.Instruction[2];
+            blendListCamera.m_Instructions[0].m_VirtualCamera = childVirtualCamera1;
+            blendListCamera.m_Instructions[0].m_Hold = 1f;
+            blendListCamera.m_Instructions[1].m_VirtualCamera = childVirtualCamera2;
+            blendListCamera.m_Instructions[1].m_Blend.m_Style = CinemachineBlendDefinition.Style.EaseInOut;
+            blendListCamera.m_Instructions[1].m_Blend.m_Time = 2f;
         }
         
-#if CINEMACHINE_UNITY_ANIMATION
-        [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_MenuPriority)]
-        static void CreateStateDivenCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateStateDivenCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("State-Driven Camera");
-            CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineStateDrivenCamera), "CM StateDrivenCamera"),
-                    typeof(CinemachineStateDrivenCamera));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create state driven camera");
+            var stateDrivenCamera = CreateCinemachineGameObject<CinemachineStateDrivenCamera>("State-Driven Camera", command.context as GameObject);
 
-            // Give it a child
-            Undo.SetTransformParent(CreateDefaultVirtualCamera().transform, go.transform, "create state driven camera");
+            // We give the camera a child as an example setup.
+            CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
         }
-#endif
 
-#if CINEMACHINE_PHYSICS
-        [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_MenuPriority)]
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Clear Shot Camera", false, m_GameObjectMenuPriority)]
         static void CreateClearShotVirtualCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("ClearShot Camera");
-            CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineClearShot), "CM ClearShot"),
-                    typeof(CinemachineClearShot));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create ClearShot camera");
+            var clearShotCamera = CreateCinemachineGameObject<CinemachineClearShot>("Clear Shot Camera", command.context as GameObject);
 
-            // Give it a child
-            var child = CreateDefaultVirtualCamera();
-            Undo.SetTransformParent(child.transform, go.transform, "create ClearShot camera");
-            var collider = Undo.AddComponent<CinemachineCollider>(child.gameObject);
+            // We give the camera a child as an example setup.
+            CinemachineVirtualCamera childVirtualCamera = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
+            var collider = Undo.AddComponent<CinemachineCollider>(childVirtualCamera.gameObject);
             collider.m_AvoidObstacles = false;
-            Undo.RecordObject(collider, "create ClearShot camera");
-        }
-#endif
-
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_MenuPriority)]
-        static void CreateDollyCameraWithPath(MenuCommand command)
-        {
-            CinemachineEditorAnalytics.SendCreateEvent("Dolly Camera with Track");
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineSmoothPath), "DollyTrack"),
-                    typeof(CinemachineSmoothPath));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create track");
-            CinemachineSmoothPath path = go.GetComponent<CinemachineSmoothPath>();
-
-            CinemachineVirtualCamera vcam = InternalCreateVirtualCamera(
-                    "CM vcam", true, typeof(CinemachineComposer), typeof(CinemachineTrackedDolly));
-            SetParentToMenuContextObject(vcam.gameObject, command);
-            vcam.GetCinemachineComponent<CinemachineTrackedDolly>().m_Path = path;
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Track with Cart", false, m_MenuPriority)]
-        static void CreateDollyTrackWithCart(MenuCommand command)
-        {
-            CinemachineEditorAnalytics.SendCreateEvent("Dolly Track with Cart");
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineSmoothPath), "DollyTrack"),
-                    typeof(CinemachineSmoothPath));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create track");
-            CinemachineSmoothPath path = go.GetComponent<CinemachineSmoothPath>();
 
-            go = InspectorUtility.CreateGameObject(
-                GenerateUniqueObjectName(typeof(CinemachineDollyCart), "DollyCart"),
-                typeof(CinemachineDollyCart));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create cart");
-            go.GetComponent<CinemachineDollyCart>().m_Path = path;
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]
+        private static void CreateDollyCameraWithPath(MenuCommand command)
+        {
+            CinemachineSmoothPath path = CreateCinemachineGameObject<CinemachineSmoothPath>("Dolly Track", command.context as GameObject, false);
+            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", command.context as GameObject, true);
+
+            AddCinemachineComponent<CinemachineComposer>(virtualCamera);
+            var trackedDolly = AddCinemachineComponent<CinemachineTrackedDolly>(virtualCamera);
+
+            trackedDolly.m_Path = path;
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Target Group Camera", false, m_MenuPriority)]
-        static void CreateTargetGroupCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Track with Cart", false, m_GameObjectMenuPriority)]
+        private static void CreateDollyTrackWithCart(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("Target Group Camera");
-            CinemachineVirtualCamera vcam = InternalCreateVirtualCamera(
-                    "CM vcam", true, typeof(CinemachineGroupComposer), typeof(CinemachineTransposer));
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineTargetGroup), "TargetGroup"),
-                    typeof(CinemachineTargetGroup));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create target group");
-            vcam.LookAt = go.transform;
-            vcam.Follow = go.transform;
+            CinemachineSmoothPath path = CreateCinemachineGameObject<CinemachineSmoothPath>("Dolly Track", command.context as GameObject, false);
+            CinemachineDollyCart dollyCart = CreateCinemachineGameObject<CinemachineDollyCart>("Dolly Cart", command.context as GameObject, true);
+
+            dollyCart.m_Path = path;
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_MenuPriority)]
-        static void CreateMixingCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Target Group Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateTargetGroupCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("Mixing Camera");
-            CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineMixingCamera), "CM MixingCamera"),
-                    typeof(CinemachineMixingCamera));
-            SetParentToMenuContextObject(go, command);
-            if (SceneView.lastActiveSceneView != null)
-                go.transform.position = SceneView.lastActiveSceneView.pivot;
-            Undo.RegisterCreatedObjectUndo(go, "create MixingCamera camera");
+            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", command.context as GameObject, false);
 
-            // Give it a couple of children
-            Undo.SetTransformParent(CreateDefaultVirtualCamera().transform, go.transform, "create MixedCamera child");
-            Undo.SetTransformParent(CreateDefaultVirtualCamera().transform, go.transform, "create MixingCamera child");
+            AddCinemachineComponent<CinemachineGroupComposer>(virtualCamera);
+            AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
+
+            CinemachineTargetGroup targetGroup = CreateCinemachineGameObject<CinemachineTargetGroup>("Target Group", command.context as GameObject, true);
+            virtualCamera.LookAt = targetGroup.transform;
+            virtualCamera.Follow = targetGroup.transform;
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_MenuPriority)]
-        static void Create2DCamera(MenuCommand command)
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_GameObjectMenuPriority)]
+        private static void CreateMixingCamera(MenuCommand command)
         {
-            CinemachineEditorAnalytics.SendCreateEvent("2D Camera");
-            var go = InternalCreateVirtualCamera(
-                "CM vcam", true, typeof(CinemachineFramingTransposer)).gameObject;
-            SetParentToMenuContextObject(go, command);
+            CinemachineMixingCamera mixingCamera = CreateCinemachineGameObject<CinemachineMixingCamera>("Mixing Camera", command.context as GameObject);
+
+            // We give the camera a couple of children as an example of setup.
+            CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
+            CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
         }
 
-#if !UNITY_2019_1_OR_NEWER
-        [MenuItem("Cinemachine/Import Post Processing V2 Adapter Asset Package")]
-        static void ImportPostProcessingV2Package()
+        [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_GameObjectMenuPriority)]
+        private static void Create2DCamera(MenuCommand command)
         {
-            var message = "In Cinemachine 2.4.0 and up, the PostProcessing adapter is built-in, and "
-                + "can be auto-enabled by Unity 2019 and up.\n\n"
-                + "Unity 2018.4 is unable to auto-detect the presence of PostProcessing, so you must "
-                + "manually add a define to your player settings to enable the code.\n\n"
-                + "To enable support for PostProcessing v2, please do the following:\n\n"
-                + "1. Delete the CinemachinePostProcessing folder from your assets, if it's present\n\n"
-                + "2. Open the Player Settings tab in Project Settings\n\n"
-                + "3. Add this define: CINEMACHINE_POST_PROCESSING_V2";
-
-            EditorUtility.DisplayDialog("Cinemachine Adapter Code for PostProcessing V2", message, "OK");
-        }
-
-        [MenuItem("Cinemachine/Import CinemachineExamples Asset Package")]
-        static void ImportExamplePackage()
-        {
-            string pkgFile = ScriptableObjectUtility.CinemachineInstallPath
-                + "/Extras~/CinemachineExamples.unitypackage";
-            if (!System.IO.File.Exists(pkgFile))
-                Debug.LogError("Missing file " + pkgFile);
-            else
-                AssetDatabase.ImportPackage(pkgFile, true);
-        }
-#endif
-
-        /// <summary>
-        /// Create a default Virtual Camera, with standard components
-        /// </summary>
-        public static CinemachineVirtualCamera CreateDefaultVirtualCamera()
-        {
-            return InternalCreateVirtualCamera(
-                "CM vcam", false, typeof(CinemachineComposer), typeof(CinemachineTransposer));
+            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("2D Camera", command.context as GameObject);
+            AddCinemachineComponent<CinemachineFramingTransposer>(virtualCamera);
         }
 
         /// <summary>
-        /// Create a static Virtual Camera, with no procedural components
+        /// Sets the specified <see cref="CinemachineVirtualCamera"/> to match the position, rotation, and lens settings of the <see cref="SceneView"/> camera.
         /// </summary>
-        public static CinemachineVirtualCamera CreateStaticVirtualCamera()
-        {
-            return InternalCreateVirtualCamera("CM vcam", false);
-        }
-
-        /// <summary>
-        /// Create a Virtual Camera, with components
-        /// </summary>
-        static CinemachineVirtualCamera InternalCreateVirtualCamera(
-            string name, bool selectIt, params Type[] components)
-        {
-            // Create a new virtual camera
-            var brain = CreateCameraBrainIfAbsent();
-            GameObject go = InspectorUtility.CreateGameObject(
-                    GenerateUniqueObjectName(typeof(CinemachineVirtualCamera), name),
-                    typeof(CinemachineVirtualCamera));
-            CinemachineVirtualCamera vcam = go.GetComponent<CinemachineVirtualCamera>();
-            SetVcamFromSceneView(vcam);
-            Undo.RegisterCreatedObjectUndo(go, "create " + name);
-            GameObject componentOwner = vcam.GetComponentOwner().gameObject;
-            foreach (Type t in components)
-                Undo.AddComponent(componentOwner, t);
-            vcam.InvalidateComponentPipeline();
-            if (brain != null && brain.OutputCamera != null)
-                vcam.m_Lens = LensSettings.FromCamera(brain.OutputCamera);
-            if (selectIt)
-                Selection.activeObject = go;
-            return vcam;
-        }
-
-        public static void SetVcamFromSceneView(CinemachineVirtualCamera vcam)
+        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to match with the <see cref="SceneView"/> settings to.</param>
+        public static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
         {
             if (SceneView.lastActiveSceneView != null)
             {
-                vcam.transform.position = SceneView.lastActiveSceneView.camera.transform.position;
-                vcam.transform.rotation = SceneView.lastActiveSceneView.camera.transform.rotation;
-                var lens = LensSettings.FromCamera(SceneView.lastActiveSceneView.camera);
-                // Don't grab these
+                Camera sceneViewCamera = SceneView.lastActiveSceneView.camera;
+                virtualCamera.transform.SetPositionAndRotation(sceneViewCamera.transform.position, sceneViewCamera.transform.rotation);
+                var lens = LensSettings.FromCamera(sceneViewCamera);
+                // Don't grab these.
                 lens.NearClipPlane = LensSettings.Default.NearClipPlane;
                 lens.FarClipPlane = LensSettings.Default.FarClipPlane;
-                vcam.m_Lens = lens;
+                virtualCamera.m_Lens = lens;
             }
         }
 
         /// <summary>
-        /// If there is no CinemachineBrain in the scene, try to create one on the main camera
+        /// Creates a <see cref="CinemachineVirtualCamera"/>, with standard components.
         /// </summary>
-        public static CinemachineBrain CreateCameraBrainIfAbsent()
+        public static CinemachineVirtualCamera CreateDefaultVirtualCamera(string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
         {
-            CinemachineBrain[] brains = UnityEngine.Object.FindObjectsOfType(
-                    typeof(CinemachineBrain)) as CinemachineBrain[];
-            CinemachineBrain brain = (brains != null && brains.Length > 0) ? brains[0] : null;
+            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(name, parentObject, select);
+
+            AddCinemachineComponent<CinemachineComposer>(virtualCamera);
+            AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
+
+            return virtualCamera;
+        }
+
+        /// <summary>
+        /// Creates a Cinemachine <see cref="GameObject"/> in the scene with a specified component.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="Component"/> to add to the new <see cref="GameObject"/>.</typeparam>
+        /// <param name="name">The name of the new <see cref="GameObject"/>.</param>
+        /// <param name="parentObject">The <see cref="GameObject"/> to parent the new <see cref="GameObject"/> to.</param>
+        /// <param name="select">Whether the new <see cref="GameObject"/> should be selected.</param>
+        /// <returns>The instance of the component that is added to the new <see cref="GameObject"/>.</returns>
+        public static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
+        {
+            CinemachineEditorAnalytics.SendCreateEvent(name);
+
+            CinemachineBrain brain = GetCreateBrain();
+            // We use ObjectFactory to create a new GameObject as it automatically supports undo/redo.
+            GameObject go = ObjectFactory.CreateGameObject(name);
+            T component = go.AddComponent<T>();
+
+            if (parentObject != null)
+                Undo.SetTransformParent(go.transform, parentObject.transform, "Set parent of " + name);
+
+            // We ensure that the new object has a unique name, for example "Camera (1)".
+            // This must be done after setting the parent in order to get an accurate unique name.
+            GameObjectUtility.EnsureUniqueNameForSibling(go);
+
+            // We set the new object to be at the current pivot of the scene.
+            // TODO: Support the "Place Objects At World Origin" preference option in 2020.3+, see GOCreationCommands.cs
+            if (SceneView.lastActiveSceneView != null)
+                go.transform.position = SceneView.lastActiveSceneView.pivot;
+
+            // If we created a Virtual Camera we setup it's look.
+            if (component is CinemachineVirtualCamera virtualCamera)
+            {
+                CopySceneViewLook(virtualCamera);
+
+                if (brain != null && brain.OutputCamera != null)
+                    virtualCamera.m_Lens = LensSettings.FromCamera(brain.OutputCamera);
+            }
+
+            if (select)
+                Selection.activeGameObject = go;
+
+            return component;
+        }
+
+        /// <summary>
+        /// Gets the first loaded <see cref="CinemachineBrain"/>. Creates one on the <see cref="Camera.main"/> if none were found.
+        /// </summary>
+        private static CinemachineBrain GetCreateBrain()
+        {
+            CinemachineBrain brain = Object.FindObjectOfType<CinemachineBrain>();
+
             if (brain == null)
             {
                 Camera cam = Camera.main;
                 if (cam == null)
-                {
-                    Camera[] cams = UnityEngine.Object.FindObjectsOfType(
-                            typeof(Camera)) as Camera[];
-                    if (cams != null && cams.Length > 0)
-                        cam = cams[0];
-                }
+                    cam = Object.FindObjectOfType<Camera>();
+
                 if (cam != null)
-                {
                     brain = Undo.AddComponent<CinemachineBrain>(cam.gameObject);
-                }
             }
+
             return brain;
         }
 
         /// <summary>
-        /// Generate a unique name with the given prefix by adding a suffix to it
+        /// Adds an component to the specified <see cref="CinemachineVirtualCamera"/>'s hidden component owner, that supports undo.
         /// </summary>
-        public static string GenerateUniqueObjectName(Type type, string prefix)
+        /// <typeparam name="T">The type of <see cref="Component"/> to add to the cinemachine pipeline.</typeparam>
+        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to add components to.</param>
+        /// <returns>The instance of the componented that was added.</returns>
+        private static T AddCinemachineComponent<T>(CinemachineVirtualCamera virtualCamera) where T : CinemachineComponentBase
         {
-            int count = 0;
-            UnityEngine.Object[] all = Resources.FindObjectsOfTypeAll(type);
-            foreach (UnityEngine.Object o in all)
-            {
-                if (o != null && o.name.StartsWith(prefix))
-                {
-                    string suffix = o.name.Substring(prefix.Length);
-                    int i;
-                    if (Int32.TryParse(suffix, out i) && i > count)
-                        count = i;
-                }
-            }
-            return prefix + (count + 1);
+            // We can't use the CinemachineVirtualCamera.AddCinemachineComponent<T>() because we want to support undo/redo.
+            GameObject componentOwner = virtualCamera.GetComponentOwner().gameObject;
+            var component = Undo.AddComponent<T>(componentOwner);
+            virtualCamera.InvalidateComponentPipeline();
+
+            return component;
         }
     }
 }

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -34,26 +34,23 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Virtual Camera", false, m_GameObjectMenuPriority)]
         static void CreateVirtualCamera(MenuCommand command)
         {
-            var name = "Virtual Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
             CreateDefaultVirtualCamera(parentObject: command.context as GameObject, select: true);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "FreeLook Camera", false, m_GameObjectMenuPriority)]
         static void CreateFreeLookCamera(MenuCommand command)
         {
-            var name = "FreeLook Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
-            CreateCinemachineObject<CinemachineFreeLook>(name, command.context as GameObject, true);
+            CinemachineEditorAnalytics.SendCreateEvent("FreeLook Camera");
+            CreateCinemachineObject<CinemachineFreeLook>("FreeLook Camera", command.context as GameObject, true);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
         static void CreateBlendListCamera(MenuCommand command)
         {
-            var name = "Blend List Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("Blend List Camera");
             var blendListCamera = CreateCinemachineObject<CinemachineBlendListCamera>(
-                name, command.context as GameObject, true);
+                "Blend List Camera", command.context as GameObject, true);
 
             // We give the camera a couple of children as an example of setup
             var childVcam1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
@@ -72,10 +69,9 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
         static void CreateStateDivenCamera(MenuCommand command)
         {
-            var name = "State-Driven Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("State-Driven Camera");
             var stateDrivenCamera = CreateCinemachineObject<CinemachineStateDrivenCamera>(
-                name, command.context as GameObject, true);
+                "State-Driven Camera", command.context as GameObject, true);
 
             // We give the camera a child as an example setup
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
@@ -84,10 +80,9 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_GameObjectMenuPriority)]
         static void CreateClearShotVirtualCamera(MenuCommand command)
         {
-            var name = "ClearShot Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("ClearShot Camera");
             var clearShotCamera = CreateCinemachineObject<CinemachineClearShot>(
-                name, command.context as GameObject, true);
+                "ClearShot Camera", command.context as GameObject, true);
 
             // We give the camera a child as an example setup
             var childVcam = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
@@ -138,10 +133,9 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_GameObjectMenuPriority)]
         static void CreateMixingCamera(MenuCommand command)
         {
-            var name = "Mixing Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("Mixing Camera");
             var mixingCamera = CreateCinemachineObject<CinemachineMixingCamera>(
-                name, command.context as GameObject, true);
+                "Mixing Camera", command.context as GameObject, true);
 
             // We give the camera a couple of children as an example of setup
             CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
@@ -151,10 +145,9 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_GameObjectMenuPriority)]
         static void Create2DCamera(MenuCommand command)
         {
-            var name = "2D Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
             var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(
-                name, command.context as GameObject, true);
+                "Virtual Camera", command.context as GameObject, true);
             vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
 
             AddCinemachineComponent<CinemachineFramingTransposer>(vcam);

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -86,7 +86,9 @@ namespace Cinemachine.Editor
 
             // We give the camera a child as an example setup
             var childVcam = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
+#if CINEMACHINE_PHYSICS
             Undo.AddComponent<CinemachineCollider>(childVcam.gameObject).m_AvoidObstacles = false;
+#endif
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -5,56 +5,56 @@ namespace Cinemachine.Editor
 {
     internal static class CinemachineMenu
     {
-        private const string m_CinemachineAssetsRootMenu = "Assets/Create/Cinemachine/";
-        private const string m_CinemachineGameObjectRootMenu = "GameObject/Cinemachine/";
-        private const int m_GameObjectMenuPriority = 11; // Right after Camera.
+        const string m_CinemachineAssetsRootMenu = "Assets/Create/Cinemachine/";
+        const string m_CinemachineGameObjectRootMenu = "GameObject/Cinemachine/";
+        const int m_GameObjectMenuPriority = 11; // Right after Camera.
 
-
-        // Assets Menu.
+        // Assets Menu
 
         [MenuItem(m_CinemachineAssetsRootMenu + "BlenderSettings")]
-        private static void CreateBlenderSettingAsset()
+        static void CreateBlenderSettingAsset()
         {
             ScriptableObjectUtility.Create<CinemachineBlenderSettings>();
         }
 
         [MenuItem(m_CinemachineAssetsRootMenu + "NoiseSettings")]
-        private static void CreateNoiseSettingAsset()
+        static void CreateNoiseSettingAsset()
         {
             ScriptableObjectUtility.Create<NoiseSettings>();
         }
 
         [MenuItem(m_CinemachineAssetsRootMenu + "Fixed Signal Definition")]
-        private static void CreateFixedSignalDefinition()
+        static void CreateFixedSignalDefinition()
         {
             ScriptableObjectUtility.Create<CinemachineFixedSignal>();
         }
 
-        // GameObject Menu.
+        // GameObject Menu
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Virtual Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateVirtualCamera(MenuCommand command)
+        static void CreateVirtualCamera(MenuCommand command)
         {
             CreateDefaultVirtualCamera(parentObject: command.context as GameObject, select: true);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Free Look Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateFreeLookCamera(MenuCommand command)
+        static void CreateFreeLookCamera(MenuCommand command)
         {
             CreateCinemachineGameObject<CinemachineFreeLook>("Free Look Camera", command.context as GameObject);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateBlendListCamera(MenuCommand command)
+        static void CreateBlendListCamera(MenuCommand command)
         {
-            var blendListCamera = CreateCinemachineGameObject<CinemachineBlendListCamera>("Blend List Camera", command.context as GameObject);
+            var blendListCamera = CreateCinemachineGameObject<CinemachineBlendListCamera>(
+                "Blend List Camera", command.context as GameObject);
 
-            // We give the camera a couple of children as an example of setup.
-            CinemachineVirtualCamera childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
-            CinemachineVirtualCamera childVirtualCamera2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            // We give the camera a couple of children as an example of setup
+            var childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            var childVirtualCamera2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
             childVirtualCamera2.m_Lens.FieldOfView = 10;
 
-            // Set up initial instruction set.
+            // Set up initial instruction set
             blendListCamera.m_Instructions = new CinemachineBlendListCamera.Instruction[2];
             blendListCamera.m_Instructions[0].m_VirtualCamera = childVirtualCamera1;
             blendListCamera.m_Instructions[0].m_Hold = 1f;
@@ -64,31 +64,34 @@ namespace Cinemachine.Editor
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateStateDivenCamera(MenuCommand command)
+        static void CreateStateDivenCamera(MenuCommand command)
         {
-            var stateDrivenCamera = CreateCinemachineGameObject<CinemachineStateDrivenCamera>("State-Driven Camera", command.context as GameObject);
+            var stateDrivenCamera = CreateCinemachineGameObject<CinemachineStateDrivenCamera>(
+                "State-Driven Camera", command.context as GameObject);
 
-            // We give the camera a child as an example setup.
+            // We give the camera a child as an example setup
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Clear Shot Camera", false, m_GameObjectMenuPriority)]
         static void CreateClearShotVirtualCamera(MenuCommand command)
         {
-            var clearShotCamera = CreateCinemachineGameObject<CinemachineClearShot>("Clear Shot Camera", command.context as GameObject);
+            var clearShotCamera = CreateCinemachineGameObject<CinemachineClearShot>(
+                "Clear Shot Camera", command.context as GameObject);
 
-            // We give the camera a child as an example setup.
-            CinemachineVirtualCamera childVirtualCamera = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
+            // We give the camera a child as an example setup
+            var childVirtualCamera = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
             var collider = Undo.AddComponent<CinemachineCollider>(childVirtualCamera.gameObject);
             collider.m_AvoidObstacles = false;
         }
 
-
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]
-        private static void CreateDollyCameraWithPath(MenuCommand command)
+        static void CreateDollyCameraWithPath(MenuCommand command)
         {
-            CinemachineSmoothPath path = CreateCinemachineGameObject<CinemachineSmoothPath>("Dolly Track", command.context as GameObject, false);
-            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", command.context as GameObject, true);
+            var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
+                "Dolly Track", command.context as GameObject, false);
+            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
+                "Virtual Camera", command.context as GameObject, true);
 
             AddCinemachineComponent<CinemachineComposer>(virtualCamera);
             var trackedDolly = AddCinemachineComponent<CinemachineTrackedDolly>(virtualCamera);
@@ -97,56 +100,65 @@ namespace Cinemachine.Editor
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Track with Cart", false, m_GameObjectMenuPriority)]
-        private static void CreateDollyTrackWithCart(MenuCommand command)
+        static void CreateDollyTrackWithCart(MenuCommand command)
         {
-            CinemachineSmoothPath path = CreateCinemachineGameObject<CinemachineSmoothPath>("Dolly Track", command.context as GameObject, false);
-            CinemachineDollyCart dollyCart = CreateCinemachineGameObject<CinemachineDollyCart>("Dolly Cart", command.context as GameObject, true);
+            var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
+                "Dolly Track", command.context as GameObject, false);
+            var dollyCart = CreateCinemachineGameObject<CinemachineDollyCart>(
+                "Dolly Cart", command.context as GameObject, true);
 
             dollyCart.m_Path = path;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Target Group Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateTargetGroupCamera(MenuCommand command)
+        static void CreateTargetGroupCamera(MenuCommand command)
         {
-            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", command.context as GameObject, false);
+            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
+                "Virtual Camera", command.context as GameObject, false);
 
             AddCinemachineComponent<CinemachineGroupComposer>(virtualCamera);
             AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
 
-            CinemachineTargetGroup targetGroup = CreateCinemachineGameObject<CinemachineTargetGroup>("Target Group", command.context as GameObject, true);
+            var targetGroup = CreateCinemachineGameObject<CinemachineTargetGroup>(
+                "Target Group", command.context as GameObject, true);
             virtualCamera.LookAt = targetGroup.transform;
             virtualCamera.Follow = targetGroup.transform;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_GameObjectMenuPriority)]
-        private static void CreateMixingCamera(MenuCommand command)
+        static void CreateMixingCamera(MenuCommand command)
         {
-            CinemachineMixingCamera mixingCamera = CreateCinemachineGameObject<CinemachineMixingCamera>("Mixing Camera", command.context as GameObject);
+            var mixingCamera = CreateCinemachineGameObject<CinemachineMixingCamera>(
+                "Mixing Camera", command.context as GameObject);
 
-            // We give the camera a couple of children as an example of setup.
+            // We give the camera a couple of children as an example of setup
             CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
             CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_GameObjectMenuPriority)]
-        private static void Create2DCamera(MenuCommand command)
+        static void Create2DCamera(MenuCommand command)
         {
-            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>("2D Camera", command.context as GameObject);
+            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
+                "2D Camera", command.context as GameObject);
             AddCinemachineComponent<CinemachineFramingTransposer>(virtualCamera);
         }
 
         /// <summary>
-        /// Sets the specified <see cref="CinemachineVirtualCamera"/> to match the position, rotation, and lens settings of the <see cref="SceneView"/> camera.
+        /// Sets the specified <see cref="CinemachineVirtualCamera"/> to match the position, 
+        /// rotation, and lens settings of the <see cref="SceneView"/> camera.
         /// </summary>
-        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to match with the <see cref="SceneView"/> settings to.</param>
-        public static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
+        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to match with 
+        /// the <see cref="SceneView"/> settings to.</param>
+        static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
         {
             if (SceneView.lastActiveSceneView != null)
             {
-                Camera sceneViewCamera = SceneView.lastActiveSceneView.camera;
-                virtualCamera.transform.SetPositionAndRotation(sceneViewCamera.transform.position, sceneViewCamera.transform.rotation);
+                var sceneViewCamera = SceneView.lastActiveSceneView.camera;
+                virtualCamera.transform.SetPositionAndRotation(
+                    sceneViewCamera.transform.position, sceneViewCamera.transform.rotation);
                 var lens = LensSettings.FromCamera(sceneViewCamera);
-                // Don't grab these.
+                // Don't grab these
                 lens.NearClipPlane = LensSettings.Default.NearClipPlane;
                 lens.FarClipPlane = LensSettings.Default.FarClipPlane;
                 virtualCamera.m_Lens = lens;
@@ -156,9 +168,10 @@ namespace Cinemachine.Editor
         /// <summary>
         /// Creates a <see cref="CinemachineVirtualCamera"/>, with standard components.
         /// </summary>
-        public static CinemachineVirtualCamera CreateDefaultVirtualCamera(string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
+        static CinemachineVirtualCamera CreateDefaultVirtualCamera(
+            string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
         {
-            CinemachineVirtualCamera virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(name, parentObject, select);
+            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(name, parentObject, select);
 
             AddCinemachineComponent<CinemachineComposer>(virtualCamera);
             AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
@@ -174,20 +187,20 @@ namespace Cinemachine.Editor
         /// <param name="parentObject">The <see cref="GameObject"/> to parent the new <see cref="GameObject"/> to.</param>
         /// <param name="select">Whether the new <see cref="GameObject"/> should be selected.</param>
         /// <returns>The instance of the component that is added to the new <see cref="GameObject"/>.</returns>
-        public static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
+        static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
         {
             CinemachineEditorAnalytics.SendCreateEvent(name);
 
-            CinemachineBrain brain = GetCreateBrain();
-            // We use ObjectFactory to create a new GameObject as it automatically supports undo/redo.
-            GameObject go = ObjectFactory.CreateGameObject(name);
+            var brain = GetOrCreateBrain();
+            // We use ObjectFactory to create a new GameObject as it automatically supports undo/redo
+            var go = ObjectFactory.CreateGameObject(name);
             T component = go.AddComponent<T>();
 
             if (parentObject != null)
                 Undo.SetTransformParent(go.transform, parentObject.transform, "Set parent of " + name);
 
             // We ensure that the new object has a unique name, for example "Camera (1)".
-            // This must be done after setting the parent in order to get an accurate unique name.
+            // This must be done after setting the parent in order to get an accurate unique name
             GameObjectUtility.EnsureUniqueNameForSibling(go);
 
             // We set the new object to be at the current pivot of the scene.
@@ -195,7 +208,7 @@ namespace Cinemachine.Editor
             if (SceneView.lastActiveSceneView != null)
                 go.transform.position = SceneView.lastActiveSceneView.pivot;
 
-            // If we created a Virtual Camera we setup it's look.
+            // If we created a Virtual Camera we setup its look
             if (component is CinemachineVirtualCamera virtualCamera)
             {
                 CopySceneViewLook(virtualCamera);
@@ -211,38 +224,37 @@ namespace Cinemachine.Editor
         }
 
         /// <summary>
-        /// Gets the first loaded <see cref="CinemachineBrain"/>. Creates one on the <see cref="Camera.main"/> if none were found.
+        /// Gets the first loaded <see cref="CinemachineBrain"/>. Creates one on 
+        /// the <see cref="Camera.main"/> if none were found.
         /// </summary>
-        private static CinemachineBrain GetCreateBrain()
+        static CinemachineBrain GetOrCreateBrain()
         {
-            CinemachineBrain brain = Object.FindObjectOfType<CinemachineBrain>();
-
+            var brain = Object.FindObjectOfType<CinemachineBrain>();
             if (brain == null)
             {
                 Camera cam = Camera.main;
                 if (cam == null)
                     cam = Object.FindObjectOfType<Camera>();
-
                 if (cam != null)
                     brain = Undo.AddComponent<CinemachineBrain>(cam.gameObject);
             }
-
             return brain;
         }
 
         /// <summary>
-        /// Adds an component to the specified <see cref="CinemachineVirtualCamera"/>'s hidden component owner, that supports undo.
+        /// Adds an component to the specified <see cref="CinemachineVirtualCamera"/>'s hidden 
+        /// component owner, that supports undo.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="Component"/> to add to the cinemachine pipeline.</typeparam>
         /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to add components to.</param>
         /// <returns>The instance of the componented that was added.</returns>
-        private static T AddCinemachineComponent<T>(CinemachineVirtualCamera virtualCamera) where T : CinemachineComponentBase
+        static T AddCinemachineComponent<T>(CinemachineVirtualCamera virtualCamera) where T : CinemachineComponentBase
         {
-            // We can't use the CinemachineVirtualCamera.AddCinemachineComponent<T>() because we want to support undo/redo.
-            GameObject componentOwner = virtualCamera.GetComponentOwner().gameObject;
+            // We can't use the CinemachineVirtualCamera.AddCinemachineComponent<T>()
+            // because we want to support undo/redo
+            var componentOwner = virtualCamera.GetComponentOwner().gameObject;
             var component = Undo.AddComponent<T>(componentOwner);
             virtualCamera.InvalidateComponentPipeline();
-
             return component;
         }
     }

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -44,7 +44,7 @@ namespace Cinemachine.Editor
         {
             var name = "FreeLook Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            CreateCinemachineGameObject<CinemachineFreeLook>(name, command.context as GameObject);
+            CreateCinemachineObject<CinemachineFreeLook>(name, command.context as GameObject, true);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
@@ -52,19 +52,19 @@ namespace Cinemachine.Editor
         {
             var name = "Blend List Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var blendListCamera = CreateCinemachineGameObject<CinemachineBlendListCamera>(
-                name, command.context as GameObject);
+            var blendListCamera = CreateCinemachineObject<CinemachineBlendListCamera>(
+                name, command.context as GameObject, true);
 
             // We give the camera a couple of children as an example of setup
-            var childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
-            var childVirtualCamera2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
-            childVirtualCamera2.m_Lens.FieldOfView = 10;
+            var childVcam1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            var childVcam2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
+            childVcam2.m_Lens.FieldOfView = 10;
 
             // Set up initial instruction set
             blendListCamera.m_Instructions = new CinemachineBlendListCamera.Instruction[2];
-            blendListCamera.m_Instructions[0].m_VirtualCamera = childVirtualCamera1;
+            blendListCamera.m_Instructions[0].m_VirtualCamera = childVcam1;
             blendListCamera.m_Instructions[0].m_Hold = 1f;
-            blendListCamera.m_Instructions[1].m_VirtualCamera = childVirtualCamera2;
+            blendListCamera.m_Instructions[1].m_VirtualCamera = childVcam2;
             blendListCamera.m_Instructions[1].m_Blend.m_Style = CinemachineBlendDefinition.Style.EaseInOut;
             blendListCamera.m_Instructions[1].m_Blend.m_Time = 2f;
         }
@@ -74,8 +74,8 @@ namespace Cinemachine.Editor
         {
             var name = "State-Driven Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var stateDrivenCamera = CreateCinemachineGameObject<CinemachineStateDrivenCamera>(
-                name, command.context as GameObject);
+            var stateDrivenCamera = CreateCinemachineObject<CinemachineStateDrivenCamera>(
+                name, command.context as GameObject, true);
 
             // We give the camera a child as an example setup
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
@@ -86,56 +86,53 @@ namespace Cinemachine.Editor
         {
             var name = "ClearShot Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var clearShotCamera = CreateCinemachineGameObject<CinemachineClearShot>(
-                name, command.context as GameObject);
+            var clearShotCamera = CreateCinemachineObject<CinemachineClearShot>(
+                name, command.context as GameObject, true);
 
             // We give the camera a child as an example setup
-            var childVirtualCamera = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
-            var collider = Undo.AddComponent<CinemachineCollider>(childVirtualCamera.gameObject);
-            collider.m_AvoidObstacles = false;
+            var childVcam = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
+            Undo.AddComponent<CinemachineCollider>(childVcam.gameObject).m_AvoidObstacles = false;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]
         static void CreateDollyCameraWithPath(MenuCommand command)
         {
             CinemachineEditorAnalytics.SendCreateEvent("Dolly Camera with Track");
-            var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
+            var path = CreateCinemachineObject<CinemachineSmoothPath>(
                 "Dolly Track", command.context as GameObject, false);
-            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
+            var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(
                 "Virtual Camera", command.context as GameObject, true);
+            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
 
-            AddCinemachineComponent<CinemachineComposer>(virtualCamera);
-            var trackedDolly = AddCinemachineComponent<CinemachineTrackedDolly>(virtualCamera);
-
-            trackedDolly.m_Path = path;
+            AddCinemachineComponent<CinemachineComposer>(vcam);
+            AddCinemachineComponent<CinemachineTrackedDolly>(vcam).m_Path = path;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Track with Cart", false, m_GameObjectMenuPriority)]
         static void CreateDollyTrackWithCart(MenuCommand command)
         {
             CinemachineEditorAnalytics.SendCreateEvent("Dolly Track with Cart");
-            var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
+            var path = CreateCinemachineObject<CinemachineSmoothPath>(
                 "Dolly Track", command.context as GameObject, false);
-            var dollyCart = CreateCinemachineGameObject<CinemachineDollyCart>(
-                "Dolly Cart", command.context as GameObject, true);
-
-            dollyCart.m_Path = path;
+            CreateCinemachineObject<CinemachineDollyCart>(
+                "Dolly Cart", command.context as GameObject, true).m_Path = path;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Target Group Camera", false, m_GameObjectMenuPriority)]
         static void CreateTargetGroupCamera(MenuCommand command)
         {
             CinemachineEditorAnalytics.SendCreateEvent("Target Group Camera");
-            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
+            var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(
                 "Virtual Camera", command.context as GameObject, false);
+            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
 
-            AddCinemachineComponent<CinemachineGroupComposer>(virtualCamera);
-            AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
+            AddCinemachineComponent<CinemachineGroupComposer>(vcam);
+            AddCinemachineComponent<CinemachineTransposer>(vcam);
 
-            var targetGroup = CreateCinemachineGameObject<CinemachineTargetGroup>(
+            var targetGroup = CreateCinemachineObject<CinemachineTargetGroup>(
                 "Target Group", command.context as GameObject, true);
-            virtualCamera.LookAt = targetGroup.transform;
-            virtualCamera.Follow = targetGroup.transform;
+            vcam.LookAt = targetGroup.transform;
+            vcam.Follow = targetGroup.transform;
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_GameObjectMenuPriority)]
@@ -143,8 +140,8 @@ namespace Cinemachine.Editor
         {
             var name = "Mixing Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var mixingCamera = CreateCinemachineGameObject<CinemachineMixingCamera>(
-                name, command.context as GameObject);
+            var mixingCamera = CreateCinemachineObject<CinemachineMixingCamera>(
+                name, command.context as GameObject, true);
 
             // We give the camera a couple of children as an example of setup
             CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
@@ -156,44 +153,70 @@ namespace Cinemachine.Editor
         {
             var name = "2D Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
-                name, command.context as GameObject);
-            AddCinemachineComponent<CinemachineFramingTransposer>(virtualCamera);
+            var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(
+                name, command.context as GameObject, true);
+            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+
+            AddCinemachineComponent<CinemachineFramingTransposer>(vcam);
         }
 
         /// <summary>
-        /// Sets the specified <see cref="CinemachineVirtualCamera"/> to match the position, 
-        /// rotation, and lens settings of the <see cref="SceneView"/> camera.
+        /// Sets the specified <see cref="Transform"/> to match the position and 
+        /// rotation of the <see cref="SceneView"/> camera, and returns the scene view 
+        /// camera's lens settings.
         /// </summary>
-        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to match with 
-        /// the <see cref="SceneView"/> settings to.</param>
-        public static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
+        /// <param name="sceneObject">The <see cref="Transform"/> to match with the 
+        /// <see cref="SceneView"/> camera.</param>
+        /// <returns>A <see cref="LensSettings"/> representing the scene view camera's lens</returns>
+        public static LensSettings MatchSceneViewCamera(Transform sceneObject)
         {
+            var lens = LensSettings.Default;
+
+            // Take initial settings from the GameView camera, because we don't want to override 
+            // things like ortho vs perspective - we just want position and FOV
+            var brain = GetOrCreateBrain();
+            if (brain != null && brain.OutputCamera != null)
+                lens = LensSettings.FromCamera(brain.OutputCamera);
+
             if (SceneView.lastActiveSceneView != null)
             {
-                var sceneViewCamera = SceneView.lastActiveSceneView.camera;
-                virtualCamera.transform.SetPositionAndRotation(
-                    sceneViewCamera.transform.position, sceneViewCamera.transform.rotation);
-                var lens = LensSettings.FromCamera(sceneViewCamera);
-                // Don't grab these
-                lens.NearClipPlane = LensSettings.Default.NearClipPlane;
-                lens.FarClipPlane = LensSettings.Default.FarClipPlane;
-                virtualCamera.m_Lens = lens;
+                var src = SceneView.lastActiveSceneView.camera;
+                sceneObject.SetPositionAndRotation(src.transform.position, src.transform.rotation);
+                if (lens.Orthographic == src.orthographic)
+                {
+                    if (src.orthographic)
+                        lens.OrthographicSize = src.orthographicSize;
+                    else
+                        lens.FieldOfView = src.fieldOfView;
+                }
             }
+            return lens;
         }
 
         /// <summary>
-        /// Creates a <see cref="CinemachineVirtualCamera"/>, with standard components.
+        /// Creates a <see cref="CinemachineVirtualCamera"/> with standard procedural components.
         /// </summary>
         public static CinemachineVirtualCamera CreateDefaultVirtualCamera(
             string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
         {
-            var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(name, parentObject, select);
+            var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(name, parentObject, select);
+            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
 
-            AddCinemachineComponent<CinemachineComposer>(virtualCamera);
-            AddCinemachineComponent<CinemachineTransposer>(virtualCamera);
+            AddCinemachineComponent<CinemachineComposer>(vcam);
+            AddCinemachineComponent<CinemachineTransposer>(vcam);
 
-            return virtualCamera;
+            return vcam;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="CinemachineVirtualCamera"/> with no procedural components.
+        /// </summary>
+        public static CinemachineVirtualCamera CreatePassiveVirtualCamera(
+            string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
+        {
+            var vcam = CreateCinemachineObject<CinemachineVirtualCamera>(name, parentObject, select);
+            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            return vcam;
         }
 
         /// <summary>
@@ -204,10 +227,10 @@ namespace Cinemachine.Editor
         /// <param name="parentObject">The <see cref="GameObject"/> to parent the new <see cref="GameObject"/> to.</param>
         /// <param name="select">Whether the new <see cref="GameObject"/> should be selected.</param>
         /// <returns>The instance of the component that is added to the new <see cref="GameObject"/>.</returns>
-        public static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
+        static T CreateCinemachineObject<T>(string name, GameObject parentObject, bool select) where T : Component
         {
             // We always enforce the existence of the CM brain
-            var brain = GetOrCreateBrain();
+            GetOrCreateBrain();
 
             // We use ObjectFactory to create a new GameObject as it automatically supports undo/redo
             var go = ObjectFactory.CreateGameObject(name);
@@ -221,18 +244,9 @@ namespace Cinemachine.Editor
             GameObjectUtility.EnsureUniqueNameForSibling(go);
 
             // We set the new object to be at the current pivot of the scene.
-            // TODO: Support the "Place Objects At World Origin" preference option in 2020.3+, see GOCreationCommands.cs
+            // GML TODO: Support the "Place Objects At World Origin" preference option in 2020.3+, see GOCreationCommands.cs
             if (SceneView.lastActiveSceneView != null)
                 go.transform.position = SceneView.lastActiveSceneView.pivot;
-
-            // If we created a Virtual Camera we setup its look
-            if (component is CinemachineVirtualCamera virtualCamera)
-            {
-                CopySceneViewLook(virtualCamera);
-
-                if (brain != null && brain.OutputCamera != null)
-                    virtualCamera.m_Lens = LensSettings.FromCamera(brain.OutputCamera);
-            }
 
             if (select)
                 Selection.activeGameObject = go;
@@ -246,16 +260,18 @@ namespace Cinemachine.Editor
         /// </summary>
         static CinemachineBrain GetOrCreateBrain()
         {
-            var brain = Object.FindObjectOfType<CinemachineBrain>();
-            if (brain == null)
-            {
-                Camera cam = Camera.main;
-                if (cam == null)
-                    cam = Object.FindObjectOfType<Camera>();
-                if (cam != null)
-                    brain = Undo.AddComponent<CinemachineBrain>(cam.gameObject);
-            }
-            return brain;
+            if (CinemachineCore.Instance.BrainCount > 0)
+                return CinemachineCore.Instance.GetActiveBrain(0);
+
+            // Create a CinemachineBrain on the main camera
+            Camera cam = Camera.main;
+            if (cam == null)
+                cam = Object.FindObjectOfType<Camera>();
+            if (cam != null)
+                return Undo.AddComponent<CinemachineBrain>(cam.gameObject);
+
+            // No camera, just create a brain on an empty object
+            return ObjectFactory.CreateGameObject("CinemachineBrain").AddComponent<CinemachineBrain>();
         }
 
         /// <summary>
@@ -263,15 +279,15 @@ namespace Cinemachine.Editor
         /// component owner, that supports undo.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="Component"/> to add to the cinemachine pipeline.</typeparam>
-        /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to add components to.</param>
+        /// <param name="vcam">The <see cref="CinemachineVirtualCamera"/> to add components to.</param>
         /// <returns>The instance of the componented that was added.</returns>
-        static T AddCinemachineComponent<T>(CinemachineVirtualCamera virtualCamera) where T : CinemachineComponentBase
+        static T AddCinemachineComponent<T>(CinemachineVirtualCamera vcam) where T : CinemachineComponentBase
         {
             // We can't use the CinemachineVirtualCamera.AddCinemachineComponent<T>()
             // because we want to support undo/redo
-            var componentOwner = virtualCamera.GetComponentOwner().gameObject;
+            var componentOwner = vcam.GetComponentOwner().gameObject;
             var component = Undo.AddComponent<T>(componentOwner);
-            virtualCamera.InvalidateComponentPipeline();
+            vcam.InvalidateComponentPipeline();
             return component;
         }
     }

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -34,20 +34,26 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Virtual Camera", false, m_GameObjectMenuPriority)]
         static void CreateVirtualCamera(MenuCommand command)
         {
+            var name = "Virtual Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             CreateDefaultVirtualCamera(parentObject: command.context as GameObject, select: true);
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Free Look Camera", false, m_GameObjectMenuPriority)]
+        [MenuItem(m_CinemachineGameObjectRootMenu + "FreeLook Camera", false, m_GameObjectMenuPriority)]
         static void CreateFreeLookCamera(MenuCommand command)
         {
-            CreateCinemachineGameObject<CinemachineFreeLook>("Free Look Camera", command.context as GameObject);
+            var name = "FreeLook Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
+            CreateCinemachineGameObject<CinemachineFreeLook>(name, command.context as GameObject);
         }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
         static void CreateBlendListCamera(MenuCommand command)
         {
+            var name = "Blend List Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             var blendListCamera = CreateCinemachineGameObject<CinemachineBlendListCamera>(
-                "Blend List Camera", command.context as GameObject);
+                name, command.context as GameObject);
 
             // We give the camera a couple of children as an example of setup
             var childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
@@ -66,18 +72,22 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
         static void CreateStateDivenCamera(MenuCommand command)
         {
+            var name = "State-Driven Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             var stateDrivenCamera = CreateCinemachineGameObject<CinemachineStateDrivenCamera>(
-                "State-Driven Camera", command.context as GameObject);
+                name, command.context as GameObject);
 
             // We give the camera a child as an example setup
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
         }
 
-        [MenuItem(m_CinemachineGameObjectRootMenu + "Clear Shot Camera", false, m_GameObjectMenuPriority)]
+        [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_GameObjectMenuPriority)]
         static void CreateClearShotVirtualCamera(MenuCommand command)
         {
+            var name = "ClearShot Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             var clearShotCamera = CreateCinemachineGameObject<CinemachineClearShot>(
-                "Clear Shot Camera", command.context as GameObject);
+                name, command.context as GameObject);
 
             // We give the camera a child as an example setup
             var childVirtualCamera = CreateDefaultVirtualCamera(parentObject: clearShotCamera.gameObject);
@@ -88,6 +98,7 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Camera with Track", false, m_GameObjectMenuPriority)]
         static void CreateDollyCameraWithPath(MenuCommand command)
         {
+            CinemachineEditorAnalytics.SendCreateEvent("Dolly Camera with Track");
             var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
                 "Dolly Track", command.context as GameObject, false);
             var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
@@ -102,6 +113,7 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Dolly Track with Cart", false, m_GameObjectMenuPriority)]
         static void CreateDollyTrackWithCart(MenuCommand command)
         {
+            CinemachineEditorAnalytics.SendCreateEvent("Dolly Track with Cart");
             var path = CreateCinemachineGameObject<CinemachineSmoothPath>(
                 "Dolly Track", command.context as GameObject, false);
             var dollyCart = CreateCinemachineGameObject<CinemachineDollyCart>(
@@ -113,6 +125,7 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Target Group Camera", false, m_GameObjectMenuPriority)]
         static void CreateTargetGroupCamera(MenuCommand command)
         {
+            CinemachineEditorAnalytics.SendCreateEvent("Target Group Camera");
             var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
                 "Virtual Camera", command.context as GameObject, false);
 
@@ -128,8 +141,10 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Mixing Camera", false, m_GameObjectMenuPriority)]
         static void CreateMixingCamera(MenuCommand command)
         {
+            var name = "Mixing Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             var mixingCamera = CreateCinemachineGameObject<CinemachineMixingCamera>(
-                "Mixing Camera", command.context as GameObject);
+                name, command.context as GameObject);
 
             // We give the camera a couple of children as an example of setup
             CreateDefaultVirtualCamera(parentObject: mixingCamera.gameObject);
@@ -139,8 +154,10 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "2D Camera", false, m_GameObjectMenuPriority)]
         static void Create2DCamera(MenuCommand command)
         {
+            var name = "2D Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
             var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(
-                "2D Camera", command.context as GameObject);
+                name, command.context as GameObject);
             AddCinemachineComponent<CinemachineFramingTransposer>(virtualCamera);
         }
 
@@ -150,7 +167,7 @@ namespace Cinemachine.Editor
         /// </summary>
         /// <param name="virtualCamera">The <see cref="CinemachineVirtualCamera"/> to match with 
         /// the <see cref="SceneView"/> settings to.</param>
-        static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
+        public static void CopySceneViewLook(CinemachineVirtualCamera virtualCamera)
         {
             if (SceneView.lastActiveSceneView != null)
             {
@@ -168,7 +185,7 @@ namespace Cinemachine.Editor
         /// <summary>
         /// Creates a <see cref="CinemachineVirtualCamera"/>, with standard components.
         /// </summary>
-        static CinemachineVirtualCamera CreateDefaultVirtualCamera(
+        public static CinemachineVirtualCamera CreateDefaultVirtualCamera(
             string name = "Virtual Camera", GameObject parentObject = null, bool select = false)
         {
             var virtualCamera = CreateCinemachineGameObject<CinemachineVirtualCamera>(name, parentObject, select);
@@ -187,11 +204,11 @@ namespace Cinemachine.Editor
         /// <param name="parentObject">The <see cref="GameObject"/> to parent the new <see cref="GameObject"/> to.</param>
         /// <param name="select">Whether the new <see cref="GameObject"/> should be selected.</param>
         /// <returns>The instance of the component that is added to the new <see cref="GameObject"/>.</returns>
-        static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
+        public static T CreateCinemachineGameObject<T>(string name, GameObject parentObject, bool select = true) where T : Component
         {
-            CinemachineEditorAnalytics.SendCreateEvent(name);
-
+            // We always enforce the existence of the CM brain
             var brain = GetOrCreateBrain();
+
             // We use ObjectFactory to create a new GameObject as it automatically supports undo/redo
             var go = ObjectFactory.CreateGameObject(name);
             T component = go.AddComponent<T>();

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -13,7 +13,7 @@ namespace Cinemachine.Editor
         // Assets Menu.
 
         [MenuItem(m_CinemachineAssetsRootMenu + "BlenderSettings")]
-        static void CreateBlenderSettingAsset()
+        private static void CreateBlenderSettingAsset()
         {
             ScriptableObjectUtility.Create<CinemachineBlenderSettings>();
         }
@@ -47,7 +47,7 @@ namespace Cinemachine.Editor
         [MenuItem(m_CinemachineGameObjectRootMenu + "Blend List Camera", false, m_GameObjectMenuPriority)]
         private static void CreateBlendListCamera(MenuCommand command)
         {
-            var blendListCamera  = CreateCinemachineGameObject<CinemachineBlendListCamera>("Blend List Camera", command.context as GameObject);
+            var blendListCamera = CreateCinemachineGameObject<CinemachineBlendListCamera>("Blend List Camera", command.context as GameObject);
 
             // We give the camera a couple of children as an example of setup.
             CinemachineVirtualCamera childVirtualCamera1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
@@ -62,7 +62,7 @@ namespace Cinemachine.Editor
             blendListCamera.m_Instructions[1].m_Blend.m_Style = CinemachineBlendDefinition.Style.EaseInOut;
             blendListCamera.m_Instructions[1].m_Blend.m_Time = 2f;
         }
-        
+
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
         private static void CreateStateDivenCamera(MenuCommand command)
         {

--- a/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
@@ -24,12 +24,9 @@ namespace Cinemachine.Editor
                 GenericMenu menu = new GenericMenu();
                 menu.AddItem(new GUIContent("Convert to TargetGroup"), false, () =>
                 {
-                    GameObject go = InspectorUtility.CreateGameObject(
-                            CinemachineMenu.GenerateUniqueObjectName(
-                                typeof(CinemachineTargetGroup), "CM TargetGroup"),
-                            typeof(CinemachineTargetGroup));
+                    GameObject go = ObjectFactory.CreateGameObject("Target Group", typeof(CinemachineTargetGroup));
                     var group = go.GetComponent<CinemachineTargetGroup>();
-                    Undo.RegisterCreatedObjectUndo(go, "convert to TargetGroup");
+                   
                     group.m_RotationMode = CinemachineTargetGroup.RotationMode.GroupAverage;
                     group.AddMember(target, 1, 1);
                     property.objectReferenceValue = group.Transform;

--- a/Editor/Timeline/CinemachineShotClipEditor.cs
+++ b/Editor/Timeline/CinemachineShotClipEditor.cs
@@ -73,7 +73,7 @@ public class CinemachineShotClipEditor : ClipEditor
         if (CinemachineShotEditor.AutoCreateShotFromSceneView)
         {
             var asset = clip.asset as CinemachineShot;
-            var vcam = CinemachineShotEditor.CreateStaticVcamFromSceneView();
+            var vcam = CinemachineShotEditor.CreatePassiveVcamFromSceneView();
             var d = TimelineEditor.inspectedDirector;
             if (d != null && d.GetReferenceValue(asset.VirtualCamera.exposedName, out bool idValid) == null)
             {

--- a/Editor/Timeline/CinemachineShotEditor.cs
+++ b/Editor/Timeline/CinemachineShotEditor.cs
@@ -52,10 +52,9 @@ using Cinemachine;
 #endif
 
         static public CinemachineVirtualCameraBase CreatePassiveVcamFromSceneView()
-        {
-            var name = "Virtual Camera";
-            CinemachineEditorAnalytics.SendCreateEvent(name);
-            var vcam = CinemachineMenu.CreatePassiveVirtualCamera(name, null, false);
+       {
+            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
+            var vcam = CinemachineMenu.CreatePassiveVirtualCamera("Virtual Camera", null, false);
             vcam.m_StandbyUpdate = CinemachineVirtualCameraBase.StandbyUpdateMode.Never;
 
 #if false 

--- a/Editor/Timeline/CinemachineShotEditor.cs
+++ b/Editor/Timeline/CinemachineShotEditor.cs
@@ -53,7 +53,9 @@ using Cinemachine;
 
         static public CinemachineVirtualCameraBase CreateStaticVcamFromSceneView()
         {
-            CinemachineVirtualCameraBase vcam = CinemachineMenu.CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", null, false);
+            var name = "Virtual Camera";
+            CinemachineEditorAnalytics.SendCreateEvent(name);
+            var vcam = CinemachineMenu.CreateCinemachineGameObject<CinemachineVirtualCamera>(name, null, false);
             vcam.m_StandbyUpdate = CinemachineVirtualCameraBase.StandbyUpdateMode.Never;
 
 #if false 

--- a/Editor/Timeline/CinemachineShotEditor.cs
+++ b/Editor/Timeline/CinemachineShotEditor.cs
@@ -51,11 +51,11 @@ using Cinemachine;
         }
 #endif
 
-        static public CinemachineVirtualCameraBase CreateStaticVcamFromSceneView()
+        static public CinemachineVirtualCameraBase CreatePassiveVcamFromSceneView()
         {
             var name = "Virtual Camera";
             CinemachineEditorAnalytics.SendCreateEvent(name);
-            var vcam = CinemachineMenu.CreateCinemachineGameObject<CinemachineVirtualCamera>(name, null, false);
+            var vcam = CinemachineMenu.CreatePassiveVirtualCamera(name, null, false);
             vcam.m_StandbyUpdate = CinemachineVirtualCameraBase.StandbyUpdateMode.Never;
 
 #if false 
@@ -150,7 +150,7 @@ using Cinemachine;
                 rect.x += rect.width; rect.width = createSize.x;
                 if (GUI.Button(rect, createLabel))
                 {
-                    vcam = CreateStaticVcamFromSceneView();
+                    vcam = CreatePassiveVcamFromSceneView();
                     vcamProperty.exposedReferenceValue = vcam;
                 }
                 serializedObject.ApplyModifiedProperties();

--- a/Editor/Timeline/CinemachineShotEditor.cs
+++ b/Editor/Timeline/CinemachineShotEditor.cs
@@ -53,7 +53,7 @@ using Cinemachine;
 
         static public CinemachineVirtualCameraBase CreateStaticVcamFromSceneView()
         {
-            CinemachineVirtualCameraBase vcam = CinemachineMenu.CreateStaticVirtualCamera();
+            CinemachineVirtualCameraBase vcam = CinemachineMenu.CreateCinemachineGameObject<CinemachineVirtualCamera>("Virtual Camera", null, false);
             vcam.m_StandbyUpdate = CinemachineVirtualCameraBase.StandbyUpdateMode.Never;
 
 #if false 

--- a/Editor/Timeline/CinemachineShotEditor.cs
+++ b/Editor/Timeline/CinemachineShotEditor.cs
@@ -52,8 +52,7 @@ using Cinemachine;
 #endif
 
         static public CinemachineVirtualCameraBase CreatePassiveVcamFromSceneView()
-       {
-            CinemachineEditorAnalytics.SendCreateEvent("Virtual Camera");
+        {
             var vcam = CinemachineMenu.CreatePassiveVirtualCamera("Virtual Camera", null, false);
             vcam.m_StandbyUpdate = CinemachineVirtualCameraBase.StandbyUpdateMode.Never;
 

--- a/Editor/Utility/InspectorUtility.cs
+++ b/Editor/Utility/InspectorUtility.cs
@@ -143,6 +143,19 @@ namespace Cinemachine.Editor
             }
         }
 
+        // Temporarily here
+        /// <summary>
+        /// Creates a new GameObject.
+        /// </summary>
+        /// <param name="name">Name to give the object.</param>
+        /// <param name="types">Optional components to add.</param>
+        /// <returns>The GameObject that was created.</returns>
+        [Obsolete("Use ObjectFactory.CreateGameObject(string name, params Type[] types) instead.")]
+        public static GameObject CreateGameObject(string name, params Type[] types)
+        {
+            return ObjectFactory.CreateGameObject(name, types);
+        }
+
         /// <summary>
         /// Force a repaint of the Game View
         /// </summary>

--- a/Editor/Utility/InspectorUtility.cs
+++ b/Editor/Utility/InspectorUtility.cs
@@ -143,18 +143,6 @@ namespace Cinemachine.Editor
             }
         }
 
-        // Temporarily here
-        /// <summary>
-        /// Create a game object.  Uses ObjectFactory if the Unity version is sufficient.
-        /// </summary>
-        /// <param name="name">Name to give the object</param>
-        /// <param name="types">Optional components to add</param>
-        /// <returns></returns>
-        public static GameObject CreateGameObject(string name, params Type[] types)
-        {
-            return ObjectFactory.CreateGameObject(name, types);
-        }
-
         /// <summary>
         /// Force a repaint of the Game View
         /// </summary>

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -133,7 +133,7 @@ namespace Cinemachine
         public int BrainCount { get { return mActiveBrains.Count; } }
 
         /// <summary>Access the array of active CinemachineBrains in the scene
-        /// without gebnerating garbage</summary>
+        /// without generating garbage</summary>
         /// <param name="index">Index of the brain to access, range 0-BrainCount</param>
         /// <returns>The brain at the specified index</returns>
         public CinemachineBrain GetActiveBrain(int index)


### PR DESCRIPTION
### Purpose of this PR
The current implementation used to create Cinemachine Cameras in the Hierarchy is inconsistent with the rest of Unity. This leads to Cinemachine feeling lower quality and some things to not produce the expected result.
Main changes
- Names of created objects are now consistent with the rest of Unity. Example being "Vcam" is now "Virtual Camera".
- Duplicate names of created objects is now consistent with the rest of Unity. Example being "Vcam1" is now "Virtual Camera (1)". This will also support the "Game Object Naming" scheme setting option that is present in newer versions of Unity.
- It is now easier to add more options to the menu later with less boilerplate and places for failure.

### Testing status
Manually used each menu item and ensured that the resulting GameObjects and components are the same as the current implementation.
Each menu item was manually tested with both undo and redo.

- [x] Manually tested 

### Documentation status

- [x] Commented all public classes, properties, and methods

### Technical risk
There were definitions for versions < 2019.3 which were removed as the minimum Unity version for the package is 2019.4. This should not cause any problems but worth mentioning.

~`CinemachineEditorAnalytics.SendCreateEvent(string name)` is now sent for each object that is created instead of per menu item. The name that is sent is also the same as the non-unique name of the object that is created. 
This results in slightly less specific names for the events, and a slightly higher number. I don't suspect that this will be a problem, but is a significant enough change that it is worth mentioning.~

### Comments to reviewers
Currently names of created GameObjects are the same as the menu items, but perhaps they would be better being more explicit? For example "Mixing Virtual Camera" instead of "Mixing Camera", however doing so does make the names relatively longer.
~The "2D Camera" item also creates a GameObject called "2D Camera", I'm not sure if it would be better to just call it "Virtual Camera" instead like it was.~