### PR TITLE
CMCL-779: ImpulseDefinition property not displayed correctly in the editor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: memory leak with PostProcessing if no PP layer is present on the camera
 - Bugfix: Standalone profiler no longer crashed with CM.
 - Bugfix: Cinemachine does not produce compiler error in unity editor versions older than 2020, when Input System package is installed.
+- Bugfic: EmbeddedAssetProperties were not displayed correctly in the editor.
 
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: memory leak with PostProcessing if no PP layer is present on the camera
 - Bugfix: Standalone profiler no longer crashed with CM.
 - Bugfix: Cinemachine does not produce compiler error in unity editor versions older than 2020, when Input System package is installed.
-- Bugfic: EmbeddedAssetProperties were not displayed correctly in the editor.
+- Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
 
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.

--- a/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -148,10 +148,14 @@ namespace Cinemachine.Editor
             Type type = property.serializedObject.targetObject.GetType();
             var a = property.propertyPath.Split('.');
             for (int i = 0; i < a.Length; ++i)
-                type = type.GetField(a[i],
+            {
+                var field = type.GetField(a[i],
                     System.Reflection.BindingFlags.Public
                     | System.Reflection.BindingFlags.NonPublic
-                    | System.Reflection.BindingFlags.Instance).FieldType;
+                    | System.Reflection.BindingFlags.Instance);
+                if (field == null) continue;
+                type = field.FieldType;
+            }
             return type;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Fix for https://jira.unity3d.com/browse/CMCL-779.

The fix is relevant in CM 2.7, because in later version this is legacy and not used. But for completeness sake, I added the fix to master, because it may come up with something else too. I'll backport to each version.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

### Comments to reviewers

The bug was caused because when ImpulseDefintion was part of a list, the reflection got null fields for Array. Then null.FieldType is invalid.

### Package version

- [ ] Updated package version
