### PR TITLE
CMCL-826: Pasting values to prefab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
 - Timeline guards added to scripts that rely on it.
 - Bugfix: SaveDuringPlay works with ILists now.
+- Bugfix: Pasting values to prefab instances is working now.
 
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Cinemachine.Utility;
 using System.Reflection;
 using System.Linq;
-using NUnit.Framework;
 
 namespace Cinemachine.Editor
 {
@@ -236,10 +235,8 @@ namespace Cinemachine.Editor
                         }
                         return go.transform;
                     };
-                CinemachineVirtualCamera.DestroyPipelineOverride = (GameObject pipeline) =>
-                    {
-                        Undo.DestroyObjectImmediate(pipeline);
-                    };
+                CinemachineVirtualCamera.DestroyPipelineOverride = 
+                    (GameObject pipeline) => Undo.DestroyObjectImmediate(pipeline);
             }
         }
 

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -209,6 +209,7 @@ namespace Cinemachine.Editor
                                                 copy = Undo.AddComponent(oldGo, c.GetType());
                                                 Undo.RecordObject(copy, "copying pipeline");
                                                 ReflectionHelpers.CopyFields(c, copy);
+                                                vcam.InvalidateComponentPipeline();
                                             }
                                         }
                                     }


### PR DESCRIPTION
### Purpose of this PR

Partial fix for https://jira.unity3d.com/browse/CMCL-829. I could not figure out how to fix pasting to prefab that is an asset (e.g. in the Assets folder, not in the scene).

I used this script to show hidden gameobjects, useful for checking what's going on. 
```
using Cinemachine;
using UnityEngine;

[ExecuteAlways]
public class ShowCMHidden : MonoBehaviour
{
    public bool Show;
    void Update()
    {
        CinemachineCore.sShowHiddenObjects = Show;
    }
}
```

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

### Comments to reviewers

### Package version

- [ ] Updated package version
