### PR TITLE
EAD-312: Moved initialization code using assets to OnPostprocessAllAssets callback

### DIFF
--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -8,9 +8,25 @@ using System;
 
 namespace Cinemachine.Editor
 {
+#if !UNITY_2021_2_OR_NEWER
     [InitializeOnLoad]
     internal sealed class CinemachineSettings
+#else
+    internal sealed class CinemachineSettings : AssetPostprocessor
+#endif
+    
     {
+
+#if UNITY_2021_2_OR_NEWER
+        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+        {
+            if (didDomainReload)
+            {
+                EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyGUI;
+            }
+        }
+#endif
+
         public static class CinemachineCoreSettings
         {
             private static readonly string hShowInGameGuidesKey = "CNMCN_Core_ShowInGameGuides";
@@ -256,6 +272,7 @@ namespace Cinemachine.Editor
 
         internal static event Action AdditionalCategories = null;
 
+#if !UNITY_2021_2_OR_NEWER
         [InitializeOnLoadMethod]
         /// Ensures that CM Brain logo is added to the Main Camera
         /// after adding a virtual camera to the project for the first time
@@ -280,6 +297,7 @@ namespace Cinemachine.Editor
                 EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyGUI;
             }
         }
+#endif
 
         class Styles {
             //private static readonly GUIContent sCoreShowHiddenObjectsToggle = new GUIContent("Show Hidden Objects", "If checked, Cinemachine hidden objects will be shown in the inspector.  This might be necessary to repair broken script mappings when upgrading from a pre-release version");


### PR DESCRIPTION
### Purpose of this PR

This PR moves initialization code using assets from InitializeOnLoad to OnPostprocessAllAssets. This is done to prepare for an upcoming change in trunk, which will make unity report errors, when asset operations are done in InitializeOnLoad.

A new variant of OnPostprocessAllAssets has been introduced in 2021.2 and is used in this PR.

### Testing status

- [x ] Passed all automated tests

### Documentation status

Changes where initialization is done - no need for doc update.

### Technical risk

Low risk - minor change. This PR should not change any behaviour.