### PR TITLE
CMCL-517: Support for input system in the samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 - Regression fix: could not change the projection of the main camera if a CM virtual camera is active.
 - Regression fix: Axis input was ignoring CM's IgnoreTimeScale setting.
-- Bugfix: Cinemachine assigns a default input controller delegate that returns 0 when Input System is present.
+- Bugfix: Cinemachine assigns a default input controller delegate that returns 0 when the legacy input system is disabled.
 - Cinemachine example scenes show informative text when used with Input System instead of throwing error messages.
 
 ## [2.9.0-pre.1] - 2021-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 - Regression fix: could not change the projection of the main camera if a CM virtual camera is active.
 - Regression fix: Axis input was ignoring CM's IgnoreTimeScale setting.
-- 
+- Bugfix: Cinemachine assigns a default input controller delegate that returns 0 when Input System is present.
+- Cinemachine example scenes show informative text when used with Input System instead of throwing error messages.
 
 ## [2.9.0-pre.1] - 2021-10-26
 - Added ability to directly set the active blend in CinemachineBrain.

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -219,11 +219,13 @@ namespace Cinemachine
             
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);
+#if ENABLE_LEGACY_INPUT_MANAGER
             else if (!string.IsNullOrEmpty(m_InputAxisName))
             {
                 try { m_InputAxisValue = CinemachineCore.GetInputAxis(m_InputAxisName); }
                 catch (ArgumentException e) { Debug.LogError(e.ToString()); }
             }
+#endif
 
             float input = m_InputAxisValue;
             if (m_InvertInput)

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -219,13 +219,11 @@ namespace Cinemachine
             
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);
-#if ENABLE_LEGACY_INPUT_MANAGER
             else if (!string.IsNullOrEmpty(m_InputAxisName))
             {
                 try { m_InputAxisValue = CinemachineCore.GetInputAxis(m_InputAxisName); }
                 catch (ArgumentException e) { Debug.LogError(e.ToString()); }
             }
-#endif
 
             float input = m_InputAxisValue;
             if (m_InvertInput)

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -75,7 +75,7 @@ namespace Cinemachine
 #if ENABLE_LEGACY_INPUT_MANAGER
         public static AxisInputDelegate GetInputAxis = UnityEngine.Input.GetAxis;
 #else
-        public static AxisInputDelegate GetInputAxis = null;
+        public static AxisInputDelegate GetInputAxis = delegate { return 0; };
 #endif
 
         /// <summary>

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -72,7 +72,11 @@ namespace Cinemachine
         /// <summary>Delegate for overriding Unity's default input system.
         /// If you set this, then your delegate will be called instead of
         /// System.Input.GetAxis(axisName) whenever in-game user input is needed.</summary>
+#if ENABLE_LEGACY_INPUT_MANAGER
         public static AxisInputDelegate GetInputAxis = UnityEngine.Input.GetAxis;
+#else
+        public static AxisInputDelegate GetInputAxis = null;
+#endif
 
         /// <summary>
         /// If non-negative, cinemachine will update with this uniform delta time.

--- a/Samples~/Cinemachine Example Scenes.meta
+++ b/Samples~/Cinemachine Example Scenes.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cdb4a4a1e25180c4aaaa32ceb3ca4280
+guid: 8febee9c7b10e4ecb942ac1d6feb4ab4
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Samples~/Cinemachine Example Scenes/Scenes/2D/MouseScrollZoom2D.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/2D/MouseScrollZoom2D.cs
@@ -48,8 +48,12 @@ namespace Cinemachine.Examples
 
         void Update()
         {
+#if ENABLE_LEGACY_INPUT_MANAGER
             float zoom = m_VirtualCamera.m_Lens.OrthographicSize + Input.mouseScrollDelta.y * ZoomMultiplier;
             m_VirtualCamera.m_Lens.OrthographicSize = Mathf.Clamp(zoom, MinZoom, MaxZoom);
+#else
+            InputSystemHelper.EnableBackendsWarningMessage();
+#endif
         }
     }
 }

--- a/Samples~/Cinemachine Example Scenes/Scenes/3rdPersonWithAimMode/ActivateOnKeypress.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/3rdPersonWithAimMode/ActivateOnKeypress.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Cinemachine.Examples;
+using UnityEngine;
 
 public class ActivateOnKeypress : MonoBehaviour
 {
@@ -16,6 +17,7 @@ public class ActivateOnKeypress : MonoBehaviour
 
     void Update()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         if (vcam != null)
         {
             if (Input.GetKey(ActivationKey))
@@ -34,5 +36,8 @@ public class ActivateOnKeypress : MonoBehaviour
         }
         if (Reticle != null)
             Reticle.SetActive(boosted);
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
     }
 }

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.unity
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.49641287, b: 0.5748173, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -212,10 +212,138 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 3.3263245, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &172123695
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 172123696}
+  - component: {fileID: 172123699}
+  - component: {fileID: 172123698}
+  - component: {fileID: 172123697}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &172123696
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 172123695}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1230895536}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &172123697
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 172123695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &172123698
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 172123695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 2.5, z: -3}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &172123699
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 172123695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &226826961
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,8 +391,8 @@ MonoBehaviour:
     Dutch: 0
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
-    GateFit: 0
-    m_SensorSize: {x: 2.3370473, y: 1}
+    GateFit: 2
+    m_SensorSize: {x: 2.098, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 1
@@ -283,6 +411,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10.3, y: 2.6230001, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 153900723451599077}
   - {fileID: 424502139}
@@ -444,6 +573,7 @@ Transform:
   m_LocalRotation: {x: 0.3232659, y: -0.00000007186669, z: 0.000000024550193, w: 0.9463082}
   m_LocalPosition: {x: -4.6440506, y: -3.8999977, z: 3.0482786}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 226826963}
   m_RootOrder: 1
@@ -527,10 +657,294 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1508344078}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &550607600
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 550607601}
+  - component: {fileID: 550607604}
+  - component: {fileID: 550607603}
+  - component: {fileID: 550607602}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &550607601
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550607600}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 587991581}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &550607602
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550607600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &550607603
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550607600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 2.5, z: -3}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &550607604
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550607600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &587991579
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 587991581}
+  - component: {fileID: 587991580}
+  m_Layer: 0
+  m_Name: BottomRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &587991580
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 587991579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2.098, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 550607601}
+--- !u!4 &587991581
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 587991579}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.027835, y: -6.9991746, z: 3.3739662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 550607601}
+  m_Father: {fileID: 1356970872}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &644378120
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 644378122}
+  - component: {fileID: 644378121}
+  m_Layer: 0
+  m_Name: MiddleRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &644378121
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 644378120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2.098, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2072987680}
+--- !u!4 &644378122
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 644378120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.027835, y: -6.9991746, z: 3.3739662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2072987680}
+  m_Father: {fileID: 1356970872}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1134903599
 GameObject:
@@ -602,9 +1016,243 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 8.527199, y: -0.140625, z: -7.5859556}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1230895534
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1230895536}
+  - component: {fileID: 1230895535}
+  m_Layer: 0
+  m_Name: TopRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1230895535
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230895534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  - Header
+  - Extensions
+  - m_Priority
+  - m_Transitions
+  - m_Follow
+  - m_StandbyUpdate
+  - m_Lens
+  m_LockStageInInspector: 00000000
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2.098, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 172123696}
+--- !u!4 &1230895536
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230895534}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.027835, y: -6.9991746, z: 3.3739662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 172123696}
+  m_Father: {fileID: 1356970872}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1356970869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1356970872}
+  - component: {fileID: 1356970871}
+  - component: {fileID: 1356970870}
+  m_Layer: 0
+  m_Name: CM FreeLook1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1356970870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356970869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb7194dc27b9df64c8beca7482ee8e0d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerIndex: -1
+  XYAxis: {fileID: 0}
+  ZAxis: {fileID: 0}
+--- !u!114 &1356970871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356970869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_CommonLens: 1
+  m_Lens:
+    FieldOfView: 40
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2.098, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_YAxis:
+    Value: 0.5
+    m_SpeedMode: 0
+    m_MaxSpeed: 2
+    m_AccelTime: 0.2
+    m_DecelTime: 0.1
+    m_InputAxisName: Mouse Y
+    m_InputAxisValue: 0
+    m_InvertInput: 0
+    m_MinValue: 0
+    m_MaxValue: 1
+    m_Wrap: 0
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_YAxisRecentering:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: Mouse X
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_BindingMode: 5
+  m_SplineCurvature: 0.2
+  m_Orbits:
+  - m_Height: 4.5
+    m_Radius: 1.75
+  - m_Height: 2.5
+    m_Radius: 3
+  - m_Height: 0.4
+    m_Radius: 1.3
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_Rigs:
+  - {fileID: 1230895535}
+  - {fileID: 644378121}
+  - {fileID: 587991580}
+--- !u!4 &1356970872
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356970869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 8.027835, y: 6.9991746, z: -3.3739662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1230895536}
+  - {fileID: 644378122}
+  - {fileID: 587991581}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1493626625
 PrefabInstance:
@@ -742,9 +1390,10 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1787124812}
-  m_LocalRotation: {x: -0.000000032511643, y: -0.0000007369306, z: -2.3958825e-14, w: 1}
-  m_LocalPosition: {x: 10.3, y: 2.6230001, z: -2}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -809,10 +1458,138 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.623, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4921246272369262}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2072987679
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2072987680}
+  - component: {fileID: 2072987683}
+  - component: {fileID: 2072987682}
+  - component: {fileID: 2072987681}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2072987680
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2072987679}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 644378122}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2072987681
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2072987679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.55
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &2072987682
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2072987679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 2.5, z: -3}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &2072987683
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2072987679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1034295081501960
 GameObject:
   m_ObjectHideFlags: 0
@@ -2000,6 +2777,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: -0.04963885, y: 0.11306744, z: -0.029689595}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4910201191786486}
   m_RootOrder: 1
@@ -2014,6 +2792,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.027341224, y: -0.0000001068289, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4562537071338080}
   m_Father: {fileID: 4940479983457288}
@@ -2029,6 +2808,7 @@ Transform:
   m_LocalRotation: {x: 0.000000001217143, y: 0.010789105, z: -0.00000011280568, w: 0.9999418}
   m_LocalPosition: {x: 0.2598076, y: -0.000000058593667, z: 0.0000000065556907}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4578838276210018}
   m_Father: {fileID: 4306490394211684}
@@ -2044,6 +2824,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.032299604, y: -1.2479823e-16, z: -3.2554504e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4690956774275456}
   m_RootOrder: 0
@@ -2058,6 +2839,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.028015258, y: -0.00000006713867, z: -6.120983e-11}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4623383317032384}
   m_Father: {fileID: 4656712348910608}
@@ -2073,6 +2855,7 @@ Transform:
   m_LocalRotation: {x: 1, y: -0.00000080360593, z: -0.00000003485639, w: 0.0000000028799356}
   m_LocalPosition: {x: -0.10144374, y: -0.010422724, z: 0.032279857}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4181935650218516}
   m_Father: {fileID: 4922610750754240}
@@ -2088,6 +2871,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0.00000048059263, z: 0.000000045818194, w: 0.000000002879936}
   m_LocalPosition: {x: -0.09005295, y: -0.01086029, z: -0.033707228}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4253244186624738}
   m_Father: {fileID: 4922610750754240}
@@ -2103,6 +2887,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0.000003907246, z: 7.633312e-12, w: 0.0000019536299}
   m_LocalPosition: {x: 0.101765, y: 0.0092, z: -0.0076735197}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4123188799949912}
   m_Father: {fileID: 4578838276210018}
@@ -2118,6 +2903,7 @@ Transform:
   m_LocalRotation: {x: 0.0000027608096, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.038115, y: 0.00000029784886, z: 1.164116e-12}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4387490760862814}
   m_Father: {fileID: 4094310770169538}
@@ -2133,6 +2919,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.16252996, w: 0.98670363}
   m_LocalPosition: {x: -0.22944902, y: 0, z: 3.8648323e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4910201191786486}
   m_Father: {fileID: 4249977530399418}
@@ -2148,6 +2935,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.0763707, y: 0.0041095037, z: 1.3457705e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4433167837323158}
   m_Father: {fileID: 4395714782842420}
@@ -2163,6 +2951,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.03038064, y: 0.000000024414062, z: 0.0000000010589601}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4374627063963924}
   m_Father: {fileID: 4067341440938288}
@@ -2178,6 +2967,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.031395752, y: -0.00000016593874, z: 0.00000001956757}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4394862387420100}
   m_Father: {fileID: 4718307535146354}
@@ -2193,6 +2983,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0.0000009611853, z: 0.00000009163637, w: 0.00000048049026}
   m_LocalPosition: {x: 0.09005299, y: 0.01086, z: 0.03370722}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4736048062372990}
   m_Father: {fileID: 4578838276210018}
@@ -2208,6 +2999,7 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0.032763, y: 0.019399999, z: -0.03258728}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4718307535146354}
   m_Father: {fileID: 4578838276210018}
@@ -2223,6 +3015,7 @@ Transform:
   m_LocalRotation: {x: 0.000003517392, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.029609999, y: 0.00000023138672, z: -1.3519946e-12}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4387490760862814}
   m_RootOrder: 0
@@ -2237,6 +3030,7 @@ Transform:
   m_LocalRotation: {x: 0.000000001217143, y: 0.010789105, z: -0.00000011280568, w: 0.9999418}
   m_LocalPosition: {x: -0.25980794, y: 1.2984311e-16, z: 1.3635393e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4922610750754240}
   m_Father: {fileID: 4371101458568866}
@@ -2252,6 +3046,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.02762249, w: 0.9996185}
   m_LocalPosition: {x: -0.099863835, y: 3.837587e-10, z: 4.2860933e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4133103639598966}
   - {fileID: 4764501272463272}
@@ -2269,6 +3064,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.004908496, w: 0.99998796}
   m_LocalPosition: {x: 0.05013466, y: -0.0024317356, z: -0.089999996}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4757780850791414}
   m_Father: {fileID: 4395714782842420}
@@ -2284,6 +3080,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.020319965, y: -0.000000009765624, z: -9.310237e-10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4794868105199280}
   m_Father: {fileID: 4081740136882770}
@@ -2299,6 +3096,7 @@ Transform:
   m_LocalRotation: {x: 0.0000014476384, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.027727999, y: -0.000000089129905, z: -0.0000000038657064}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4441217134629996}
   m_RootOrder: 0
@@ -2313,6 +3111,7 @@ Transform:
   m_LocalRotation: {x: 0.0000000010905377, y: -0.0096692005, z: 0.0000001127794, w: 0.99995327}
   m_LocalPosition: {x: 0.14904709, y: -0.021559998, z: 0.026150005}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4018260219674140}
   m_Father: {fileID: 4665268592255836}
@@ -2328,6 +3127,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0.0758718, y: 0.1706926, z: 1.0658141e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4759044232245152}
   m_Father: {fileID: 4327388097787786}
@@ -2343,6 +3143,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.054048985, y: -9.722308e-18, z: 1.0302869e-15}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4368496118721320}
   m_RootOrder: 0
@@ -2357,6 +3158,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.04628874, w: 0.9989281}
   m_LocalPosition: {x: 0.42483592, y: 0.00000004328955, z: 1.9539925e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4314694541946112}
   m_Father: {fileID: 4757780850791414}
@@ -2372,6 +3174,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: -0.0758718, y: -0.17069253, z: 5.1514347e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4325166092024820}
   m_Father: {fileID: 4994112069974886}
@@ -2387,6 +3190,7 @@ Transform:
   m_LocalRotation: {x: 0.0000000010905377, y: -0.0096692005, z: 0.0000001127794, w: 0.99995327}
   m_LocalPosition: {x: -0.14904714, y: 0.021559998, z: -0.026150007}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4240823294680710}
   m_Father: {fileID: 4764501272463272}
@@ -2402,6 +3206,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.023295304, y: 0.00000006185455, z: 0.0000000026829414}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4747823360574078}
   m_Father: {fileID: 4181935650218516}
@@ -2417,6 +3222,7 @@ Transform:
   m_LocalRotation: {x: 0.00000017615224, y: 0.00000044237117, z: 0.46174863, w: 0.8870109}
   m_LocalPosition: {x: -0.015590345, y: -0.02269687, z: -0.0022699998}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4690956774275456}
   m_Father: {fileID: 4650630383809934}
@@ -2432,6 +3238,7 @@ Transform:
   m_LocalRotation: {x: 0.0000021149021, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.027341, y: 0.00000021365567, z: -3.446715e-13}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4240494404266806}
   m_Father: {fileID: 4123188799949912}
@@ -2447,6 +3254,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.032299694, y: 0.00000041872633, z: 0.000000020130532}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4209719543557254}
   m_RootOrder: 0
@@ -2461,6 +3269,7 @@ Transform:
   m_LocalRotation: {x: 0.5, y: -0.5, z: -0.5, w: 0.5}
   m_LocalPosition: {x: 1.1827783e-16, y: 0.99710166, z: 0.011954045}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4495135636622886}
   - {fileID: 4250521619505792}
@@ -2478,6 +3287,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.102159195, y: 0, z: 3.418214e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4249977530399418}
   m_Father: {fileID: 4167897274266364}
@@ -2493,6 +3303,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: -0, w: 6.123234e-17}
   m_LocalPosition: {x: 0.100981995, y: 0.00868, z: 0.0151886195}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4629790936744636}
   m_Father: {fileID: 4578838276210018}
@@ -2508,6 +3319,7 @@ Transform:
   m_LocalRotation: {x: 0.00000087025205, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.023294998, y: -0.000000074880305, z: -0.000000003247809}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4260617025203136}
   m_Father: {fileID: 4965446167656668}
@@ -2523,6 +3335,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.026131999, y: -3.3821833e-13, z: 2.3536727e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4813974348053656}
   m_RootOrder: 0
@@ -2537,6 +3350,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.99998796, w: 0.004908496}
   m_LocalPosition: {x: 0.05013466, y: -0.0024317312, z: 0.089999996}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4902840864619486}
   m_Father: {fileID: 4395714782842420}
@@ -2552,6 +3366,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.029609164, y: -0.00000011569029, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4010660356237594}
   m_RootOrder: 0
@@ -2566,6 +3381,7 @@ Transform:
   m_LocalRotation: {x: -0.00011591564, y: 0.00007256035, z: -0.8476265, w: 0.53059345}
   m_LocalPosition: {x: 0.020377725, y: 0.023429718, z: 0.000011341149}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4911014152170456}
   m_Father: {fileID: 4910201191786486}
@@ -2581,6 +3397,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.026132211, y: -0.00000012525189, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4623383317032384}
   m_RootOrder: 0
@@ -2595,6 +3412,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0.0011199615, z: -0, w: 0.9999994}
   m_LocalPosition: {x: 0.25833765, y: 8.2224006e-13, z: -0.0000000040112766}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4231691677825054}
   - {fileID: 4230998713309538}
@@ -2614,6 +3432,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.029936645, y: -0.00000014348656, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4568598647890834}
   m_Father: {fileID: 4045389142029868}
@@ -2629,6 +3448,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.028015, y: -3.6322944e-13, z: 2.509104e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4813974348053656}
   m_Father: {fileID: 4439116517134178}
@@ -2644,6 +3464,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0.000001953623, z: 5.6263126e-15, w: 0.0000000028799376}
   m_LocalPosition: {x: -0.10176471, y: -0.009200126, z: 0.0076735215}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4940479983457288}
   m_Father: {fileID: 4922610750754240}
@@ -2659,6 +3480,7 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.032763172, y: -0.019399941, z: 0.032587297}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4375941099766496}
   m_Father: {fileID: 4922610750754240}
@@ -2674,6 +3496,7 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: -0, w: 0.000000002879931}
   m_LocalPosition: {x: -0.10098182, y: -0.008680271, z: -0.01518866}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4045389142029868}
   m_Father: {fileID: 4922610750754240}
@@ -2689,6 +3512,7 @@ Transform:
   m_LocalRotation: {x: 0.51362044, y: 0.48599797, z: -0.51362044, w: 0.48599797}
   m_LocalPosition: {x: -0.14809349, y: 0.018417655, z: -0.041293897}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4306490394211684}
   m_Father: {fileID: 4249977530399418}
@@ -2704,6 +3528,7 @@ Transform:
   m_LocalRotation: {x: 0.00000086590364, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.021772001, y: 0.000000041853575, z: 0.000000003990134}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4700388366158268}
   m_RootOrder: 0
@@ -2718,6 +3543,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.03139568, y: 0, z: 2.8111882e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4039498477818268}
   m_Father: {fileID: 4375941099766496}
@@ -2733,6 +3559,7 @@ Transform:
   m_LocalRotation: {x: 0.00000052042185, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.01966, y: 0.00000003779355, z: 0.0000000036031094}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4670727923768522}
   m_Father: {fileID: 4736048062372990}
@@ -2748,6 +3575,7 @@ Transform:
   m_LocalRotation: {x: 1, y: -0.0000016072119, z: -0.00000006971279, w: 0.0000008035582}
   m_LocalPosition: {x: 0.10144399, y: 0.010419999, z: -0.03227988}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4965446167656668}
   m_Father: {fileID: 4578838276210018}
@@ -2763,6 +3591,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4807133242489310}
   m_Father: {fileID: 4921246272369262}
@@ -2778,6 +3607,7 @@ Transform:
   m_LocalRotation: {x: 0.00000017597144, y: 0.00000044227704, z: 0.46174863, w: 0.8870109}
   m_LocalPosition: {x: 0.015591, y: 0.0226969, z: 0.0022699998}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4209719543557254}
   m_Father: {fileID: 4231691677825054}
@@ -2793,6 +3623,7 @@ Transform:
   m_LocalRotation: {x: 0.00000067755235, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.02032, y: 0.0000000390623, z: 0.0000000037241212}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4700388366158268}
   m_Father: {fileID: 4230998713309538}
@@ -2808,6 +3639,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.027728153, y: 0.000000044565017, z: 0.000000001933008}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4374627063963924}
   m_RootOrder: 0
@@ -2822,6 +3654,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.041384947, w: 0.9991433}
   m_LocalPosition: {x: 0.43576697, y: -4.867446e-10, z: 1.9539925e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4327388097787786}
   m_Father: {fileID: 4250521619505792}
@@ -2837,6 +3670,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.054049, y: 4.2188474e-17, z: 3.5527136e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4314694541946112}
   m_RootOrder: 0
@@ -2851,6 +3685,7 @@ Transform:
   m_LocalRotation: {x: -0.48599797, y: 0.51362044, z: 0.48599797, w: 0.51362044}
   m_LocalPosition: {x: -0.14809349, y: 0.018417658, z: 0.041293867}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4371101458568866}
   m_Father: {fileID: 4249977530399418}
@@ -2866,6 +3701,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: -0.04963602, y: 0.11306743, z: 0.03}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4910201191786486}
   m_RootOrder: 2
@@ -2880,6 +3716,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.021771478, y: -0.000000020926425, z: -0.0000000019950588}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4794868105199280}
   m_RootOrder: 0
@@ -2894,6 +3731,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.019660275, y: -0.000000018897165, z: -0.0000000018015959}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4770718595724854}
   m_Father: {fileID: 4253244186624738}
@@ -2909,6 +3747,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4395714782842420}
   m_Father: {fileID: 4710283860315220}
@@ -2924,6 +3763,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.029937, y: -3.8795632e-13, z: 2.7311487e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4478648147915672}
   m_Father: {fileID: 4629790936744636}
@@ -2939,6 +3779,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4921246272369262}
   m_RootOrder: 1
@@ -2953,6 +3794,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.041384947, w: 0.9991433}
   m_LocalPosition: {x: -0.43576738, y: 8.0373204e-16, z: -2.3092638e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4994112069974886}
   m_Father: {fileID: 4495135636622886}
@@ -2968,6 +3810,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.13521273, w: 0.9908166}
   m_LocalPosition: {x: -0.09720324, y: -3.5527136e-17, z: -7.336409e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4562873851605902}
   - {fileID: 4009420136217332}
@@ -2985,6 +3828,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.094900064, y: 1.8092883e-17, z: 4.9371638e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4562873851605902}
   m_RootOrder: 0
@@ -2999,6 +3843,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1923080548}
   - {fileID: 4861992439017204}
@@ -3016,6 +3861,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0.0011199615, z: -0, w: 0.9999994}
   m_LocalPosition: {x: -0.25833747, y: -4.1848454e-17, z: 7.817271e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4650630383809934}
   - {fileID: 4081740136882770}
@@ -3035,6 +3881,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.03811528, y: -0.00000007446289, z: 2.8247632e-11}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4010660356237594}
   m_Father: {fileID: 4634094916491360}
@@ -3050,6 +3897,7 @@ Transform:
   m_LocalRotation: {x: 0.0000011344717, y: 0, z: -0, w: 1}
   m_LocalPosition: {x: 0.030381, y: -0.00000009765779, z: -0.0000000042359667}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4441217134629996}
   m_Father: {fileID: 4704659787430792}
@@ -3065,6 +3913,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.04628874, w: 0.9989281}
   m_LocalPosition: {x: -0.4248355, y: 3.2196466e-16, z: 1.9539925e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4368496118721320}
   m_Father: {fileID: 4902840864619486}
@@ -3118,7 +3967,7 @@ Rigidbody:
   m_CollisionDetection: 0
 --- !u!95 &95487102469724584
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -3131,6 +3980,7 @@ Animator:
   m_UpdateMode: 1
   m_ApplyRootMotion: 1
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -3271,6 +4121,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 260066437471993806}
   - {fileID: 5101484583889120993}
@@ -3290,15 +4141,16 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6521527274971629406}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 25.17281}
+  m_LocalPosition: {x: 0, y: 0, z: 20.13345}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 153900723451599077}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0011174016, y: 0.0000349188}
+  m_AnchoredPosition: {x: -0.0013405625, y: 0.00005585677}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &321541157406378396
@@ -3495,6 +4347,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3526094740835135317}
   m_RootOrder: 0
@@ -3574,6 +4427,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2723711936400274817}
   m_Father: {fileID: 5101484583889120993}
@@ -3594,6 +4448,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3842700712863957352}
   m_Father: {fileID: 5101484583889120993}
@@ -3644,6 +4499,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3566171088614978507}
   m_RootOrder: 0
@@ -3781,6 +4637,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5918418925356973809}
   m_Father: {fileID: 5101484583889120993}
@@ -3801,6 +4658,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5337428573539602516}
   m_Father: {fileID: 5101484583889120993}
@@ -3821,6 +4679,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4952681795414530779}
   - {fileID: 3526094740835135317}
@@ -3844,6 +4703,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4952681795414530779}
   m_RootOrder: 0
@@ -3886,6 +4746,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4759813928997548577}
   m_RootOrder: 0

--- a/Samples~/Cinemachine Example Scenes/Scenes/Anywhere Door/PlayerLookAt.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/Anywhere Door/PlayerLookAt.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Cinemachine.Examples;
 using UnityEngine;
 
 public class PlayerLookAt : MonoBehaviour
@@ -8,12 +9,14 @@ public class PlayerLookAt : MonoBehaviour
 
 	void Update()
 	{
-		
+#if ENABLE_LEGACY_INPUT_MANAGER
 		float horizontal = Input.GetAxis("Mouse X") * speed;
 		float vertical = Input.GetAxis("Mouse Y") * speed;
 
 		transform.Rotate(0f, horizontal, 0f, Space.World);
 		transform.Rotate(-vertical, 0f, 0f, Space.Self);
-
+#else
+		InputSystemHelper.EnableBackendsWarningMessage();
+#endif
 	}
 }

--- a/Samples~/Cinemachine Example Scenes/Scenes/Anywhere Door/PlayerMovement.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/Anywhere Door/PlayerMovement.cs
@@ -1,26 +1,32 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Cinemachine.Examples;
 using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
 {
-public float movementSpeed = 10f;
-public float lookatspeed = 5f;
+    public float movementSpeed = 10f;
+    public float lookatspeed = 5f;
 
-
-    void Update () {
- 
-        if (Input.GetKey ("w")) {
+    void Update () 
+    {
+#if ENABLE_LEGACY_INPUT_MANAGER
+        if (Input.GetKey ("w")) 
+        {
             transform.position += transform.TransformDirection (Vector3.forward) * Time.deltaTime * movementSpeed;
-        }   else if (Input.GetKey ("s")) {
+        }   
+        else if (Input.GetKey ("s")) 
+        {
             transform.position -= transform.TransformDirection (Vector3.forward) * Time.deltaTime * movementSpeed;
         }
  
-        if (Input.GetKey ("a") && !Input.GetKey ("d")) {
-                transform.position += transform.TransformDirection (Vector3.left) * Time.deltaTime * movementSpeed;
-            } else if (Input.GetKey ("d") && !Input.GetKey ("a")) {
-                transform.position -= transform.TransformDirection (Vector3.left) * Time.deltaTime * movementSpeed;
-            }
+        if (Input.GetKey ("a") && !Input.GetKey ("d")) 
+        {
+            transform.position += transform.TransformDirection (Vector3.left) * Time.deltaTime * movementSpeed;
+        } else if (Input.GetKey ("d") && !Input.GetKey ("a")) 
+        {
+            transform.position -= transform.TransformDirection (Vector3.left) * Time.deltaTime * movementSpeed;
+        }
 
         //mouse look at
         float horizontal = Input.GetAxis("Mouse X") * lookatspeed;
@@ -28,5 +34,8 @@ public float lookatspeed = 5f;
 
 		transform.Rotate(0f, horizontal, 0f, Space.World);
 		//transform.Rotate(-vertical, 0f, 0f, Space.Self);
-        }
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
+    }
 }

--- a/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovement.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovement.cs
@@ -33,6 +33,7 @@ public class CharacterMovement : MonoBehaviour
 	// Update is called once per frame
 	void FixedUpdate ()
 	{
+#if ENABLE_LEGACY_INPUT_MANAGER
 	    input.x = Input.GetAxis("Horizontal");
 	    input.y = Input.GetAxis("Vertical");
 
@@ -71,6 +72,9 @@ public class CharacterMovement : MonoBehaviour
 
             transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.Euler(euler), turnSpeed * turnSpeedMultiplier * Time.deltaTime);
         }
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
 	}
 
     public virtual void UpdateTargetDirection()

--- a/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovement2D.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovement2D.cs
@@ -31,10 +31,11 @@ public class CharacterMovement2D : MonoBehaviour
 	    targetrot = transform.rotation;        
 	}
 	
+#if ENABLE_LEGACY_INPUT_MANAGER
 	// Update is called once per frame
 	void FixedUpdate ()
 	{
-	    input.x = Input.GetAxis("Horizontal");
+		input.x = Input.GetAxis("Horizontal");
 
         // Check if direction changes
 	    if ((input.x < 0f && !headingleft) || (input.x > 0f && headingleft))
@@ -56,15 +57,20 @@ public class CharacterMovement2D : MonoBehaviour
 	    if ((Input.GetKeyUp(sprintJoystick) || Input.GetKeyUp(sprintKeyboard))|| input == Vector2.zero) isSprinting = false;
         anim.SetBool("isSprinting", isSprinting);
     }
-
+#endif
     private void Update()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         // Jump
 	    if ((Input.GetKeyDown(jumpJoystick) || Input.GetKeyDown(jumpKeyboard)))
 	    {
 		    rigbody.AddForce(new Vector3(0, jumpVelocity, 0), ForceMode.Impulse);
 	    }
+#else
+	    InputSystemHelper.EnableBackendsWarningMessage();
+#endif
 	}
+
 
     public bool isGrounded()
     {

--- a/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovementNoCamera.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Models/UnityCharacter/Scripts/CharacterMovementNoCamera.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Cinemachine.Examples;
+using UnityEngine;
 
 // WASD to move, Space to sprint
 public class CharacterMovementNoCamera : MonoBehaviour
@@ -28,6 +29,7 @@ public class CharacterMovementNoCamera : MonoBehaviour
 
     void FixedUpdate()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         var input = new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"));
         var speed = input.y;
         speed = Mathf.Clamp(speed, -1f, 1f);
@@ -58,5 +60,8 @@ public class CharacterMovementNoCamera : MonoBehaviour
             rot.x = Mathf.Clamp(rot.x, VerticalRotMin, VerticalRotMax);
             InvisibleCameraOrigin.localRotation = Quaternion.Euler(rot);
         }
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
     }
 }

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs
@@ -11,11 +11,11 @@ namespace Cinemachine.Examples
             if (Time.realtimeSinceStartup - s_LastMessageTime > 5)
             {
                 Debug.Log(
-                    "Old input backends are disabled. Cinemachine examples use UnityEngine.Input. " +
-                    "To enable input in our examples: Edit > Project Settings > Player, " +
+                    "Old input backends are disabled. Cinemachine examples use Unity’s classic input system. " +
+                    "To enable classic input: Edit > Project Settings > Player, " +
                     "set Active Input Handling to Both!\n" +
                     "Note: This is probably because the Input System Package has been added to the project. To use " +
-                    "Cinemachine Virtual Cameras with Input System Package, add CinemachineInputProvider to them.");
+                    "Cinemachine Virtual Cameras with the Input System Package, add CinemachineInputProvider component to them.");
                 s_LastMessageTime = Time.realtimeSinceStartup;
             }
         }

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace Cinemachine.Examples
+{
+    public static class InputSystemHelper
+    {
+        static float s_LastMessageTime = -10;
+        // Logs warning every 5 seconds
+        public static void EnableBackendsWarningMessage()
+        {
+            if (Time.realtimeSinceStartup - s_LastMessageTime > 5)
+            {
+                Debug.Log(
+                    "Old input backends are disabled. Cinemachine examples use UnityEngine.Input. " +
+                    "To enable input in our examples: Edit > Project Settings > Player, " +
+                    "set Active Input Handling to Both!\n" +
+                    "Note: This is probably because the Input System Package has been added to the project. To use " +
+                    "Cinemachine Virtual Cameras with Input System Package, add CinemachineInputProvider to them.");
+                s_LastMessageTime = Time.realtimeSinceStartup;
+            }
+        }
+    }
+}

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs.meta
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/InputSystemHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5204e51f84074d79a29384cce2de3747
+timeCreated: 1636397410

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMove.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMove.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cinemachine.Examples;
 using Cinemachine.Utility;
 using UnityEngine;
 
@@ -41,6 +42,7 @@ public class PlayerMove : MonoBehaviour
 
     void Update()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         Vector3 fwd;
         switch (InputForward)
         {
@@ -89,6 +91,9 @@ public class PlayerMove : MonoBehaviour
             SpaceAction();
         if (Input.GetKeyDown(KeyCode.Return) && EnterAction != null)
             EnterAction();
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
     }
 
     public void Jump() { m_currentJumpSpeed += 10 * JumpTime * 0.5f; }

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMoveOnSphere.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMoveOnSphere.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Cinemachine.Examples;
 using Cinemachine.Utility;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ public class PlayerMoveOnSphere : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         Vector3 input = new Vector3(Input.GetAxis("Horizontal"), 0, Input.GetAxis("Vertical"));
         if (input.magnitude > 0)
         {
@@ -39,5 +41,8 @@ public class PlayerMoveOnSphere : MonoBehaviour
             transform.position = Sphere.transform.position + up * (Sphere.radius + transform.localScale.y / 2);
             transform.rotation = Quaternion.LookRotation(fwd, up);
         }
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
     }
 }

--- a/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMovePhysics.cs
+++ b/Samples~/Cinemachine Example Scenes/Shared/Scripts/PlayerMovePhysics.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cinemachine.Examples;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -25,6 +26,7 @@ public class PlayerMovePhysics : MonoBehaviour
 
     void FixedUpdate()
     {
+#if ENABLE_LEGACY_INPUT_MANAGER
         Vector3 input = new Vector3(Input.GetAxis("Horizontal"), 0, Input.GetAxis("Vertical"));
 
         //input = Vector3.forward;
@@ -50,5 +52,9 @@ public class PlayerMovePhysics : MonoBehaviour
             spaceAction();
         if (Input.GetKeyDown(KeyCode.Return) && enterAction != null)
             enterAction();
+        
+#else
+        InputSystemHelper.EnableBackendsWarningMessage();
+#endif
 	}
 }


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-517

When Input System is added to Cinemachine, the Cinemachine examples are throwing a lot of errors, because they are trying to read from the old backends (UnityEngine.Input). 

There is a guard that checks if the old backends are disabled (ENABLE_LEGACY_INPUT_MANAGER). I added this to all example scripts that use Input, and a Debug.Log that tells users how they can fix it.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

### Comments to reviewers
I added a guard to AxisState too, but I think it is better if that error is actually displayed as it was before. See my review comment for more details.

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
