### PR TITLE
CMCL-768: PP memleak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Bugfix: memory leak with PostProcessing if no PP layer is present on the camera
+
+
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.
 - Regression fix: could not change the projection of the main camera if a CM virtual camera is active.

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -318,31 +318,47 @@ namespace Cinemachine.PostFX
             if (layer != null)
                 return layer;   // layer is valid and in our lookup
 
-            if (found)
+            // If the layer in the lookup table is a deleted object, we must remove
+            // the brain's callback for it
+            if (found && !ReferenceEquals(layer, null))
             {
                 // layer is a deleted object
                 brain.m_CameraCutEvent.RemoveListener(OnCameraCut);
                 mBrainToLayer.Remove(brain);
                 layer = null;
+                found = false;
             }
-            // Brain is not in our lookup - add it
+
+            // Brain is not in our lookup - add it.
 #if UNITY_2019_2_OR_NEWER
             brain.TryGetComponent(out layer);
-#else
-            layer = brain.GetComponent<PostProcessLayer>();
-#endif
             if (layer != null)
+            {
                 brain.m_CameraCutEvent.AddListener(OnCameraCut); // valid layer
-#if UNITY_EDITOR
-            // Never add null in edit mode in case user adds a layer dynamically
-            if (Application.isPlaying || layer != null)  
-#endif
                 mBrainToLayer[brain] = layer;
+            }
+#else
+            // In order to avoid calling GetComponent() every frame in the case
+            // where there is legitimately no layer on the brain, we will add
+            // null to the lookup table if no layer is present.
+            if (!found)
+            {
+                layer = brain.GetComponent<PostProcessLayer>();
+                if (layer != null)
+                    brain.m_CameraCutEvent.AddListener(OnCameraCut); // valid layer
 
+                // Exception: never add null in the case where user adds a layer while
+                // in the editor.  If we were to add null in this case, then the new
+                // layer would not be detected.  We are willing to live with
+                // calling GetComponent() every frame while in edit mode.
+                if (Application.isPlaying || layer != null)
+                    mBrainToLayer[brain] = layer;
+            }
+#endif
             return layer;
         }
 
-        static void OnSceneUnloaded(Scene scene)
+        static void CleanupLookupTable()
         {
             var iter = mBrainToLayer.GetEnumerator();
             while (iter.MoveNext())
@@ -356,17 +372,24 @@ namespace Cinemachine.PostFX
 
 #if UNITY_EDITOR
         [UnityEditor.InitializeOnLoad]
-        class EditorInitialize { static EditorInitialize() { InitializeModule(); } }
+        class EditorInitialize 
+        { 
+            static EditorInitialize() 
+            { 
+                UnityEditor.EditorApplication.playModeStateChanged += (pmsc) => CleanupLookupTable();
+                InitializeModule(); 
+            } 
+        }
 #endif
         [RuntimeInitializeOnLoadMethod]
         static void InitializeModule()
         {
-            // Afetr the brain pushes the state to the camera, hook in to the PostFX
+            // After the brain pushes the state to the camera, hook in to the PostFX
             CinemachineCore.CameraUpdatedEvent.RemoveListener(ApplyPostFX);
             CinemachineCore.CameraUpdatedEvent.AddListener(ApplyPostFX);
 
             // Clean up our resources
-            SceneManager.sceneUnloaded += OnSceneUnloaded;
+            SceneManager.sceneUnloaded += (scene) => CleanupLookupTable();
         }
     }
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-768: memory leak when PostProcessing package installed and no PP Layer on the Brain

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
