### PR TITLE
CMCL-608: cannot change camera projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+- Regression fix: could not change the projection of the main camera if a CM virtual camera is active
+
 ## [2.9.0-pre.1] - 2021-10-26
 - Added ability to directly set the active blend in CinemachineBrain.
 - Bugfix: OnTargetObjectWarped() did not work properly for 3rdPersonFollow.

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -941,7 +941,8 @@ namespace Cinemachine
                     cam.orthographicSize = state.Lens.OrthographicSize;
                     cam.fieldOfView = state.Lens.FieldOfView;
                     cam.lensShift = state.Lens.LensShift;
-                    cam.orthographic = state.Lens.Orthographic;
+                    if (state.Lens.ModeOverride != LensSettings.OverrideModes.None)
+                        cam.orthographic = state.Lens.Orthographic;
                     bool isPhysical = state.Lens.ModeOverride == LensSettings.OverrideModes.None 
                         ? cam.usePhysicalProperties : state.Lens.IsPhysicalCamera;
                     cam.usePhysicalProperties = isPhysical;


### PR DESCRIPTION
### Purpose of this PR

dev/CMCL-608: cannot change camera projection if vcam present

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

