### PR TITLE
CMCL-779: ImpulseDefinition property not displayed correctly in the editor 2

### DIFF
--- a/Editor/Impulse/CinemachineImpulseDefinitionPropertyDrawer.cs
+++ b/Editor/Impulse/CinemachineImpulseDefinitionPropertyDrawer.cs
@@ -291,7 +291,7 @@ namespace Cinemachine.Editor
             prop.NextVisible(true); // Skip outer foldout
             do
             {
-                if (!prop.propertyPath.StartsWith(prefix))
+                if (!prop.propertyPath.Contains(prefix)) // if it is part of an array, then it won't StartWith prefix
                     break;
                 string header = HeaderText(prop);
                 if (header != null)
@@ -327,7 +327,7 @@ namespace Cinemachine.Editor
             prop.NextVisible(true); // Skip outer foldout
             do
             {
-                if (!prop.propertyPath.StartsWith(prefix))
+                if (!prop.propertyPath.Contains(prefix)) // if it is part of an array, then it won't StartWith prefix
                     break;
                 string header = HeaderText(prop);
                 if (header != null)


### PR DESCRIPTION
### Purpose of this PR

This fixes https://jira.unity3d.com/browse/CMCL-779 for some other cases for which https://github.com/Unity-Technologies/com.unity.cinemachine/pull/394 was not enough.

So these two PRs fix https://jira.unity3d.com/browse/CMCL-779 together.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested (2.7, 2.8, 2.9)

### Documentation status

No need to add new changelog, because https://github.com/Unity-Technologies/com.unity.cinemachine/pull/394's changelog is valid for this one too.

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

### Comments to reviewers

### Package version

- [ ] Updated package version
