### PR TITLE
CMCL-589: bumped version to 2.9.0-pre.1 and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [2.9.0-pre.1] - 2021-10-26
 - Added ability to directly set the active blend in CinemachineBrain.
 - Bugfix: OnTargetObjectWarped() did not work properly for 3rdPersonFollow.
 - Bugfix: POV did not properly handle overridden up.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,12 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.9.0-exp.1",
+    "version": "2.9.0-pre.1",
     "unity": "2019.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],
     "category": "cinematography",
     "dependencies": {
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Unity-Technologies/upm-package-cinemachine",
-        "revision": "679387cb1fa822190b530bdbb8ea0945f508b5f6"
     },
     "samples": [
         {


### PR DESCRIPTION
### Purpose of this PR

Prep for 2.9.0-pre.1: bumps version and updates changelog.

### Testing status

- [X] Automated tests pass
- [X] Manually tested 

### Documentation status

- [X] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated user documentation

### Technical risk

Low.

### Package version

- [X] Updated package version to 2.9.0-pre.1 - new features, new API
