### PR TITLE
CMCL-841: Yamato package signing

### DIFF
--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -6,6 +6,8 @@ pack:
     type: Unity::VM
     image: package-ci/ubuntu:stable
     flavor: b1.large
+  variables:
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack

--- a/.yamato/package-promotion.yml
+++ b/.yamato/package-promotion.yml
@@ -8,6 +8,7 @@ promote:
     flavor: b1.large
   variables:
     UPMCI_PROMOTION: 1
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package promote


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-841: Package PR merge to trunk is blocked because APV fails because package is not signed. Added variable to yamato to trigger signing.

This will need to backported to each release branch.

### Testing status
### Documentation status
### Technical risk
### Comments to reviewers
It's not clear if I need to add the variable to the promotion or pack or publish yamato files.

### Package version