### PR TITLE
CMCL-862: POV orientation was incorrect with world up override set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Timeline guards added to scripts that rely on it.
 - Bugfix: SaveDuringPlay works with ILists now.
 - Bugfix: CinemachineInputProvider now correctly tracks enabled state of input action
+- Bugfix: POV orientation was incorrect with World Up override
 
 
 ## [2.9.0-pre.6] - 2022-01-12

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -132,9 +132,13 @@ namespace Cinemachine
             // If we have a transform parent, then apply POV in the local space of the parent
             Quaternion rot = Quaternion.Euler(m_VerticalAxis.Value, m_HorizontalAxis.Value, 0);
             Transform parent = VirtualCamera.transform.parent;
+            var up = Vector3.up;
             if (parent != null)
+            {
                 rot = parent.rotation * rot;
-            rot = Quaternion.FromToRotation(Vector3.up, curState.ReferenceUp) * rot;
+                up = parent.up;
+            }
+            rot = Quaternion.FromToRotation(up, curState.ReferenceUp) * rot;
             curState.RawOrientation = rot;
         }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-862 

https://forum.unity.com/threads/initial-viewing-direction-of-pov-camera.621202/#post-7979415

POV orientation is wrong when there is a WorldUp override

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

