### PR TITLE
CMCL-876: Confiner2D confines to midpoint when camera window is bigger than the axis aligned bounding box of the input confiner

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+- Bugfix: Confiner2D confines to midpoint when camera window is bigger than the axis aligned bounding box of the input confiner.
+
+
 ## [2.9.0-pre.7] - 2022-03-29
 - Bugfix: memory leak with PostProcessing if no PP layer is present on the camera
 - Bugfix: Standalone profiler no longer crashed with CM.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -138,7 +138,7 @@ namespace Cinemachine
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 extra.m_vcam = vcam;
                 if (confinerStateChanged || extra.m_BakedSolution == null 
-                    || !extra.m_BakedSolution.IsValid(bakedSpaceFrustumHeight))
+                    || !extra.m_BakedSolution.IsValid())
                 {
                     extra.m_BakedSolution = m_shapeCache.m_confinerOven.GetBakedSolution(bakedSpaceFrustumHeight);
                 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -371,7 +371,8 @@ namespace Cinemachine
         }
 
         internal float BakeProgress() => m_shapeCache.m_confinerOven != null ? m_shapeCache.m_confinerOven.bakeProgress : 0f;
-        internal bool ConfinerOvenTimedOut() => m_shapeCache.m_confinerOven is { State: ConfinerOven.BakingState.TIMEOUT };
+        internal bool ConfinerOvenTimedOut() => m_shapeCache.m_confinerOven != null && 
+            m_shapeCache.m_confinerOven.State == ConfinerOven.BakingState.TIMEOUT;
 #endif
 
         void OnValidate()

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -263,10 +263,6 @@ namespace Cinemachine
         /// </summary>
         public BakedSolution GetBakedSolution(float frustumHeight)
         {
-            frustumHeight = m_Cache.userSetMaxFrustumHeight < 0
-                ? frustumHeight
-                : Mathf.Min(m_Cache.userSetMaxFrustumHeight, frustumHeight);
-            
             // Special case, when we want to shrink to a point
             if (State == BakingState.BAKED && frustumHeight > m_Cache.theoriticalMaxFrustumHeight && 
                 m_Cache.userSetMaxFrustumHeight >= 0)
@@ -278,6 +274,10 @@ namespace Cinemachine
                     m_AspectStretcher.Aspect, frustumHeight, m_MinFrustumHeightWithBones < frustumHeight,
                     m_PolygonRect, m_OriginalPolygon, PolygonSolution.Lerp(s1, s2, frustumHeight).polygons);
             }
+            
+            frustumHeight = m_Cache.userSetMaxFrustumHeight < 0
+                ? frustumHeight
+                : Mathf.Min(m_Cache.userSetMaxFrustumHeight, frustumHeight);
 
             // Inflate with clipper to frustumHeight
             var offsetter = new ClipperOffset();

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -430,10 +430,10 @@ namespace Cinemachine
             m_Cache.currentFrustumHeight = 0;
             m_Cache.maxCandidate = new List<List<IntPoint>>();
             m_Cache.offsetter.Execute(ref m_Cache.maxCandidate, -1f * m_Cache.maxFrustumHeight * k_FloatToIntScaler);
-            if (m_Cache.maxCandidate == null || m_Cache.maxCandidate.Count == 0)
-            {
-                m_Cache.maxCandidate = new List<List<IntPoint>> { new List<IntPoint> { m_Cache.midPoint } };
-            }
+            // if (m_Cache.maxCandidate == null || m_Cache.maxCandidate.Count == 0)
+            // {
+            //     m_Cache.maxCandidate = new List<List<IntPoint>> { new List<IntPoint> { m_Cache.midPoint } };
+            // }
 
             m_Cache.bakeTime = 0;
             State = BakingState.BAKING;
@@ -527,18 +527,18 @@ namespace Cinemachine
                 }
 
                 // Pause after max time per iteration reached
-                var elapsedTime = Time.realtimeSinceStartup - startTime;
-                if (elapsedTime > maxComputationTimePerFrameInSeconds)
-                {
-                    m_Cache.bakeTime += elapsedTime;
-                    if (m_Cache.bakeTime > m_maxComputationTimeForFullSkeletonBakeInSeconds)
-                    {
-                        State = BakingState.TIMEOUT; 
-                    }
-
-                    m_BakeProgress = m_Cache.leftCandidate.m_FrustumHeight / m_Cache.maxFrustumHeight;
-                    return;
-                }
+                // var elapsedTime = Time.realtimeSinceStartup - startTime;
+                // if (elapsedTime > maxComputationTimePerFrameInSeconds)
+                // {
+                //     m_Cache.bakeTime += elapsedTime;
+                //     if (m_Cache.bakeTime > m_maxComputationTimeForFullSkeletonBakeInSeconds)
+                //     {
+                //         State = BakingState.TIMEOUT; 
+                //     }
+                //
+                //     m_BakeProgress = m_Cache.leftCandidate.m_FrustumHeight / m_Cache.maxFrustumHeight;
+                //     return;
+                // }
             }
 
             ComputeSkeleton(in m_Cache.solutions);

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -98,7 +98,7 @@ namespace Cinemachine
                 return m_AspectStretcher.Unstretch(result);
                 
                 // local functions
-                static IntPoint IntPointLerp(IntPoint a, IntPoint b, float lerp)
+                IntPoint IntPointLerp(IntPoint a, IntPoint b, float lerp)
                 {
                     return new IntPoint
                     {
@@ -110,7 +110,7 @@ namespace Cinemachine
                 bool IsInsideOriginal(IntPoint p) => 
                     m_OriginalPolygon.Any(t => Clipper.PointInPolygon(p, t) != 0);
 
-                static float ClosestPointOnSegment(IntPoint p, IntPoint s0, IntPoint s1)
+                float ClosestPointOnSegment(IntPoint p, IntPoint s0, IntPoint s1)
                 {
                     double sX = s1.X - s0.X;
                     double sY = s1.Y - s0.Y;
@@ -123,6 +123,7 @@ namespace Cinemachine
                     var dot = s0pX * sX + s0pY * sY;
                     return Mathf.Clamp01((float) (dot / len2));
                 }
+                
                 bool DoesIntersectOriginal(IntPoint l1, IntPoint l2)
                 {
                     foreach (var original in m_OriginalPolygon)
@@ -201,7 +202,7 @@ namespace Cinemachine
                 return (t1 >= 0 && t1 <= 1 && t2 >= 0 && t2 < 1) ? 2 : 1; // 2 = segments intersect, 1 = lines intersect
                 
                 // local function
-                static double IntPointDiffSqrMagnitude(IntPoint p1, IntPoint p2)
+                double IntPointDiffSqrMagnitude(IntPoint p1, IntPoint p2)
                 {
                     double x = p1.X - p2.X;
                     double y = p1.Y - p2.Y;
@@ -412,7 +413,7 @@ namespace Cinemachine
             bakeProgress = 0;
             
             // local functions
-            static Rect GetPolygonBoundingBox(in List<List<Vector2>> polygons)
+            Rect GetPolygonBoundingBox(in List<List<Vector2>> polygons)
             {
                 float minX = float.PositiveInfinity, maxX = float.NegativeInfinity;
                 float minY = float.PositiveInfinity, maxY = float.NegativeInfinity;
@@ -430,7 +431,7 @@ namespace Cinemachine
                 return new Rect(minX, minY, Mathf.Max(0, maxX - minX), Mathf.Max(0, maxY - minY));
             }
 
-            static IntPoint MidPointOfIntRect(IntRect bounds) => 
+            IntPoint MidPointOfIntRect(IntRect bounds) => 
                 new IntPoint((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
         }
         

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -372,7 +372,7 @@ namespace Cinemachine
             }
 
             // Don't compute further than what is the theoretical max
-            m_Cache.theoriticalMaxFrustumHeight = Mathf.Min(m_PolygonRect.width / aspectRatio, m_PolygonRect.height) / 2f;
+            m_Cache.theoriticalMaxFrustumHeight = Mathf.Max(m_PolygonRect.width / aspectRatio, m_PolygonRect.height) / 2f;
  
             // exact comparison to 0 is intentional!
             if (m_Cache.userSetMaxFrustumHeight == 0 || m_Cache.userSetMaxFrustumHeight > m_Cache.theoriticalMaxFrustumHeight) 

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -409,6 +409,7 @@ namespace Cinemachine
             State = BakingState.BAKING;
             bakeProgress = 0;
             
+            // local functions
             static Rect GetPolygonBoundingBox(in List<List<Vector2>> polygons)
             {
                 float minX = float.PositiveInfinity, maxX = float.NegativeInfinity;

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -107,10 +107,10 @@ namespace Cinemachine
                     };
                 }
                 
-                bool IsInsideOriginal(IntPoint p) => 
-                    m_OriginalPolygon.Any(t => Clipper.PointInPolygon(p, t) != 0);
+                bool IsInsideOriginal(IntPoint point) => 
+                    m_OriginalPolygon.Any(t => Clipper.PointInPolygon(point, t) != 0);
 
-                float ClosestPointOnSegment(IntPoint p, IntPoint s0, IntPoint s1)
+                float ClosestPointOnSegment(IntPoint point, IntPoint s0, IntPoint s1)
                 {
                     double sX = s1.X - s0.X;
                     double sY = s1.Y - s0.Y;
@@ -118,8 +118,8 @@ namespace Cinemachine
                     if (len2 < k_ClipperEpsilon)
                         return 0; // degenerate segment
 
-                    double s0pX = p.X - s0.X;
-                    double s0pY = p.Y - s0.Y;
+                    double s0pX = point.X - s0.X;
+                    double s0pY = point.Y - s0.Y;
                     var dot = s0pX * sX + s0pY * sY;
                     return Mathf.Clamp01((float) (dot / len2));
                 }
@@ -202,10 +202,10 @@ namespace Cinemachine
                 return (t1 >= 0 && t1 <= 1 && t2 >= 0 && t2 < 1) ? 2 : 1; // 2 = segments intersect, 1 = lines intersect
                 
                 // local function
-                double IntPointDiffSqrMagnitude(IntPoint p1, IntPoint p2)
+                double IntPointDiffSqrMagnitude(IntPoint point1, IntPoint point2)
                 {
-                    double x = p1.X - p2.X;
-                    double y = p1.Y - p2.Y;
+                    double x = point1.X - point2.X;
+                    double y = point1.Y - point2.Y;
                     return x * x + y * y;
                 }
             }

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -290,7 +290,7 @@ namespace Cinemachine
             offsetter.Execute(ref solution, -1f * frustumHeight * k_FloatToIntScaler);
             if (solution.Count == 0)
             {
-                solution = new List<List<IntPoint>> { new List<IntPoint> { m_Cache.midPoint } };
+                solution = new List<List<IntPoint>> { new List<IntPoint> { m_Cache.midPoint } }; // TODO: we need this when window is huge, bigger both ways
             }
 
             // Add in the skeleton

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -252,7 +252,7 @@ namespace Cinemachine
         public BakedSolution GetBakedSolution(float frustumHeight)
         {
             // If the user has set a max frustum height, respect it
-            frustumHeight = m_Cache.userSetMaxFrustumHeight == 0
+            frustumHeight = m_Cache.userSetMaxFrustumHeight <= 0
                 ? frustumHeight
                 : Mathf.Min(m_Cache.userSetMaxFrustumHeight, frustumHeight);
             
@@ -346,6 +346,9 @@ namespace Cinemachine
             // calculate mid point and use it as the most shrank down version
             m_PolygonRect = GetPolygonBoundingBox(inputPath);
             m_AspectStretcher = new AspectStretcher(aspectRatio, m_PolygonRect.center.x);
+            
+            // Don't compute further than what is the theoretical max
+            m_Cache.theoriticalMaxFrustumHeight = Mathf.Max(m_PolygonRect.width / aspectRatio, m_PolygonRect.height) / 2f;
 
             // Initialize clipper
             m_OriginalPolygon = new List<List<IntPoint>>(inputPath.Count);
@@ -363,7 +366,7 @@ namespace Cinemachine
                 m_OriginalPolygon.Add(path);
             }
             m_MidPoint = MidPointOfIntRect(ClipperBase.GetBounds(m_OriginalPolygon));
-        
+
             // Skip the expensive skeleton calculation if it's not wanted (oversized window off)
             if (m_Cache.userSetMaxFrustumHeight < 0)
             {
@@ -371,9 +374,6 @@ namespace Cinemachine
                 return;
             }
 
-            // Don't compute further than what is the theoretical max
-            m_Cache.theoriticalMaxFrustumHeight = Mathf.Max(m_PolygonRect.width / aspectRatio, m_PolygonRect.height) / 2f;
- 
             // exact comparison to 0 is intentional!
             m_Cache.maxFrustumHeight = m_Cache.userSetMaxFrustumHeight;
             if (m_Cache.maxFrustumHeight == 0 || m_Cache.maxFrustumHeight > m_Cache.theoriticalMaxFrustumHeight) 

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -281,12 +281,14 @@ namespace Cinemachine
         /// </summary>
         public BakedSolution GetBakedSolution(float frustumHeight)
         {
+            frustumHeight = Mathf.Min(m_Cache.maxFrustumHeight, frustumHeight);
+            
             // Inflate with clipper to frustumHeight
             var offsetter = new ClipperOffset();
             offsetter.AddPaths(m_OriginalPolygon, JoinType.jtMiter, EndType.etClosedPolygon);
             var solution = new List<List<IntPoint>>();
             offsetter.Execute(ref solution, -1f * frustumHeight * k_FloatToIntScaler);
-            if (frustumHeight >= m_Cache.maxFrustumHeight && solution.Count == 0)
+            if (solution.Count == 0)
             {
                 solution = new List<List<IntPoint>> { new List<IntPoint> { m_Cache.midPoint } };
             }
@@ -348,7 +350,7 @@ namespace Cinemachine
             public PolygonSolution leftCandidate;
             public List<List<IntPoint>> maxCandidate;
             public float stepSize;
-            public float maxFrustumHeight;
+            public float maxFrustumHeight; // either set by the user, or the theoretical maximum
             public float currentFrustumHeight;
 
             public IntPoint midPoint;

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -200,6 +200,7 @@ namespace Cinemachine
                 double t2 = ((p3.X - p1.X) * dy12 + (p1.Y - p3.Y) * dx12) / -denominator;
                 return (t1 >= 0 && t1 <= 1 && t2 >= 0 && t2 < 1) ? 2 : 1; // 2 = segments intersect, 1 = lines intersect
                 
+                // local function
                 static double IntPointDiffSqrMagnitude(IntPoint p1, IntPoint p2)
                 {
                     double x = p1.X - p2.X;

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -282,7 +282,7 @@ namespace Cinemachine
         /// </summary>
         public BakedSolution GetBakedSolution(float frustumHeight)
         {
-            frustumHeight = Mathf.Min(m_Cache.userSetMaxFrustumHeight, frustumHeight); // TODO: need to have a user set max to check here!
+            frustumHeight = m_Cache.userSetMaxFrustumHeight < 0 ? frustumHeight : Mathf.Min(m_Cache.userSetMaxFrustumHeight, frustumHeight); // TODO: need to have a user set max to check here!
             
             // Inflate with clipper to frustumHeight
             var offsetter = new ClipperOffset();


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-876
Confiner2D confines to midpoint when camera window is bigger than the axis aligned bounding box of the input confiner.

This case was not cover, and was reported by a user. + code cleanup

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
