### PR TITLE
CMCL-339: Near Clip Plane negative value not kept if override not set to Orthographic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New feature: Added scene view overlay tools for Cinemachine components.
 - Regression fix: Lookahead works again.
 - Cinemachine3rdPersonAim exposes AimTarget, which is the position of where the player would hit.
+- Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -385,6 +385,7 @@ namespace Cinemachine.Editor
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(Target);
             if (brain != null)
                 camera = brain.OutputCamera;
+            
             m_LensSettingsInspectorHelper.SnapshotCameraShadowValues(property, camera);
 
             m_LensSettingsInspectorHelper.DrawLensSettingsInInspector(property);
@@ -449,7 +450,7 @@ namespace Cinemachine.Editor
 
             // Assume lens is up-to-date
             UseHorizontalFOV = false;
-            object lensObject = SerializedPropertyHelper.GetPropertyValue(property);
+            var lensObject = SerializedPropertyHelper.GetPropertyValue(property);
             IsOrtho = AccessProperty<bool>(typeof(LensSettings), lensObject, "Orthographic");
             IsPhysical = AccessProperty<bool>(typeof(LensSettings), lensObject, "IsPhysicalCamera");
             SensorSize = AccessProperty<Vector2>(typeof(LensSettings), lensObject, "SensorSize");
@@ -470,6 +471,13 @@ namespace Cinemachine.Editor
                     IsPhysical = camera.usePhysicalProperties;
                     SensorSize = IsPhysical ? camera.sensorSize : new Vector2(camera.aspect, 1f);
                 }
+            }
+            
+            var nearClipPlaneProperty = property.FindPropertyRelative("NearClipPlane");
+            if (!IsOrtho)
+            {
+                nearClipPlaneProperty.floatValue = Mathf.Max(nearClipPlaneProperty.floatValue, 0.001f);
+                property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
             }
         }
 

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -102,8 +102,7 @@ namespace Cinemachine
         /// </summary>
         public bool Orthographic 
         { 
-            get => 
-                ModeOverride == OverrideModes.Orthographic || ModeOverride == OverrideModes.None && m_OrthoFromCamera;
+            get => ModeOverride == OverrideModes.Orthographic || ModeOverride == OverrideModes.None && m_OrthoFromCamera;
 
             /// Obsolete: do not use
             set { m_OrthoFromCamera = value; ModeOverride = value 

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -103,7 +103,7 @@ namespace Cinemachine
         public bool Orthographic 
         { 
             get { return ModeOverride == OverrideModes.Orthographic
-                || ModeOverride == OverrideModes.None && m_OrthoFromCamera; } 
+                || ModeOverride == OverrideModes.None && (!m_OrthoPulledFromCamera || m_OrthoFromCamera); } 
 
             /// Obsolete: do not use
             set { m_OrthoFromCamera = value; ModeOverride = value 
@@ -150,6 +150,7 @@ namespace Cinemachine
 
         [SerializeField]
         Vector2 m_SensorSize;
+        bool m_OrthoPulledFromCamera;
         bool m_OrthoFromCamera;
         bool m_PhysicalFromCamera;
 
@@ -222,6 +223,7 @@ namespace Cinemachine
             if (camera != null && ModeOverride == OverrideModes.None)
             {
                 m_OrthoFromCamera = camera.orthographic;
+                m_OrthoPulledFromCamera = true;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
                 m_SensorSize = camera.sensorSize;
                 GateFit = camera.gateFit;

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -102,8 +102,8 @@ namespace Cinemachine
         /// </summary>
         public bool Orthographic 
         { 
-            get { return ModeOverride == OverrideModes.Orthographic
-                || ModeOverride == OverrideModes.None && (!m_OrthoPulledFromCamera || m_OrthoFromCamera); } 
+            get => 
+                ModeOverride == OverrideModes.Orthographic || ModeOverride == OverrideModes.None && m_OrthoFromCamera;
 
             /// Obsolete: do not use
             set { m_OrthoFromCamera = value; ModeOverride = value 
@@ -150,7 +150,6 @@ namespace Cinemachine
 
         [SerializeField]
         Vector2 m_SensorSize;
-        bool m_OrthoPulledFromCamera;
         bool m_OrthoFromCamera;
         bool m_PhysicalFromCamera;
 
@@ -223,7 +222,6 @@ namespace Cinemachine
             if (camera != null && ModeOverride == OverrideModes.None)
             {
                 m_OrthoFromCamera = camera.orthographic;
-                m_OrthoPulledFromCamera = true;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
                 m_SensorSize = camera.sensorSize;
                 GateFit = camera.gateFit;
@@ -327,8 +325,6 @@ namespace Cinemachine
         /// <summary>Make sure lens settings are sane.  Call this from OnValidate().</summary>
         public void Validate()
         {
-            if (!Orthographic)
-                NearClipPlane = Mathf.Max(NearClipPlane, 0.001f);
             FarClipPlane = Mathf.Max(FarClipPlane, NearClipPlane + 0.001f);
             FieldOfView = Mathf.Clamp(FieldOfView, 0.01f, 179f);
             m_SensorSize.x = Mathf.Max(m_SensorSize.x, 0.1f);


### PR DESCRIPTION
### Purpose of this PR

Fix for https://jira.unity3d.com/browse/CMCL-339

Fix:
- Validate near clip plane when pulling values from camera.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
