### PR TITLE
CMCL-809: Backports for 2.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.6.12] - 2022-02-15
+- Bugfix: Standalone profiler no longer crashed with CM.
+
+
 ## [2.6.11] - 2021-10-05
 - Bugfix: OnTargetObjectWarped() did not work properly for 3rdPersonFollow.
 - Bugfix: POV did not properly handle overridden up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.6.12] - 2022-02-15
 - Bugfix: Standalone profiler no longer crashed with CM.
 - Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
+- Timeline guards added to scripts that rely on it.
 
 
 ## [2.6.11] - 2021-10-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.6.12] - 2022-02-15
 - Bugfix: Standalone profiler no longer crashed with CM.
+- Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
 
 
 ## [2.6.11] - 2021-10-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Standalone profiler no longer crashes with CM.
 - Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
 - Timeline guards added to scripts that rely on it.
+- Regression fix: Axis input was ignoring CM's IgnoreTimeScale setting.
 
 
 ## [2.6.11] - 2021-10-05

--- a/Editor/Helpers/CinemachineTriggerActionEditor.cs
+++ b/Editor/Helpers/CinemachineTriggerActionEditor.cs
@@ -82,6 +82,7 @@ namespace Cinemachine.Editor
                 if (isBoost)
                     EditorGUILayout.PropertyField(property.FindPropertyRelative(() => def.m_BoostAmount));
 
+#if CINEMACHINE_TIMELINE
                 bool isPlay = actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.Mode.Play;
                 if (isPlay)
                 {
@@ -97,7 +98,7 @@ namespace Cinemachine.Editor
                     InspectorUtility.MultiPropertyOnLine(
                         EditorGUILayout.GetControlRect(), null, props, sublabels);
                 }
-
+#endif
                 if (actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.Mode.Custom)
                 {
                     EditorGUILayout.HelpBox("Use the Event() list below to call custom methods", MessageType.Info);
@@ -117,7 +118,7 @@ namespace Cinemachine.Editor
                     if (value != null && (value as Behaviour) == null)
                         EditorGUILayout.HelpBox("Target must be a Behaviour in order to Enable/Disable", MessageType.Warning);
                 }
-
+#if CINEMACHINE_TIMELINE
                 bool isPlayStop = isPlay
                     || actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.Mode.Stop;
                 if (isPlayStop)
@@ -128,7 +129,7 @@ namespace Cinemachine.Editor
                         EditorGUILayout.HelpBox("Target must have a PlayableDirector or Animator in order to Play/Stop", MessageType.Warning);
                     }
                 }
-
+#endif
                 if (!isCustom && targetProp.objectReferenceValue == null)
                     EditorGUILayout.HelpBox("No action will be taken because target is not valid", MessageType.Info);
 

--- a/Editor/Impulse/CinemachineImpulseDefinitionPropertyDrawer.cs
+++ b/Editor/Impulse/CinemachineImpulseDefinitionPropertyDrawer.cs
@@ -39,7 +39,7 @@ namespace Cinemachine.Editor
             prop.NextVisible(true); // Skip outer foldout
             do
             {
-                if (!prop.propertyPath.StartsWith(prefix))
+                if (!prop.propertyPath.Contains(prefix)) // if it is part of an array, then it won't StartWith prefix
                     break;
                 string header = HeaderText(prop);
                 if (header != null)
@@ -68,7 +68,7 @@ namespace Cinemachine.Editor
             prop.NextVisible(true); // Skip outer foldout
             do
             {
-                if (!prop.propertyPath.StartsWith(prefix))
+                if (!prop.propertyPath.Contains(prefix)) // if it is part of an array, then it won't StartWith prefix
                     break;
                 string header = HeaderText(prop);
                 if (header != null)

--- a/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -148,10 +148,14 @@ namespace Cinemachine.Editor
             Type type = property.serializedObject.targetObject.GetType();
             var a = property.propertyPath.Split('.');
             for (int i = 0; i < a.Length; ++i)
-                type = type.GetField(a[i],
+            {
+                var field = type.GetField(a[i],
                     System.Reflection.BindingFlags.Public
                     | System.Reflection.BindingFlags.NonPublic
-                    | System.Reflection.BindingFlags.Instance).FieldType;
+                    | System.Reflection.BindingFlags.Instance);
+                if (field == null) continue;
+                type = field.FieldType;
+            }
             return type;
         }
 

--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -232,6 +232,30 @@ namespace Cinemachine.Editor
 
         internal static event Action AdditionalCategories = null;
 
+#if !UNITY_2021_2_OR_NEWER
+        [InitializeOnLoadMethod]
+        /// Ensures that CM Brain logo is added to the Main Camera
+        /// after adding a virtual camera to the project for the first time
+        static void OnPackageLoadedInEditor()
+        {
+#if UNITY_2020_3_OR_NEWER
+            // Nothing to load in the context of a secondary process.
+            if ((int)UnityEditor.MPE.ProcessService.level == 2 /*UnityEditor.MPE.ProcessLevel.Secondary*/)
+                return;
+#endif
+            if (CinemachineLogoTexture == null) 
+            {
+                // After adding the CM to a project, we need to wait for one update cycle for the assets to load
+                EditorApplication.update -= OnPackageLoadedInEditor;
+                EditorApplication.update += OnPackageLoadedInEditor; 
+            }
+            else
+            {
+                EditorApplication.update -= OnPackageLoadedInEditor;
+                EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyGUI; // Update hierarchy with CM Brain logo
+            }
+        }
+
         static CinemachineSettings()
         {
             if (CinemachineLogoTexture != null)

--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -263,6 +263,7 @@ namespace Cinemachine.Editor
                 EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyGUI;
             }
         }
+#endif
 
         class Styles {
             //private static readonly GUIContent sCoreShowHiddenObjectsToggle = new GUIContent("Show Hidden Objects", "If checked, Cinemachine hidden objects will be shown in the inspector.  This might be necessary to repair broken script mappings when upgrading from a pre-release version");

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -197,11 +197,11 @@ namespace Cinemachine
         public bool HasInputProvider { get => m_InputAxisProvider != null; }
 
         /// <summary>
-        /// Updates the state of this axis based on the axis defined
+        /// Updates the state of this axis based on the Input axis defined
         /// by AxisState.m_AxisName
         /// </summary>
         /// <param name="deltaTime">Delta time in seconds</param>
-        /// <returns>Returns <b>true</b> if this axis' input was non-zero this Update,
+        /// <returns>Returns <b>true</b> if this axis's input was non-zero this Update,
         /// <b>false</b> otherwise</returns>
         public bool Update(float deltaTime)
         {
@@ -213,9 +213,9 @@ namespace Cinemachine
             // Cheating: we want the render frame time, not the fixed frame time
             if (CinemachineCore.UniformDeltaTimeOverride >= 0)
                 deltaTime = CinemachineCore.UniformDeltaTimeOverride; 
-            else if (deltaTime >= 0 && m_LastUpdateTime != 0)
-                deltaTime = Time.time - m_LastUpdateTime;
-            m_LastUpdateTime = Time.time;
+            else if (Time.inFixedTimeStep && deltaTime >= 0 && m_LastUpdateTime != 0)
+                deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
+            m_LastUpdateTime = Time.realtimeSinceStartup;
             
             if (m_InputAxisProvider != null)
                 m_InputAxisValue = m_InputAxisProvider.GetAxisValue(m_InputAxisIndex);

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -23,7 +23,7 @@ namespace Cinemachine
         public static readonly int kStreamingVersion = 20170927;
 
         /// <summary>Human-readable Cinemachine Version</summary>
-        public static readonly string kVersionString = "2.6.11";
+        public static readonly string kVersionString = "2.6.12";
 
         /// <summary>
         /// Stages in the Cinemachine Component pipeline, used for

--- a/Runtime/Helpers/CinemachineTriggerAction.cs
+++ b/Runtime/Helpers/CinemachineTriggerAction.cs
@@ -68,10 +68,12 @@ namespace Cinemachine
                 Enable,
                 /// <summary>Disable a component</summary>
                 Disable,
+#if CINEMACHINE_TIMELINE
                 /// <summary>Start animation on target</summary>
                 Play,
                 /// <summary>Stop animation on target</summary>
                 Stop
+#endif
             }
 
             /// <summary>Serializable parameterless game event</summary>
@@ -169,6 +171,7 @@ namespace Cinemachine
                                     targetBehaviour.enabled = false;
                                 break;
                             }
+#if CINEMACHINE_TIMELINE
                         case Mode.Play:
                             {
                                 PlayableDirector playable
@@ -219,6 +222,7 @@ namespace Cinemachine
                                 }
                                 break;
                             }
+#endif
                     }
                 }
                 m_Event.Invoke();

--- a/Samples~/Cinemachine Example Scenes/Scenes/Trigger volumes/GenericTrigger.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/Trigger volumes/GenericTrigger.cs
@@ -1,37 +1,37 @@
-﻿using UnityEngine;
+﻿#if CINEMACHINE_TIMELINE
+using UnityEngine;
 using UnityEngine.Playables;
 
 namespace Cinemachine.Examples
 {
-
-public class GenericTrigger : MonoBehaviour
-{
-    public PlayableDirector timeline;
-    
-    // Use this for initialization
-    void Start()
+    public class GenericTrigger : MonoBehaviour
     {
-        timeline = GetComponent<PlayableDirector>();
-    }
-
-    void OnTriggerExit(Collider c)
-    {
-        if (c.gameObject.CompareTag("Player"))
+        public PlayableDirector timeline;
+        
+        // Use this for initialization
+        void Start()
         {
-            // Jump to the end of the timeline where the blend happens
-            // This value (in seconds) needs to be adjusted as needed if the timeline is modified
-            timeline.time = 27; 
+            timeline = GetComponent<PlayableDirector>();
         }
-    }
 
-    void OnTriggerEnter(Collider c)
-    {
-        if (c.gameObject.CompareTag("Player"))
+        void OnTriggerExit(Collider c)
         {
-            timeline.Stop(); // Make sure the timeline is stopped before starting it
-            timeline.Play();
+            if (c.gameObject.CompareTag("Player"))
+            {
+                // Jump to the end of the timeline where the blend happens
+                // This value (in seconds) needs to be adjusted as needed if the timeline is modified
+                timeline.time = 27; 
+            }
+        }
+
+        void OnTriggerEnter(Collider c)
+        {
+            if (c.gameObject.CompareTag("Player"))
+            {
+                timeline.Stop(); // Make sure the timeline is stopped before starting it
+                timeline.Play();
+            }
         }
     }
 }
-
-}
+#endif

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.6.11",
+    "version": "2.6.12",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nIMPORTANT NOTE: If you are upgrading from the Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

Backports:
https://jira.unity3d.com/browse/CMCL-757 -> https://github.com/Unity-Technologies/com.unity.cinemachine/pull/385
https://jira.unity3d.com/browse/CMCL-779 -> https://github.com/Unity-Technologies/com.unity.cinemachine/pull/394 and https://github.com/Unity-Technologies/com.unity.cinemachine/pull/397
https://jira.unity3d.com/browse/CMCL-783 -> https://github.com/Unity-Technologies/com.unity.cinemachine/pull/398
https://jira.unity3d.com/browse/CMCL-622

JIRA:
https://jira.unity3d.com/browse/CMCL-809

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [x] Passed all automated tests on editors: 2019, 2020, 2021
- [x] Manually tested on editors: 2019, 2020, 2021

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

### Comments to reviewers

### Package version

- [x] Updated package version
