### PR TITLE
CMCL-513: Target Override for Brain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 - Regression fix: could not change the projection of the main camera if a CM virtual camera is active.
 - Regression fix: Axis input was ignoring CM's IgnoreTimeScale setting.
-- 
+- New feature: CinemachineBrain may control other GameObject instead of the one it is attached to.
 
 ## [2.9.0-pre.1] - 2021-10-26
 - Added ability to directly set the active blend in CinemachineBrain.

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -197,8 +197,8 @@ namespace Cinemachine
         
         /// <summary>
         /// CinemachineBrain controls this GameObject.  Normally, this is the GameObject to which 
-        /// the CinemachinewBrain component is attached.  However, it is possible to override this
-        /// by setting this property to another GamePObject.  If a Camera component is attached to the 
+        /// the CinemachineBrain component is attached.  However, it is possible to override this
+        /// by setting this property to another GameObject.  If a Camera component is attached to the 
         /// Controlled Object, then that Camera component's lens settings will also be driven 
         /// by the CinemachineBrain.
         /// If this property is set to null, then CinemachineBrain is controlling the GameObject 

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -123,6 +123,14 @@ namespace Cinemachine
             + "because Virtual Cameras don't like looking straight up or straight down.")]
         public Transform m_WorldUpOverride;
 
+        /// <summary>
+        /// CinemachineBrain controls this gameObject.
+        /// If null, then CinemachineBrain is controlling the gameObject to which it is attached.
+        /// </summary>
+        [Tooltip("CinemachineBrain controls this gameObject. If null, then CinemachineBrain " +
+            "is controlling the gameObject to which it is attached.")]
+        public GameObject m_TargetOverride = null;
+
         /// <summary>This enum defines the options available for the update method.</summary>
         [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
         public enum UpdateMethod
@@ -190,7 +198,7 @@ namespace Cinemachine
             {
                 if (m_OutputCamera == null && !Application.isPlaying)
 #if UNITY_2019_2_OR_NEWER
-                    TryGetComponent(out m_OutputCamera);
+                    m_TargetOverride.TryGetComponent(out m_OutputCamera);
 #else
                     m_OutputCamera = GetComponent<Camera>();
 #endif
@@ -250,11 +258,16 @@ namespace Cinemachine
 
         private void OnEnable()
         {
+            if (m_TargetOverride == null)
+            {
+                m_TargetOverride = gameObject;
+            }
+            
             // Make sure there is a first stack frame
             if (mFrameStack.Count == 0)
                 mFrameStack.Add(new BrainFrame());
 
-            m_OutputCamera = GetComponent<Camera>();
+            m_TargetOverride.TryGetComponent(out m_OutputCamera);
             CinemachineCore.Instance.AddActiveBrain(this);
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             CinemachineDebug.OnGUIHandlers += OnGuiHandler;
@@ -680,8 +693,8 @@ namespace Cinemachine
                 // No active virtal camera.  We create a state representing its position
                 // and call the callback, but we don't actively set the transform or lens
                 var state = CameraState.Default;
-                state.RawPosition = transform.position;
-                state.RawOrientation = transform.rotation;
+                state.RawPosition = m_TargetOverride.transform.position;
+                state.RawOrientation = m_TargetOverride.transform.rotation;
                 state.Lens = LensSettings.FromCamera(m_OutputCamera);
                 state.BlendHint |= CameraState.BlendHintValue.NoTransform | CameraState.BlendHintValue.NoLens;
                 PushStateToUnityCamera(ref state);
@@ -928,9 +941,9 @@ namespace Cinemachine
         {
             CurrentCameraState = state;
             if ((state.BlendHint & CameraState.BlendHintValue.NoPosition) == 0)
-                transform.position = state.FinalPosition;
+                m_TargetOverride.transform.position = state.FinalPosition;
             if ((state.BlendHint & CameraState.BlendHintValue.NoOrientation) == 0)
-                transform.rotation = state.FinalOrientation;
+                m_TargetOverride.transform.rotation = state.FinalOrientation;
             if ((state.BlendHint & CameraState.BlendHintValue.NoLens) == 0)
             {
                 Camera cam = OutputCamera;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -188,7 +188,7 @@ namespace Cinemachine
         {
             get
             {
-                if (m_OutputCamera == null || !Application.isPlaying)
+                if (m_OutputCamera == null && !Application.isPlaying)
 #if UNITY_2019_2_OR_NEWER
                     TargetOverride.TryGetComponent(out m_OutputCamera);
 #else
@@ -265,7 +265,6 @@ namespace Cinemachine
             if (mFrameStack.Count == 0)
                 mFrameStack.Add(new BrainFrame());
 
-            TargetOverride.TryGetComponent(out m_OutputCamera);
             CinemachineCore.Instance.AddActiveBrain(this);
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             CinemachineDebug.OnGUIHandlers += OnGuiHandler;
@@ -303,6 +302,7 @@ namespace Cinemachine
         {
             m_LastFrameUpdated = -1;
             UpdateVirtualCameras(CinemachineCore.UpdateFilter.Late, -1f);
+            TargetOverride.TryGetComponent(out m_OutputCamera);
         }
 
         private void OnGuiHandler()
@@ -691,8 +691,9 @@ namespace Cinemachine
                 // No active virtal camera.  We create a state representing its position
                 // and call the callback, but we don't actively set the transform or lens
                 var state = CameraState.Default;
-                state.RawPosition = TargetOverride.transform.position;
-                state.RawOrientation = TargetOverride.transform.rotation;
+                var targetOverride = TargetOverride;
+                state.RawPosition = targetOverride.transform.position;
+                state.RawOrientation = targetOverride.transform.rotation;
                 state.Lens = LensSettings.FromCamera(m_OutputCamera);
                 state.BlendHint |= CameraState.BlendHintValue.NoTransform | CameraState.BlendHintValue.NoLens;
                 PushStateToUnityCamera(ref state);

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -189,21 +189,22 @@ namespace Cinemachine
             get
             {
                 if (m_OutputCamera == null && !Application.isPlaying)
-#if UNITY_2019_2_OR_NEWER
-                    TargetOverride.TryGetComponent(out m_OutputCamera);
-#else
-                    m_OutputCamera = GetComponent<Camera>();
-#endif
+                    ControlledObject.TryGetComponent(out m_OutputCamera);
                 return m_OutputCamera;
             }
         }
         private Camera m_OutputCamera = null; // never use directly - use accessor
         
         /// <summary>
-        /// CinemachineBrain controls this gameObject.
-        /// If null, then CinemachineBrain is controlling the gameObject to which it is attached.
+        /// CinemachineBrain controls this GameObject.  Normally, this is the GameObject to which 
+        /// the CinemachinewBrain component is attached.  However, it is possible to override this
+        /// by setting this property to another GamePObject.  If a Camera component is attached to the 
+        /// Controlled Object, then that Camera component's lens settings will also be driven 
+        /// by the CinemachineBrain.
+        /// If this property is set to null, then CinemachineBrain is controlling the GameObject 
+        /// to which it is attached.  The value of this property will always report as non-null.
         /// </summary>
-        public GameObject TargetOverride
+        public GameObject ControlledObject
         {
             get => m_TargetOverride == null ? gameObject : m_TargetOverride;
             set => m_TargetOverride = value;
@@ -302,7 +303,7 @@ namespace Cinemachine
         {
             m_LastFrameUpdated = -1;
             UpdateVirtualCameras(CinemachineCore.UpdateFilter.Late, -1f);
-            TargetOverride.TryGetComponent(out m_OutputCamera);
+            ControlledObject.TryGetComponent(out m_OutputCamera);
         }
 
         private void OnGuiHandler()
@@ -691,9 +692,9 @@ namespace Cinemachine
                 // No active virtal camera.  We create a state representing its position
                 // and call the callback, but we don't actively set the transform or lens
                 var state = CameraState.Default;
-                var targetOverride = TargetOverride;
-                state.RawPosition = targetOverride.transform.position;
-                state.RawOrientation = targetOverride.transform.rotation;
+                var target = ControlledObject.transform;
+                state.RawPosition = target.position;
+                state.RawOrientation = target.rotation;
                 state.Lens = LensSettings.FromCamera(m_OutputCamera);
                 state.BlendHint |= CameraState.BlendHintValue.NoTransform | CameraState.BlendHintValue.NoLens;
                 PushStateToUnityCamera(ref state);
@@ -939,10 +940,11 @@ namespace Cinemachine
         private void PushStateToUnityCamera(ref CameraState state)
         {
             CurrentCameraState = state;
+            var target = ControlledObject.transform;
             if ((state.BlendHint & CameraState.BlendHintValue.NoPosition) == 0)
-                TargetOverride.transform.position = state.FinalPosition;
+                target.position = state.FinalPosition;
             if ((state.BlendHint & CameraState.BlendHintValue.NoOrientation) == 0)
-                TargetOverride.transform.rotation = state.FinalOrientation;
+                target.rotation = state.FinalOrientation;
             if ((state.BlendHint & CameraState.BlendHintValue.NoLens) == 0)
             {
                 Camera cam = OutputCamera;
@@ -963,11 +965,7 @@ namespace Cinemachine
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
 #if CINEMACHINE_HDRP
-    #if UNITY_2019_2_OR_NEWER
                         cam.TryGetComponent<HDAdditionalCameraData>(out var hda);
-    #else
-                        var hda = cam.GetComponent<HDAdditionalCameraData>();
-    #endif
                         if (hda != null)
                         {
                             hda.physicalParameters.iso = state.Lens.Iso;

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -22,13 +22,13 @@ namespace Tests.Runtime
             
             m_CameraHolderWithoutBrain = CreateGameObject("MainCamera 2", typeof(Camera));
             m_BrainAlone = CreateGameObject("BrainAlone for MainCamera 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>();
-            m_BrainAlone.TargetOverride = m_CameraHolderWithoutBrain;
+            m_BrainAlone.ControlledObject = m_CameraHolderWithoutBrain;
             
             m_GoWithBrain = CreateGameObject("Empty 1", typeof(CinemachineBrain));
 
             m_GoWithoutBrain = CreateGameObject("Empty 2");
             m_BrainAlone2 = CreateGameObject("BrainAlone for Empty 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>(); 
-            m_BrainAlone2.TargetOverride = m_GoWithoutBrain;
+            m_BrainAlone2.ControlledObject = m_GoWithoutBrain;
             
             m_Vcam = CreateGameObject("CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
             m_Vcam.Priority = 100;
@@ -60,8 +60,8 @@ namespace Tests.Runtime
         
         IEnumerator CheckDisconnectedBrains()
         {
-            m_BrainAlone.TargetOverride = null;
-            m_BrainAlone2.TargetOverride = null;
+            m_BrainAlone.ControlledObject = null;
+            m_BrainAlone2.ControlledObject = null;
             m_FollowObject.transform.position += m_Delta;
             yield return null;
             Assert.That(m_CameraHolderWithBrain.transform.position == m_CameraHolderWithoutBrain.transform.position, Is.False);

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -37,15 +37,7 @@ namespace Tests.Runtime
             base.SetUp();
         }
         
-        void AreBrainControlledTransformsTheSame()
-        {
-            Assert.That(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView == m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView, Is.True);
-            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_CameraHolderWithoutBrain.transform), Is.True);
-            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithBrain.transform), Is.True);
-            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithoutBrain.transform), Is.True);
-            
-            bool EqualTransforms(Transform a, Transform b) => a.position == b.position && a.rotation == b.rotation;
-        }
+        
 
         Vector3 m_Delta = new Vector3(10, 0, 0);
         IEnumerator CheckThatBrainsAreControllingTheirTargets()
@@ -56,6 +48,16 @@ namespace Tests.Runtime
             m_FollowObject.transform.position += m_Delta;
             yield return null;
             AreBrainControlledTransformsTheSame();
+            
+            void AreBrainControlledTransformsTheSame()
+            {
+                Assert.That(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView == m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView, Is.True);
+                Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_CameraHolderWithoutBrain.transform), Is.True);
+                Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithBrain.transform), Is.True);
+                Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithoutBrain.transform), Is.True);
+            
+                bool EqualTransforms(Transform a, Transform b) => a.position == b.position && a.rotation == b.rotation;
+            }
         }
         
         IEnumerator CheckDisconnectedBrains()
@@ -64,8 +66,9 @@ namespace Tests.Runtime
             m_BrainAlone2.ControlledObject = null;
             m_FollowObject.transform.position += m_Delta;
             yield return null;
-            Assert.That(m_CameraHolderWithBrain.transform.position == m_CameraHolderWithoutBrain.transform.position, Is.False);
-            Assert.That(m_CameraHolderWithBrain.transform.position == m_GoWithoutBrain.transform.position, Is.False);
+            var position = m_CameraHolderWithBrain.transform.position;
+            Assert.That(position == m_CameraHolderWithoutBrain.transform.position, Is.False);
+            Assert.That(position == m_GoWithoutBrain.transform.position, Is.False);
         }
         
         [UnityTest]
@@ -84,9 +87,7 @@ namespace Tests.Runtime
             yield return CheckThatBrainsAreControllingTheirTargets();
             yield return CheckDisconnectedBrains();
         }
-
         
-
         [UnityTest]
         public IEnumerator FramingTransposer()
         {

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -1,0 +1,146 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Cinemachine;
+using UnityEngine.TestTools.Utils;
+
+namespace Tests.Runtime
+{
+    public class BrainTargetOverrideTests : CinemachineFixtureBase
+    {
+        GameObject m_CameraHolderWithBrain, m_CameraHolderWithoutBrain, m_GoWithBrain, m_GoWithoutBrain;
+        CinemachineVirtualCamera m_Vcam;
+        GameObject m_FollowObject;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            m_CameraHolderWithBrain = CreateGameObject("MainCamera 1", typeof(Camera), typeof(CinemachineBrain));
+            
+            m_CameraHolderWithoutBrain = CreateGameObject("MainCamera 2", typeof(Camera));
+            var brainAlone = CreateGameObject("BrainAlone for MainCamera 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>();
+            brainAlone.TargetOverride = m_CameraHolderWithoutBrain;
+            
+            m_GoWithBrain = CreateGameObject("Empty 1", typeof(CinemachineBrain));
+
+            m_GoWithoutBrain = CreateGameObject("Empty 2");
+            var brainAlone2 = CreateGameObject("BrainAlone for Empty 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>(); 
+            brainAlone2.TargetOverride = m_GoWithoutBrain;
+            
+            m_Vcam = CreateGameObject("CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            m_Vcam.Priority = 100;
+            m_FollowObject = CreateGameObject("Follow Object");
+            
+            base.SetUp();
+        }
+        
+        void AreBrainControlledTransformsTheSame()
+        {
+            Debug.Log(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView + "|" + m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView);
+            Assert.That(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView == m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView, Is.True);
+            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_CameraHolderWithoutBrain.transform), Is.True);
+            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithBrain.transform), Is.True);
+            Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithoutBrain.transform), Is.True);
+            
+            bool EqualTransforms(Transform a, Transform b) => a.position == b.position && a.rotation == b.rotation;
+        }
+
+        [UnityTest]
+        public IEnumerator DoNothing()
+        {
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_Vcam.m_Lens.FieldOfView = 50;
+            m_FollowObject.transform.position += new Vector3(2, 2, 2);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator ThirdPerson()
+        {
+            m_Vcam.AddCinemachineComponent<Cinemachine3rdPersonFollow>();
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator FramingTransposer()
+        {
+            var component = m_Vcam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_CameraDistance = 1f;
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator HardLockToTarget()
+        {
+            m_Vcam.AddCinemachineComponent<CinemachineHardLockToTarget>();
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator OrbTransposer()
+        {
+            var component = m_Vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
+            component.m_XAxis.m_InputAxisName = ""; // to avoid error when the Input System is installed in the testing project
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_FollowOffset = new Vector3(0, 0, 0);
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator TrackedDolly()
+        {
+            m_Vcam.AddCinemachineComponent<CinemachineTrackedDolly>();
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(2, 2, 2);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+
+        [UnityTest]
+        public IEnumerator Transposer()
+        {
+            var component = m_Vcam.AddCinemachineComponent<CinemachineTransposer>();
+            component.m_XDamping = 0;
+            component.m_YDamping = 0;
+            component.m_ZDamping = 0;
+            component.m_FollowOffset = new Vector3(0, 0, 0);
+            m_Vcam.Follow = m_FollowObject.transform;
+            m_FollowObject.transform.position += new Vector3(10, 0, 0);
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+    }
+}

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -13,20 +13,22 @@ namespace Tests.Runtime
         CinemachineVirtualCamera m_Vcam;
         GameObject m_FollowObject;
 
+        CinemachineBrain m_BrainAlone, m_BrainAlone2;
+
         [SetUp]
         public override void SetUp()
         {
             m_CameraHolderWithBrain = CreateGameObject("MainCamera 1", typeof(Camera), typeof(CinemachineBrain));
             
             m_CameraHolderWithoutBrain = CreateGameObject("MainCamera 2", typeof(Camera));
-            var brainAlone = CreateGameObject("BrainAlone for MainCamera 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>();
-            brainAlone.TargetOverride = m_CameraHolderWithoutBrain;
+            m_BrainAlone = CreateGameObject("BrainAlone for MainCamera 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>();
+            m_BrainAlone.TargetOverride = m_CameraHolderWithoutBrain;
             
             m_GoWithBrain = CreateGameObject("Empty 1", typeof(CinemachineBrain));
 
             m_GoWithoutBrain = CreateGameObject("Empty 2");
-            var brainAlone2 = CreateGameObject("BrainAlone for Empty 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>(); 
-            brainAlone2.TargetOverride = m_GoWithoutBrain;
+            m_BrainAlone2 = CreateGameObject("BrainAlone for Empty 2", typeof(CinemachineBrain)).GetComponent<CinemachineBrain>(); 
+            m_BrainAlone2.TargetOverride = m_GoWithoutBrain;
             
             m_Vcam = CreateGameObject("CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
             m_Vcam.Priority = 100;
@@ -37,7 +39,6 @@ namespace Tests.Runtime
         
         void AreBrainControlledTransformsTheSame()
         {
-            Debug.Log(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView + "|" + m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView);
             Assert.That(m_CameraHolderWithBrain.GetComponent<Camera>().fieldOfView == m_CameraHolderWithoutBrain.GetComponent<Camera>().fieldOfView, Is.True);
             Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_CameraHolderWithoutBrain.transform), Is.True);
             Assert.That(EqualTransforms(m_CameraHolderWithBrain.transform, m_GoWithBrain.transform), Is.True);
@@ -46,29 +47,45 @@ namespace Tests.Runtime
             bool EqualTransforms(Transform a, Transform b) => a.position == b.position && a.rotation == b.rotation;
         }
 
+        Vector3 m_Delta = new Vector3(10, 0, 0);
+        IEnumerator CheckThatBrainsAreControllingTheirTargets()
+        {
+            m_FollowObject.transform.position += m_Delta;
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+            m_FollowObject.transform.position += m_Delta;
+            yield return null;
+            AreBrainControlledTransformsTheSame();
+        }
+        
+        IEnumerator CheckDisconnectedBrains()
+        {
+            m_BrainAlone.TargetOverride = null;
+            m_BrainAlone2.TargetOverride = null;
+            m_FollowObject.transform.position += m_Delta;
+            yield return null;
+            Assert.That(m_CameraHolderWithBrain.transform.position == m_CameraHolderWithoutBrain.transform.position, Is.False);
+            Assert.That(m_CameraHolderWithBrain.transform.position == m_GoWithoutBrain.transform.position, Is.False);
+        }
+        
         [UnityTest]
         public IEnumerator DoNothing()
         {
-            m_Vcam.Follow = m_FollowObject.transform;
             m_Vcam.m_Lens.FieldOfView = 50;
-            m_FollowObject.transform.position += new Vector3(2, 2, 2);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
         }
 
         [UnityTest]
         public IEnumerator ThirdPerson()
         {
             m_Vcam.AddCinemachineComponent<Cinemachine3rdPersonFollow>();
+            m_Vcam.m_Lens.FieldOfView = 50;
             m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(10, 0, 0);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
+            yield return CheckDisconnectedBrains();
         }
+
+        
 
         [UnityTest]
         public IEnumerator FramingTransposer()
@@ -79,11 +96,8 @@ namespace Tests.Runtime
             component.m_ZDamping = 0;
             component.m_CameraDistance = 1f;
             m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(10, 0, 0);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
+            yield return CheckDisconnectedBrains();
         }
 
         [UnityTest]
@@ -91,11 +105,8 @@ namespace Tests.Runtime
         {
             m_Vcam.AddCinemachineComponent<CinemachineHardLockToTarget>();
             m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(10, 0, 0);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
+            yield return CheckDisconnectedBrains();
         }
 
         [UnityTest]
@@ -108,23 +119,8 @@ namespace Tests.Runtime
             component.m_ZDamping = 0;
             component.m_FollowOffset = new Vector3(0, 0, 0);
             m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(10, 0, 0);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-        }
-
-        [UnityTest]
-        public IEnumerator TrackedDolly()
-        {
-            m_Vcam.AddCinemachineComponent<CinemachineTrackedDolly>();
-            m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(2, 2, 2);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
+            yield return CheckDisconnectedBrains();
         }
 
         [UnityTest]
@@ -136,11 +132,8 @@ namespace Tests.Runtime
             component.m_ZDamping = 0;
             component.m_FollowOffset = new Vector3(0, 0, 0);
             m_Vcam.Follow = m_FollowObject.transform;
-            m_FollowObject.transform.position += new Vector3(10, 0, 0);
-            yield return null;
-            AreBrainControlledTransformsTheSame();
-            yield return null;
-            AreBrainControlledTransformsTheSame();
+            yield return CheckThatBrainsAreControllingTheirTargets();
+            yield return CheckDisconnectedBrains();
         }
     }
 }

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Cinemachine;
-using UnityEngine.TestTools.Utils;
 
 namespace Tests.Runtime
 {
@@ -12,7 +11,6 @@ namespace Tests.Runtime
         GameObject m_CameraHolderWithBrain, m_CameraHolderWithoutBrain, m_GoWithBrain, m_GoWithoutBrain;
         CinemachineVirtualCamera m_Vcam;
         GameObject m_FollowObject;
-
         CinemachineBrain m_BrainAlone, m_BrainAlone2;
 
         [SetUp]
@@ -36,8 +34,6 @@ namespace Tests.Runtime
             
             base.SetUp();
         }
-        
-        
 
         Vector3 m_Delta = new Vector3(10, 0, 0);
         IEnumerator CheckThatBrainsAreControllingTheirTargets()

--- a/Tests/Runtime/BrainTargetOverrideTests.cs
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs
@@ -110,7 +110,6 @@ namespace Tests.Runtime
         public IEnumerator OrbTransposer()
         {
             var component = m_Vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
-            component.m_XAxis.m_InputAxisName = ""; // to avoid error when the Input System is installed in the testing project
             component.m_XDamping = 0;
             component.m_YDamping = 0;
             component.m_ZDamping = 0;

--- a/Tests/Runtime/BrainTargetOverrideTests.cs.meta
+++ b/Tests/Runtime/BrainTargetOverrideTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05a0e141febe431a9d24a358a0a4d929
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/CameraPositionTests.cs
+++ b/Tests/Runtime/CameraPositionTests.cs
@@ -9,8 +9,8 @@ namespace Tests.Runtime
 {
     public class CameraPositionTests : CinemachineFixtureBase
     {
-        private CinemachineVirtualCamera m_Vcam;
-        private GameObject m_FollowObject;
+        CinemachineVirtualCamera m_Vcam;
+        GameObject m_FollowObject;
 
         [SetUp]
         public override void SetUp()
@@ -27,7 +27,7 @@ namespace Tests.Runtime
         public IEnumerator DoNothing()
         {
             m_Vcam.Follow = m_FollowObject.transform;
-            Vector3 oldPos = m_Vcam.transform.position;
+            var oldPos = m_Vcam.transform.position;
             m_FollowObject.transform.position += new Vector3(2, 2, 2);
             yield return null;
             Assert.That(m_Vcam.State.FinalPosition, Is.EqualTo(oldPos).Using(Vector3EqualityComparer.Instance));
@@ -46,7 +46,7 @@ namespace Tests.Runtime
         [UnityTest]
         public IEnumerator FramingTransposer()
         {
-            CinemachineFramingTransposer component = m_Vcam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            var component = m_Vcam.AddCinemachineComponent<CinemachineFramingTransposer>();
             component.m_XDamping = 0;
             component.m_YDamping = 0;
             component.m_ZDamping = 0;
@@ -70,7 +70,8 @@ namespace Tests.Runtime
         [UnityTest]
         public IEnumerator OrbTransposer()
         {
-            CinemachineOrbitalTransposer component = m_Vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
+            var component = m_Vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
+            component.m_XAxis.m_InputAxisName = ""; // to avoid error when the Input System is installed in the testing project
             component.m_XDamping = 0;
             component.m_YDamping = 0;
             component.m_ZDamping = 0;
@@ -86,7 +87,7 @@ namespace Tests.Runtime
         {
             m_Vcam.AddCinemachineComponent<CinemachineTrackedDolly>();
             m_Vcam.Follow = m_FollowObject.transform;
-            Vector3 oldPos = m_Vcam.transform.position;
+            var oldPos = m_Vcam.transform.position;
             m_FollowObject.transform.position += new Vector3(2, 2, 2);
             yield return null;
             Assert.That(m_Vcam.State.FinalPosition, Is.EqualTo(oldPos).Using(Vector3EqualityComparer.Instance));
@@ -95,7 +96,7 @@ namespace Tests.Runtime
         [UnityTest]
         public IEnumerator Transposer()
         {
-            CinemachineTransposer component = m_Vcam.AddCinemachineComponent<CinemachineTransposer>();
+            var component = m_Vcam.AddCinemachineComponent<CinemachineTransposer>();
             component.m_XDamping = 0;
             component.m_YDamping = 0;
             component.m_ZDamping = 0;

--- a/Tests/Runtime/CameraPositionTests.cs
+++ b/Tests/Runtime/CameraPositionTests.cs
@@ -71,7 +71,6 @@ namespace Tests.Runtime
         public IEnumerator OrbTransposer()
         {
             var component = m_Vcam.AddCinemachineComponent<CinemachineOrbitalTransposer>();
-            component.m_XAxis.m_InputAxisName = ""; // to avoid error when the Input System is installed in the testing project
             component.m_XDamping = 0;
             component.m_YDamping = 0;
             component.m_ZDamping = 0;


### PR DESCRIPTION
### Purpose of this PR

Add option for user to override CinemachineBrain's targetted gameobject.
https://jira.unity3d.com/browse/CMCL-513

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
