### PR TITLE
CMCL-771: Cinemachine 2.8.4 produce compiler errors if Input System package is installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 - Bugfix: Standalone profiler no longer crashed with CM.
+- Bugfix: Cinemachine does not produce compiler error in unity editor versions older than 2020, when Input System package is installed.
 
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -100,8 +100,6 @@ namespace Cinemachine
             InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
                 user.actions.First(x => x.id == aRef.action.id);
         }
-        
-        
 
         // Clean up
         protected virtual void OnDisable()

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -95,16 +95,11 @@ namespace Cinemachine
                 m_cachedActions[axis].Enable();
             
             return m_cachedActions[axis];
-            #if UNITY_2020_1_OR_NEWER 
-            // local static function to wrap the lambda which otherwise causes a tiny gc
-            static InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
+            
+            // local function to wrap the lambda which otherwise causes a tiny gc
+            InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
                 user.actions.First(x => x.id == aRef.action.id);
-            #endif
         }
-        #if !UNITY_2020_1_OR_NEWER
-        static InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
-            user.actions.First(x => x.id == aRef.action.id);
-        #endif
         
         
 

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -95,10 +95,18 @@ namespace Cinemachine
                 m_cachedActions[axis].Enable();
             
             return m_cachedActions[axis];
+            #if UNITY_2020_1_OR_NEWER 
             // local static function to wrap the lambda which otherwise causes a tiny gc
-            static InputAction GetFirstMatch(in InputUser user, InputActionReference actionRef) => 
-                user.actions.First(x => x.id == actionRef.action.id);
+            static InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
+                user.actions.First(x => x.id == aRef.action.id);
+            #endif
         }
+        #if !UNITY_2020_1_OR_NEWER
+        static InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
+            user.actions.First(x => x.id == aRef.action.id);
+        #endif
+        
+        
 
         // Clean up
         protected virtual void OnDisable()


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-771

Cinemachine 2.8.4 does not compile on Unity versions that does not support C# 8 and when the Input system package is installed.

### Testing status

- [ ] Added an automated test - No, but todo: https://jira.unity3d.com/browse/CMCL-775
- [x] Passed all automated tests
- [x] Manually tested (in 2019 LTS, and 2020.3.25f)

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version
