### PR TITLE
CMCL-667: Show calculated confiner for not live vcams.

### DIFF
--- a/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -361,7 +361,7 @@ namespace Cinemachine
             for (int i = 0; i < allExtraStates.Count; ++i)
             {
                 var e = allExtraStates[i];
-                if (e.m_BakedSolution != null && CinemachineCore.Instance.IsLive(e.m_vcam))
+                if (e.m_BakedSolution != null)
                 {
                     currentPath.AddRange(e.m_BakedSolution.GetBakedPath());
                 }

--- a/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -247,6 +247,7 @@ namespace Cinemachine
             /// <param name="aspectRatio">Aspect ratio/param>
             /// <param name="confinerStateChanged">True, if the baked confiner state has changed.
             /// False, otherwise.</param>
+            /// <returns>True, if input is valid. False, otherwise.</returns>
             public bool ValidateCache(
                 Collider2D boundingShape2D, float maxWindowSize, 
                 float aspectRatio, out bool confinerStateChanged)


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-664
Calculated confiner is shown for not live vcams.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
0
### Comments to reviewers
### Package version
- [ ] Updated package version
