### PR TITLE
CMCL-616: added .github and .gitattributes to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,5 @@ upm-ci~/**
 TestRunnerOptions.json
 .idea/**
 upm-ci.log
+.gitattributes/**
+.github/**


### PR DESCRIPTION
### Purpose of this PR

Hide .gitattributes and .github from npm so they don't end up in the package.
Also remove old license.txt file (replaced by LICENSE.md)