### PR TITLE
CMCL-622: Axis input shouldn't ignore IgnoreTimeScale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
-- Regression fix: could not change the projection of the main camera if a CM virtual camera is active
+- Regression fix: could not change the projection of the main camera if a CM virtual camera is active.
+- Regression fix: Axis input was ignoring CM's IgnoreTimeScale setting.
+- 
 
 ## [2.9.0-pre.1] - 2021-10-26
 - Added ability to directly set the active blend in CinemachineBrain.

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -197,11 +197,11 @@ namespace Cinemachine
         public bool HasInputProvider { get => m_InputAxisProvider != null; }
 
         /// <summary>
-        /// Updates the state of this axis based on the axis defined
+        /// Updates the state of this axis based on the Input axis defined
         /// by AxisState.m_AxisName
         /// </summary>
         /// <param name="deltaTime">Delta time in seconds</param>
-        /// <returns>Returns <b>true</b> if this axis' input was non-zero this Update,
+        /// <returns>Returns <b>true</b> if this axis's input was non-zero this Update,
         /// <b>false</b> otherwise</returns>
         public bool Update(float deltaTime)
         {
@@ -213,9 +213,9 @@ namespace Cinemachine
             // Cheating: we want the render frame time, not the fixed frame time
             if (CinemachineCore.UniformDeltaTimeOverride >= 0)
                 deltaTime = CinemachineCore.UniformDeltaTimeOverride; 
-            else if (deltaTime >= 0 && m_LastUpdateTime != 0)
-                deltaTime = Time.time - m_LastUpdateTime;
-            m_LastUpdateTime = Time.time;
+            else if (Time.inFixedTimeStep && deltaTime >= 0 && m_LastUpdateTime != 0)
+                deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
+            m_LastUpdateTime = Time.realtimeSinceStartup;
             
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);


### PR DESCRIPTION
### Purpose of this PR

CMCL-622: Axis input shouldn't ignore IgnoreTimeScale

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
