### PR TITLE
CMCL-353: No Undo, instead using serializedObject

### DIFF
--- a/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -89,16 +89,20 @@ namespace Cinemachine.Editor
                     HandleUtility.GetHandleSize(camPos) / 10f, Handles.CubeHandleCap, 0.5f);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    Undo.RecordObject(thirdPerson, "Changed 3rdPersonFollow offsets using handle in Scene View.");
-
-                    thirdPerson.ShoulderOffset += 
+                    // Modify via SerializedProperty for OnValidate to get called automatically, and scene repainting too
+                    var so = new SerializedObject(thirdPerson);
+                    
+                    var shoulderOffset = so.FindProperty(() => thirdPerson.ShoulderOffset);
+                    shoulderOffset.vector3Value += 
                         CinemachineSceneToolHelpers.PositionHandleDelta(heading, newShoulderPosition, shoulderPosition);
-                    thirdPerson.VerticalArmLength += 
+                    var verticalArmLength = so.FindProperty(() => thirdPerson.VerticalArmLength);
+                    verticalArmLength.floatValue += 
                         CinemachineSceneToolHelpers.SliderHandleDelta(newArmPosition, armPosition, followUp);
-                    thirdPerson.CameraDistance -= 
+                    var cameraDistance = so.FindProperty(() => thirdPerson.CameraDistance);
+                    cameraDistance.floatValue -= 
                         CinemachineSceneToolHelpers.SliderHandleDelta(newCamPos, camPos, targetForward);
-
-                    InspectorUtility.RepaintGameView();
+                    
+                    so.ApplyModifiedProperties();
                 }
 
                 var isDragged = IsHandleDragged(sHandleMinId, sHandleMaxId, shoulderPosition, "Shoulder Offset " 

--- a/Editor/Editors/CinemachineFramingTransposerEditor.cs
+++ b/Editor/Editors/CinemachineFramingTransposerEditor.cs
@@ -252,14 +252,11 @@ namespace Cinemachine.Editor
                     HandleUtility.GetHandleSize(camPos) / 10f, Handles.CubeHandleCap, 0.5f);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    Undo.RecordObject(framingTransposer, 
-                        "Changed FramingTransposer distance using handle in Scene View.");
-                    
-                    framingTransposer.m_CameraDistance -= 
-                        CinemachineSceneToolHelpers.SliderHandleDelta(newHandlePosition, camPos, targetForward);
-                    framingTransposer.OnValidate();
-                    
-                    InspectorUtility.RepaintGameView();
+                    // Modify via SerializedProperty for OnValidate to get called automatically, and scene repainting too
+                    var so = new SerializedObject(framingTransposer);
+                    var prop = so.FindProperty(() => framingTransposer.m_CameraDistance);
+                    prop.floatValue -= CinemachineSceneToolHelpers.SliderHandleDelta(newHandlePosition, camPos, targetForward);
+                    so.ApplyModifiedProperties();
                 }
 
                 var cameraDistanceHandleIsDragged = GUIUtility.hotControl == cdHandleId;

--- a/Editor/Editors/CinemachineFreeLookEditor.cs
+++ b/Editor/Editors/CinemachineFreeLookEditor.cs
@@ -150,8 +150,12 @@ namespace Cinemachine
             }
             else if (freelook.Follow != null && CinemachineSceneToolUtility.IsToolActive(typeof(FollowOffsetTool)))
             {
-                CinemachineSceneToolHelpers.OrbitControlHandle(freelook, 
-                    ref freelook.m_Orbits, ref s_SelectedRig);
+                var so = new SerializedObject(freelook);
+                var orbits = so.FindProperty(() => freelook.m_Orbits);
+                if (CinemachineSceneToolHelpers.OrbitControlHandle(freelook, orbits, ref s_SelectedRig))
+                {
+                    so.ApplyModifiedProperties();
+                }
             }
             Handles.color = originalColor;
         }

--- a/Editor/Experimental/CinemachineNewFreeLookEditor.cs
+++ b/Editor/Experimental/CinemachineNewFreeLookEditor.cs
@@ -197,22 +197,11 @@ namespace Cinemachine
             }
             else if (newFreelook.Follow != null && CinemachineSceneToolUtility.IsToolActive(typeof(FollowOffsetTool)))
             {
-                // convert newFreelook orbits to freelook orbits
-                var tempOrbits = new CinemachineFreeLook.Orbit[newFreelook.m_Orbits.Length];
-                for (var i = 0; i < newFreelook.m_Orbits.Length; ++i)
+                var so = new SerializedObject(newFreelook);
+                var orbits = so.FindProperty(() => newFreelook.m_Orbits);
+                if (CinemachineSceneToolHelpers.OrbitControlHandle(newFreelook, orbits, ref s_SelectedRig))
                 {
-                    tempOrbits[i].m_Height = newFreelook.m_Orbits[i].m_Height;
-                    tempOrbits[i].m_Radius = newFreelook.m_Orbits[i].m_Radius;
-                }
-            
-                CinemachineSceneToolHelpers.OrbitControlHandle(newFreelook, 
-                    ref tempOrbits, ref s_SelectedRig);
-            
-                // copy freelook orbit values back to new freelook
-                for (var i = 0; i < newFreelook.m_Orbits.Length; ++i)
-                {
-                    newFreelook.m_Orbits[i].m_Height = tempOrbits[i].m_Height;
-                    newFreelook.m_Orbits[i].m_Radius = tempOrbits[i].m_Radius;
+                    so.ApplyModifiedProperties();
                 }
             }
             Handles.color = originalColor;


### PR DESCRIPTION
I am not sure if this is better. In some ways, it is, in some it is not.

What do you think?
I would need to do the same for FoV, NearClipFarClip, and TrackedObjectOffset. 
I would need to pass lens as a SerializedProperty for the first two, and trackedObjectOffset as a SerializedProperty for the last.

These:
Undo.RecordObject(vcam, "Changed clip plane using handle in scene view.");
Undo.RecordObject(vcam, "Changed FOV using handle in scene view.");
Undo.RecordObject(cmComponent, "Change Tracked Object Offset using handle in Scene View.");
