### PR TITLE
CMCL-537: Lookahead Time does not work in v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Input system should be read only once per render frame.
 - Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
 - Bugfix: Improve accuracy of Group Framing.
+- Regression fix: Lookahead works again.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("com.unity.cinemachine.editor")]
-[assembly: InternalsVisibleTo("com.unity.cinemachine.tests")]
+[assembly: InternalsVisibleTo("Cinemachine.Tests")]

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -335,7 +335,7 @@ namespace Cinemachine
 
         /// <summary>State information for damping</summary>
         Vector3 m_PreviousCameraPosition = Vector3.zero;
-        PositionPredictor m_Predictor = new PositionPredictor();
+        internal PositionPredictor m_Predictor = new PositionPredictor();
 
         /// <summary>Internal API for inspector</summary>
         public Vector3 TrackedPoint { get; private set; }

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -789,7 +789,7 @@ namespace Cinemachine
         protected void UpdateTargetCache()
         {
             var target = ResolveFollow(Follow);
-            FollowTargetChanged |= target != m_CachedFollowTarget;
+            FollowTargetChanged = target != m_CachedFollowTarget;
             if (FollowTargetChanged)
             {
                 m_CachedFollowTarget = target;
@@ -802,7 +802,7 @@ namespace Cinemachine
                 }
             }
             target = ResolveLookAt(LookAt);
-            LookAtTargetChanged |= target != m_CachedLookAtTarget;
+            LookAtTargetChanged = target != m_CachedLookAtTarget;
             if (LookAtTargetChanged)
             {
                 m_CachedLookAtTarget = target;

--- a/Tests/Runtime/LookaheadTests.cs
+++ b/Tests/Runtime/LookaheadTests.cs
@@ -9,7 +9,7 @@ namespace Tests.Runtime
     [TestFixture]
     public class LookaheadTests : CinemachineFixtureBase
     {
-        CinemachineVirtualCamera m_SourceVCam;
+        CinemachineVirtualCamera m_VCam;
         CinemachineComposer m_Composer;
         CinemachineFramingTransposer m_FramingTransposer;
         Transform m_Target;
@@ -22,12 +22,11 @@ namespace Tests.Runtime
             m_Target = CreateGameObject("Target Object").transform;
 
             // Source vcam
-            m_SourceVCam = CreateGameObject("Source CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
-            m_SourceVCam.Priority = 2;
-            m_SourceVCam.Follow = m_Target;
-            m_SourceVCam.LookAt = m_Target;
-            m_FramingTransposer = m_SourceVCam.AddCinemachineComponent<CinemachineFramingTransposer>();
-            m_Composer = m_SourceVCam.AddCinemachineComponent<CinemachineComposer>();
+            m_VCam = CreateGameObject("Source CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            m_VCam.Follow = m_Target;
+            m_VCam.LookAt = m_Target;
+            m_FramingTransposer = m_VCam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            m_Composer = m_VCam.AddCinemachineComponent<CinemachineComposer>();
             m_FramingTransposer.m_LookaheadSmoothing = m_Composer.m_LookaheadSmoothing = 0.3f;
             m_FramingTransposer.m_LookaheadTime = m_Composer.m_LookaheadTime = 10;
 
@@ -37,42 +36,40 @@ namespace Tests.Runtime
         [UnityTest]
         public IEnumerator TargetsChanged()
         {
-            yield return null;
-            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
-            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
 
             yield return null;
-            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
-            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
             
             var newTarget = CreateGameObject("Target Object 2").transform;
-            m_SourceVCam.LookAt = newTarget;
+            m_VCam.LookAt = newTarget;
 
-            yield return null; // wait until next frame
+            yield return null;
             
-            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
-            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.True);
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.True);
 
-            m_SourceVCam.Follow = newTarget;
+            m_VCam.Follow = newTarget;
 
-            yield return null; // wait until next frame
+            yield return null;
             
-            Assert.That(m_SourceVCam.FollowTargetChanged, Is.True);
-            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+            Assert.That(m_VCam.FollowTargetChanged, Is.True);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
 
-            m_SourceVCam.Follow = m_Target;
-            m_SourceVCam.LookAt = m_Target;
+            m_VCam.Follow = m_Target;
+            m_VCam.LookAt = m_Target;
 
-            yield return null; // wait until next frame
+            yield return null;
             
-            Assert.That(m_SourceVCam.FollowTargetChanged, Is.True);
-            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.True);
+            Assert.That(m_VCam.FollowTargetChanged, Is.True);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.True);
         }
 
         [UnityTest]
         public IEnumerator LookaheadDelta()
         {
-            yield return null;
             var delta = m_Composer.m_Predictor.PredictPositionDelta(m_Composer.m_LookaheadTime);
             Assert.That(delta.sqrMagnitude > 0, Is.False);
             

--- a/Tests/Runtime/LookaheadTests.cs
+++ b/Tests/Runtime/LookaheadTests.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Cinemachine;
+
+namespace Tests.Runtime
+{
+    [TestFixture]
+    public class LookaheadTests : CinemachineFixtureBase
+    {
+        CinemachineVirtualCamera m_SourceVCam;
+        CinemachineComposer m_Composer;
+        CinemachineFramingTransposer m_FramingTransposer;
+        Transform m_Target;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            // Camera
+            CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain));
+            m_Target = CreateGameObject("Target Object").transform;
+
+            // Source vcam
+            m_SourceVCam = CreateGameObject("Source CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            m_SourceVCam.Priority = 2;
+            m_SourceVCam.Follow = m_Target;
+            m_SourceVCam.LookAt = m_Target;
+            m_FramingTransposer = m_SourceVCam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            m_Composer = m_SourceVCam.AddCinemachineComponent<CinemachineComposer>();
+            m_FramingTransposer.m_LookaheadSmoothing = m_Composer.m_LookaheadSmoothing = 0.3f;
+            m_FramingTransposer.m_LookaheadTime = m_Composer.m_LookaheadTime = 10;
+
+            base.SetUp();
+        }
+
+        [UnityTest]
+        public IEnumerator TargetsChanged()
+        {
+            yield return null;
+            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
+            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+
+            yield return null;
+            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
+            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+            
+            var newTarget = CreateGameObject("Target Object 2").transform;
+            m_SourceVCam.LookAt = newTarget;
+
+            yield return null; // wait until next frame
+            
+            Assert.That(m_SourceVCam.FollowTargetChanged, Is.False);
+            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.True);
+
+            m_SourceVCam.Follow = newTarget;
+
+            yield return null; // wait until next frame
+            
+            Assert.That(m_SourceVCam.FollowTargetChanged, Is.True);
+            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.False);
+
+            m_SourceVCam.Follow = m_Target;
+            m_SourceVCam.LookAt = m_Target;
+
+            yield return null; // wait until next frame
+            
+            Assert.That(m_SourceVCam.FollowTargetChanged, Is.True);
+            Assert.That(m_SourceVCam.LookAtTargetChanged, Is.True);
+        }
+
+        [UnityTest]
+        public IEnumerator LookaheadDelta()
+        {
+            yield return null;
+            var delta = m_Composer.m_Predictor.PredictPositionDelta(m_Composer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.False);
+            
+            delta = m_FramingTransposer.m_Predictor.PredictPositionDelta(m_FramingTransposer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.False);
+            
+            m_Target.Translate(10, 0, 0);
+            yield return null;
+            
+            delta = m_Composer.m_Predictor.PredictPositionDelta(m_Composer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.True);
+            
+            delta = m_FramingTransposer.m_Predictor.PredictPositionDelta(m_FramingTransposer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.True);
+        }
+    }
+}

--- a/Tests/Runtime/LookaheadTests.cs.meta
+++ b/Tests/Runtime/LookaheadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f519ca69bd041a48f57459cc0388d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

Fix lookahead + add unit test for the related error.
https://jira.unity3d.com/browse/CMCL-538?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D

### Testing status

- [ x ] Added an automated test
- [ x ] Passed all automated tests
- [ x ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ x ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk


### Comments to reviewers

### Package version

- [ ] Updated package version
