### PR TITLE
Updated asmdef with new 2D URP assembly

### DIFF
--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "Cinemachine",
-    "rootNamespace": "",
     "references": [
         "Unity.Timeline",
         "Unity.Postprocessing.Runtime",

--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Cinemachine",
+    "rootNamespace": "",
     "references": [
         "Unity.Timeline",
         "Unity.Postprocessing.Runtime",
@@ -8,7 +9,8 @@
         "Unity.ugui",
         "Unity.RenderPipelines.Universal.Runtime",
         "Unity.2D.PixelPerfect",
-        "Unity.InputSystem"
+        "Unity.InputSystem",
+        "Unity.RenderPipelines.Universal.2D.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
### Purpose of this PR
This PR added an assembly reference to prevent compile errors with PixelPerfectCamera when using a future version of URP.

### Testing status
Tested against:
* UniversalGraphicsTest_2D
* UniversalGraphicsTest_Foundation

### Technical risk
The change should pose little technical risk or halo effect as only a single reference was added to an asmdef



