### PR TITLE
CMCL-514: Hovering and knowing which handles are picked/dragged

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -73,9 +73,14 @@ namespace Cinemachine.Editor
 
                 EditorGUI.BeginChangeCheck();
                 // shoulder handle
-                var sHandleMinId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+#if UNITY_2022_2_OR_NEWER
+                var sHandleIds = Handles.PositionHandleIds.@default;
+                var newShoulderPosition = Handles.PositionHandle(sHandleIds, shoulderPosition, heading);
+#else
+                var sHandleMinId = GUIUtility.GetControlID(FocusType.Passive);
                 var newShoulderPosition = Handles.PositionHandle(shoulderPosition, heading);
-                var sHandleMaxId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+                var sHandleMaxId = GUIUtility.GetControlID(FocusType.Passive);
+#endif
 
                 Handles.color = Handles.preselectionColor;
                 // arm handle
@@ -108,6 +113,16 @@ namespace Cinemachine.Editor
                     so.ApplyModifiedProperties();
                 }
 
+#if UNITY_2022_2_OR_NEWER
+                var isDragged = IsHandleDragged(sHandleIds.x, sHandleIds.xyz, shoulderPosition, "Shoulder Offset " 
+                    + thirdPerson.ShoulderOffset.ToString("F1"), followTargetPosition, shoulderPosition);
+                isDragged |= IsHandleDragged(aHandleId, aHandleId, armPosition, "Vertical Arm Length (" 
+                    + thirdPerson.VerticalArmLength.ToString("F1") + ")", shoulderPosition, armPosition);
+                isDragged |= IsHandleDragged(cdHandleId, cdHandleId, camPos, "Camera Distance (" 
+                    + camDistance.ToString("F1") + ")", armPosition, camPos);
+
+                CinemachineSceneToolHelpers.SoloOnDrag(isDragged, thirdPerson.VirtualCamera, sHandleIds.xyz);
+#else
                 var isDragged = IsHandleDragged(sHandleMinId, sHandleMaxId, shoulderPosition, "Shoulder Offset " 
                     + thirdPerson.ShoulderOffset.ToString("F1"), followTargetPosition, shoulderPosition);
                 isDragged |= IsHandleDragged(aHandleId, aHandleId, armPosition, "Vertical Arm Length (" 
@@ -116,6 +131,7 @@ namespace Cinemachine.Editor
                     + camDistance.ToString("F1") + ")", armPosition, camPos);
 
                 CinemachineSceneToolHelpers.SoloOnDrag(isDragged, thirdPerson.VirtualCamera, sHandleMaxId);
+#endif
                 
                 Handles.color = originalColor;
             }

--- a/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -76,6 +76,8 @@ namespace Cinemachine.Editor
 #if UNITY_2022_2_OR_NEWER
                 var sHandleIds = Handles.PositionHandleIds.@default;
                 var newShoulderPosition = Handles.PositionHandle(sHandleIds, shoulderPosition, heading);
+                var sHandleMinId = sHandleIds.x - 1;
+                var sHandleMaxId = sHandleIds.xyz + 1;
 #else
                 var sHandleMinId = GUIUtility.GetControlID(FocusType.Passive);
                 var newShoulderPosition = Handles.PositionHandle(shoulderPosition, heading);
@@ -112,17 +114,7 @@ namespace Cinemachine.Editor
                     
                     so.ApplyModifiedProperties();
                 }
-
-#if UNITY_2022_2_OR_NEWER
-                var isDragged = IsHandleDragged(sHandleIds.x, sHandleIds.xyz, shoulderPosition, "Shoulder Offset " 
-                    + thirdPerson.ShoulderOffset.ToString("F1"), followTargetPosition, shoulderPosition);
-                isDragged |= IsHandleDragged(aHandleId, aHandleId, armPosition, "Vertical Arm Length (" 
-                    + thirdPerson.VerticalArmLength.ToString("F1") + ")", shoulderPosition, armPosition);
-                isDragged |= IsHandleDragged(cdHandleId, cdHandleId, camPos, "Camera Distance (" 
-                    + camDistance.ToString("F1") + ")", armPosition, camPos);
-
-                CinemachineSceneToolHelpers.SoloOnDrag(isDragged, thirdPerson.VirtualCamera, sHandleIds.xyz);
-#else
+                
                 var isDragged = IsHandleDragged(sHandleMinId, sHandleMaxId, shoulderPosition, "Shoulder Offset " 
                     + thirdPerson.ShoulderOffset.ToString("F1"), followTargetPosition, shoulderPosition);
                 isDragged |= IsHandleDragged(aHandleId, aHandleId, armPosition, "Vertical Arm Length (" 
@@ -131,8 +123,7 @@ namespace Cinemachine.Editor
                     + camDistance.ToString("F1") + ")", armPosition, camPos);
 
                 CinemachineSceneToolHelpers.SoloOnDrag(isDragged, thirdPerson.VirtualCamera, sHandleMaxId);
-#endif
-                
+
                 Handles.color = originalColor;
             }
             

--- a/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -114,7 +114,7 @@ namespace Cinemachine.Editor
                     
                     so.ApplyModifiedProperties();
                 }
-                
+
                 var isDragged = IsHandleDragged(sHandleMinId, sHandleMaxId, shoulderPosition, "Shoulder Offset " 
                     + thirdPerson.ShoulderOffset.ToString("F1"), followTargetPosition, shoulderPosition);
                 isDragged |= IsHandleDragged(aHandleId, aHandleId, armPosition, "Vertical Arm Length (" 

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -646,9 +646,16 @@ namespace Cinemachine.Editor
             var camRot = cmComponent.GetReferenceOrientation(up);
 
             EditorGUI.BeginChangeCheck();
-            var foHandleMinId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+#if UNITY_2022_2_OR_NEWER
+            var foHandleIds = Handles.PositionHandleIds.@default;
+            var newPos = Handles.PositionHandle(foHandleIds, camPos, camRot);
+            var foHandleMinId = foHandleIds.x - 1;
+            var foHandleMaxId = foHandleIds.xyz + 1;
+#else
+            var foHandleMinId = GUIUtility.GetControlID(FocusType.Passive);
             var newPos = Handles.PositionHandle(camPos, camRot);
-            var foHandleMaxId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+            var foHandleMaxId = GUIUtility.GetControlID(FocusType.Passive);
+#endif
             if (EditorGUI.EndChangeCheck())
             {
                 var so = new SerializedObject(cmComponent);

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -359,10 +359,15 @@ namespace Cinemachine.Editor
             var camForward = camRot * Vector3.forward;
                 
             EditorGUI.BeginChangeCheck();
-            var fovHandleId = GUIUtility.GetControlID(s_ScaleSliderHash, FocusType.Passive) + 1; // TODO: KGB workaround until id is exposed
-            var newFov = Handles.ScaleSlider(
-                s_FOVAfterLastToolModification, 
+#if UNITY_2022_2_OR_NEWER
+            var fovHandleId = GUIUtility.GetControlID(s_ScaleSliderHash, FocusType.Passive);
+            var newFov = Handles.ScaleSlider(fovHandleId, s_FOVAfterLastToolModification, 
                 camPos, camForward, camRot, HandleUtility.GetHandleSize(camPos), 0.1f);
+#else
+            var fovHandleId = GUIUtility.GetControlID(s_ScaleSliderHash, FocusType.Passive) + 1;
+            var newFov = Handles.ScaleSlider(
+                s_FOVAfterLastToolModification, camPos, camForward, camRot, HandleUtility.GetHandleSize(camPos), 0.1f);
+#endif
             if (EditorGUI.EndChangeCheck())
             {
                 if (orthographic)

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -5,7 +5,6 @@ using Cinemachine.Utility;
 using UnityEditor;
 using UnityEditor.EditorTools;
 using UnityEngine;
-using UnityEngine.Rendering.VirtualTexturing;
 
 namespace Cinemachine.Editor
 {

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -5,6 +5,7 @@ using Cinemachine.Utility;
 using UnityEditor;
 using UnityEditor.EditorTools;
 using UnityEngine;
+using UnityEngine.Rendering.VirtualTexturing;
 
 namespace Cinemachine.Editor
 {
@@ -598,9 +599,16 @@ namespace Cinemachine.Editor
             var trackedObjectPos = lookAtPos + lookAtRot * trackedObjectOffset.vector3Value;
 
             EditorGUI.BeginChangeCheck();
-            var tooHandleMinId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+#if UNITY_2022_2_OR_NEWER
+            var tooHandleIds = Handles.PositionHandleIds.@default;
+            var newTrackedObjectPos = Handles.PositionHandle(tooHandleIds, trackedObjectPos, lookAtRot);
+            var tooHandleMinId = tooHandleIds.x - 1;
+            var tooHandleMaxId = tooHandleIds.xyz + 1;
+#else
+            var tooHandleMinId = GUIUtility.GetControlID(FocusType.Passive);
             var newTrackedObjectPos = Handles.PositionHandle(trackedObjectPos, lookAtRot);
-            var tooHandleMaxId = GUIUtility.GetControlID(FocusType.Passive); // TODO: KGB workaround until id is exposed
+            var tooHandleMaxId = GUIUtility.GetControlID(FocusType.Passive);
+#endif
             if (EditorGUI.EndChangeCheck())
             {
                 trackedObjectOffset.vector3Value += 


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-514
We checked for ids with a hack. Now the ids can be tracked correctly for each handle (unity version 2022.2.0a9 and above), so we use that instead.

******************
EDIT: EXPLANATION
Handles have an id with which we can check if the handle is picked or hovered.

The "hack" version was needed, because there was no exposed API for some of the handles to get the handle's id, or to set the handle's id on creation. The "hack" version checked the last used id with this call: `GUIUtility.GetControlID(FocusType.Passive)`, before creating the handle, and after creating the handle. This way, I knew that the created handle should be between beforeID and afterID. The reason why I needed a range, because handles are created on threads (so I had cases when beforeID + 1 was not my handle).
This could (with low probability) cause a small bug, that you pick a non-cm handle, but our cm-handle code would think you pick it. Because this non-cm handle was unluckily created right after my beforeID call or right before my afterID call.

The new version uses the new API for the handles that did not have expose an ID field on creation. So before creating the handle, we create a set of ids, and we pass it to the handle creation method. This way, we know exactly which ids the created handle has.
******************

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status
**No user facing change, so I did not add docs.**

- [N/A] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [N/A] Updated README (if applicable)
- [N/A] Commented all public classes, properties, and methods
- [N/A] Updated user documentation

### Technical risk

### Comments to reviewers

### Package version

- [ ] Updated package version
