### PR TITLE
CMCL-686: targets forget that they are groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New feature: CinemachineBrain may control other GameObject instead of the one it is attached to.
 - Bugfix: Cinemachine assigns a default input controller delegate that returns 0 when the legacy input system is disabled.
 - Cinemachine example scenes show informative text when used with Input System instead of throwing error messages.
-- Regression fix: compilation errors when physics module is not present
+- Regression fix: compilation errors when physics module is not present.
 - GameObjects created with Gameobject menu items now follow Unity naming conventions.
-- Handles now consistent with design
+- Regresion fix: virtual cameras no longer forget that they are targeting groups on domain reload.
 
 
 ## [2.9.0-pre.1] - 2021-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Cinemachine example scenes show informative text when used with Input System instead of throwing error messages.
 - Regression fix: compilation errors when physics module is not present.
 - GameObjects created with Gameobject menu items now follow Unity naming conventions.
-- Regresion fix: virtual cameras no longer forget that they are targeting groups on domain reload.
+- Regression fix: virtual cameras no longer forget that they are targeting groups on domain reload.
 
 
 ## [2.9.0-pre.1] - 2021-10-26

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -770,6 +770,25 @@ namespace Cinemachine
         private CinemachineVirtualCameraBase m_CachedLookAtTargetVcam;
         private ICinemachineTargetGroup m_CachedLookAtTargetGroup;
 
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoad]
+        class OnDomainReload 
+        { 
+            static OnDomainReload() 
+            {
+                var vcams = FindObjectsOfType<CinemachineVirtualCameraBase>(true);
+                foreach (var vcam in vcams)
+                {
+                    vcam.m_CachedFollowTarget = null;
+                    vcam.m_CachedFollowTargetVcam = null;
+                    vcam.m_CachedFollowTargetGroup = null;
+                    vcam.m_CachedLookAtTarget = null;
+                    vcam.m_CachedLookAtTargetVcam = null;
+                    vcam.m_CachedLookAtTargetGroup = null;
+                }
+            }
+        }
+#endif
 
         /// <summary>
         /// This property is true if the Follow target was changed this frame.

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -584,6 +584,7 @@ namespace Cinemachine
             if (!CinemachineCore.Instance.IsLive(this))
                 PreviousStateIsValid = false;
             CinemachineCore.Instance.CameraEnabled(this);
+            InvalidateCachedTargets();
             // Sanity check - if another vcam component is enabled, shut down
             var vcamComponents = GetComponents<CinemachineVirtualCameraBase>();
             for (int i = 0; i < vcamComponents.Length; ++i)
@@ -770,22 +771,29 @@ namespace Cinemachine
         private CinemachineVirtualCameraBase m_CachedLookAtTargetVcam;
         private ICinemachineTargetGroup m_CachedLookAtTargetGroup;
 
+        private void InvalidateCachedTargets()
+        {
+            m_CachedFollowTarget = null;
+            m_CachedFollowTargetVcam = null;
+            m_CachedFollowTargetGroup = null;
+            m_CachedLookAtTarget = null;
+            m_CachedLookAtTargetVcam = null;
+            m_CachedLookAtTargetGroup = null;
+        }
+
 #if UNITY_EDITOR
         [UnityEditor.InitializeOnLoad]
         class OnDomainReload 
         { 
             static OnDomainReload() 
             {
+#if UNITY_2020_1_OR_NEWER
                 var vcams = FindObjectsOfType<CinemachineVirtualCameraBase>(true);
+#else
+                var vcams = FindObjectsOfType<CinemachineVirtualCameraBase>();
+#endif
                 foreach (var vcam in vcams)
-                {
-                    vcam.m_CachedFollowTarget = null;
-                    vcam.m_CachedFollowTargetVcam = null;
-                    vcam.m_CachedFollowTargetGroup = null;
-                    vcam.m_CachedLookAtTarget = null;
-                    vcam.m_CachedLookAtTargetVcam = null;
-                    vcam.m_CachedLookAtTargetGroup = null;
-                }
+                    vcam.InvalidateCachedTargets();
             }
         }
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-686: On domain reload vcams were forgetting that they were targeting groups

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

