### PR TITLE
CMCL-339: Near Clip Plane negative value not kept if override not set to Orthographic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Input system should be read only once per render frame.
 - Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
 - Bugfix: Improve accuracy of Group Framing.
+- Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -375,6 +375,7 @@ namespace Cinemachine.Editor
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(Target);
             if (brain != null)
                 camera = brain.OutputCamera;
+            
             m_LensSettingsInspectorHelper.SnapshotCameraShadowValues(property, camera);
 
             m_LensSettingsInspectorHelper.DrawLensSettingsInInspector(property);
@@ -439,7 +440,7 @@ namespace Cinemachine.Editor
 
             // Assume lens is up-to-date
             UseHorizontalFOV = false;
-            object lensObject = SerializedPropertyHelper.GetPropertyValue(property);
+            var lensObject = SerializedPropertyHelper.GetPropertyValue(property);
             IsOrtho = AccessProperty<bool>(typeof(LensSettings), lensObject, "Orthographic");
             IsPhysical = AccessProperty<bool>(typeof(LensSettings), lensObject, "IsPhysicalCamera");
             SensorSize = AccessProperty<Vector2>(typeof(LensSettings), lensObject, "SensorSize");
@@ -460,6 +461,13 @@ namespace Cinemachine.Editor
                     IsPhysical = camera.usePhysicalProperties;
                     SensorSize = IsPhysical ? camera.sensorSize : new Vector2(camera.aspect, 1f);
                 }
+            }
+            
+            var nearClipPlaneProperty = property.FindPropertyRelative("NearClipPlane");
+            if (!IsOrtho)
+            {
+                nearClipPlaneProperty.floatValue = Mathf.Max(nearClipPlaneProperty.floatValue, 0.001f);
+                property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
             }
         }
 

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -102,8 +102,7 @@ namespace Cinemachine
         /// </summary>
         public bool Orthographic 
         { 
-            get { return ModeOverride == OverrideModes.Orthographic
-                || ModeOverride == OverrideModes.None && m_OrthoFromCamera; } 
+            get => ModeOverride == OverrideModes.Orthographic || ModeOverride == OverrideModes.None && m_OrthoFromCamera;
 
             /// Obsolete: do not use
             set { m_OrthoFromCamera = value; ModeOverride = value 
@@ -325,8 +324,6 @@ namespace Cinemachine
         /// <summary>Make sure lens settings are sane.  Call this from OnValidate().</summary>
         public void Validate()
         {
-            if (!Orthographic)
-                NearClipPlane = Mathf.Max(NearClipPlane, 0.001f);
             FarClipPlane = Mathf.Max(FarClipPlane, NearClipPlane + 0.001f);
             FieldOfView = Mathf.Clamp(FieldOfView, 0.01f, 179f);
             m_SensorSize.x = Mathf.Max(m_SensorSize.x, 0.1f);


### PR DESCRIPTION
Backport for https://jira.unity3d.com/browse/CMCL-339

Main PR: https://github.com/Unity-Technologies/com.unity.cinemachine/pull/336