### PR TITLE
CMCL-656: make tests pass without default upm packages

### DIFF
--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -41,7 +41,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci package test -u {{ editor.version }} --type package-tests
+    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci package test -u {{ editor.version }} --type package-tests --extra-create-project-arg=-upmNoDefaultPackages
   artifacts:
     logs:
       paths:
@@ -63,7 +63,7 @@ validate_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci package test -u {{ editor.version }} --type vetting-tests --platform editmode
+    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci package test -u {{ editor.version }} --type vetting-tests --platform editmode --extra-create-project-arg=-upmNoDefaultPackages
   artifacts:
     logs:
       paths:

--- a/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -23,11 +23,16 @@ namespace Cinemachine.Editor
                 Gizmos.DrawLine(shoulder, hand);
                 Gizmos.DrawSphere(root, 0.02f);
                 Gizmos.DrawSphere(shoulder, 0.02f);
+#if CINEMACHINE_PHYSICS
                 Gizmos.DrawSphere(hand, target.CameraRadius);
+#endif
 
                 if (isLive)
                     Gizmos.color = CinemachineSettings.CinemachineCoreSettings.BoundaryObjectGizmoColour;
+
+#if CINEMACHINE_PHYSICS
                 Gizmos.DrawSphere(target.VirtualCamera.State.RawPosition, target.CameraRadius);
+#endif
 
                 Gizmos.color = originalGizmoColour;
             }

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -66,6 +66,7 @@ namespace Cinemachine.Editor
             blendListCamera.m_Instructions[1].m_Blend.m_Time = 2f;
         }
 
+#if CINEMACHINE_UNITY_ANIMATION
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_GameObjectMenuPriority)]
         static void CreateStateDivenCamera(MenuCommand command)
         {
@@ -76,6 +77,7 @@ namespace Cinemachine.Editor
             // We give the camera a child as an example setup
             CreateDefaultVirtualCamera(parentObject: stateDrivenCamera.gameObject);
         }
+#endif
 
 #if CINEMACHINE_PHYSICS
         [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_GameObjectMenuPriority)]

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -103,9 +103,11 @@ namespace Cinemachine
             Damping.x = Mathf.Max(0, Damping.x);
             Damping.y = Mathf.Max(0, Damping.y);
             Damping.z = Mathf.Max(0, Damping.z);
+#if CINEMACHINE_PHYSICS
             CameraRadius = Mathf.Max(0.001f, CameraRadius);
             DampingIntoCollision = Mathf.Max(0, DampingIntoCollision);
             DampingFromCollision = Mathf.Max(0, DampingFromCollision);
+#endif
         }
 
         void Reset()
@@ -137,6 +139,7 @@ namespace Cinemachine
         /// Always returns the Aim stage</summary>
         public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
 
+#if CINEMACHINE_PHYSICS
         /// <summary>
         /// Report maximum damping time needed for this component.
         /// </summary>
@@ -145,8 +148,9 @@ namespace Cinemachine
         { 
             return Mathf.Max(
                 Mathf.Max(DampingIntoCollision, DampingFromCollision), 
-                Mathf.Max(Damping.x, Mathf.Max(Damping.y, Damping.z))); 
+                Mathf.Max(Damping.x, Mathf.Max(Damping.y, Damping.z)));
         }
+#endif
 
         /// <summary>Orients the camera to match the Follow target's orientation</summary>
         /// <param name="curState">The current camera state</param>


### PR DESCRIPTION
### Purpose of this PR

https://unity-ci.cds.internal.unity3d.com/job/10143816 is failing when using CM as a dependency.

The only apparent difference is that they're passing --extra-create-project-arg=-upmNoDefaultPackages in both upm-ci package test calls

