### PR TITLE
CMCL-881: overlays for cm3

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineFramingTransposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFramingTransposerEditor.cs
@@ -254,7 +254,7 @@ namespace Cinemachine.Editor
                 Handles.color = cameraDistanceHandleIsUsedOrHovered ? 
                     Handles.selectedColor : CinemachineSceneToolHelpers.HelperLineDefaultColor;
                 Handles.DrawLine(camPos, 
-                    framingTransposer.FollowTarget.position + framingTransposer.m_TrackedObjectOffset);
+                    framingTransposer.FollowTargetPosition + framingTransposer.m_TrackedObjectOffset);
 
                 CinemachineSceneToolHelpers.SoloOnDrag(cameraDistanceHandleIsDragged, framingTransposer.VirtualCamera,
                     cdHandleId);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookEditor.cs
@@ -150,7 +150,7 @@ namespace Cinemachine
             }
             else if (freelook.Follow != null && CinemachineSceneToolUtility.IsToolActive(typeof(FollowOffsetTool)))
             {
-                var draggedRig = CinemachineSceneToolHelpers.OrbitControlHandle(freelook,
+                var draggedRig = CinemachineSceneToolHelpers.OrbitControlHandleFreelook(freelook,
                     new SerializedObject(freelook).FindProperty(() => freelook.m_Orbits));
                 if (draggedRig >= 0)
                     SetSelectedRig(Target, draggedRig);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -90,10 +90,19 @@ namespace Cinemachine.Editor
             DrawRemainingPropertiesInInspector();
         }
         
+        static GUIContent[] s_OrbitNames = 
+        {
+            new GUIContent("Top"), 
+            new GUIContent("Middle"), 
+            new GUIContent("Bottom")
+        };
+        internal static GUIContent[] orbitNames => s_OrbitNames;
+        
         protected virtual void OnEnable()
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
+            CinemachineSceneToolUtility.RegisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }
         
@@ -101,6 +110,7 @@ namespace Cinemachine.Editor
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
+            CinemachineSceneToolUtility.UnregisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }
    

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -89,6 +89,45 @@ namespace Cinemachine.Editor
             }
             DrawRemainingPropertiesInInspector();
         }
+        
+        protected virtual void OnEnable()
+        {
+#if UNITY_2021_2_OR_NEWER
+            CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
+#endif
+        }
+        
+        protected virtual void OnDisable()
+        {
+#if UNITY_2021_2_OR_NEWER
+            CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
+#endif
+        }
+   
+#if UNITY_2021_2_OR_NEWER     
+        void OnSceneGUI()
+        {
+            DrawSceneTools();
+        }
+        
+        void DrawSceneTools()
+        {
+            var orbitalFollow = Target;
+            if (orbitalFollow == null || !orbitalFollow.IsValid)
+            {
+                return;
+            }
+            
+            var originalColor = Handles.color;
+            Handles.color = Handles.preselectionColor;
+            if (CinemachineSceneToolUtility.IsToolActive(typeof(FollowOffsetTool)))
+            {
+                CinemachineSceneToolHelpers.OrbitControlHandleOrbitalFollow(orbitalFollow.VirtualCamera,
+                    new SerializedObject(orbitalFollow).FindProperty(() => orbitalFollow.Orbits));
+            }
+            Handles.color = originalColor;
+        }
+#endif
 
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineOrbitalFollow))]
         static void DrawOrbitalGizmos(CinemachineOrbitalFollow orbital, GizmoType selectionType)

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -102,6 +102,8 @@ namespace Cinemachine.Editor
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
+#endif
+#if UNITY_2022_1_OR_NEWER
             CinemachineSceneToolUtility.RegisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }
@@ -110,6 +112,8 @@ namespace Cinemachine.Editor
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
+#endif
+#if UNITY_2022_1_OR_NEWER
             CinemachineSceneToolUtility.UnregisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -180,6 +180,8 @@ namespace Cinemachine.Editor
         }
 #endif
 
+        // TODO: ask swap's opinion on this. Do we want to always draw this or only when follow offset handle is not selected
+        // TODO: what color? when follow offset handle is selected, do we want to draw CameraPath.
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineOrbitalFollow))]
         static void DrawOrbitalGizmos(CinemachineOrbitalFollow orbital, GizmoType selectionType)
         {

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using UnityEditor;
 using System.Collections.Generic;
@@ -172,7 +171,7 @@ namespace Cinemachine.Editor
                         break;
                     default:
                         Debug.LogError("OrbitStyle has no associated handle");
-                        throw new ArgumentOutOfRangeException();
+                        throw new System.ArgumentOutOfRangeException();
                 }
                 
             }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -131,7 +131,6 @@ namespace Cinemachine.Editor
                             var camPos = orbitalFollow.VcamState.RawPosition;
                             var camTransform = orbitalFollow.VirtualCamera.transform;
                             var camRight = camTransform.right;
-                            var camUp = camTransform.up;
                             var followPos = orbitalFollow.FollowTargetPosition;
                             var handlePos = followPos + camRight * orbitalFollow.Radius;
                             var rHandleId = GUIUtility.GetControlID(FocusType.Passive);
@@ -159,7 +158,7 @@ namespace Cinemachine.Editor
                             Handles.color = orbitRadiusHandleIsUsedOrHovered ? 
                                 Handles.selectedColor : CinemachineSceneToolHelpers.HelperLineDefaultColor;
                             Handles.DrawLine(camPos, followPos);
-                            Handles.DrawWireDisc(followPos, camUp, orbitalFollow.Radius);
+                            Handles.DrawWireDisc(followPos, camTransform.up, orbitalFollow.Radius);
                             
                             CinemachineSceneToolHelpers.SoloOnDrag(
                                 orbitRadiusHandleIsDragged, orbitalFollow.VirtualCamera, rHandleId);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -102,8 +102,6 @@ namespace Cinemachine.Editor
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
-#endif
-#if UNITY_2022_1_OR_NEWER
             CinemachineSceneToolUtility.RegisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }
@@ -112,8 +110,6 @@ namespace Cinemachine.Editor
         {
 #if UNITY_2021_2_OR_NEWER
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
-#endif
-#if UNITY_2022_1_OR_NEWER
             CinemachineSceneToolUtility.UnregisterTool(typeof(OrbitalFollowOrbitSelection));
 #endif
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -93,7 +93,7 @@ namespace Cinemachine.Editor
         static GUIContent[] s_OrbitNames = 
         {
             new GUIContent("Top"), 
-            new GUIContent("Middle"), 
+            new GUIContent("Center"), 
             new GUIContent("Bottom")
         };
         internal static GUIContent[] orbitNames => s_OrbitNames;

--- a/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
+++ b/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
@@ -391,34 +391,30 @@ namespace Cinemachine.Editor
 
         void ShadowSelectedRigName()
         {
-#if GML_FIXME
-            var index = Mathf.Clamp(SelectedRig, 0, CinemachineNewFreeLookEditor.m_OrbitNames.Length - 1);
+            var index = Mathf.Clamp(SelectedRig, 0, CinemachineFreeLookEditor.RigNames.Length - 1);
             icon = m_Icons[index];
-            text = CinemachineNewFreeLookEditor.m_OrbitNames[index].text;
-#endif
+            text = CinemachineFreeLookEditor.RigNames[index].text;
         }
         
         void FreelookRigSelectionMenu()
         {
-#if GML_FIXME
             var menu = new GenericMenu();
-            for (var i = 0; i < CinemachineNewFreeLookEditor.m_OrbitNames.Length; ++i)
+            for (var i = 0; i < CinemachineFreeLookEditor.RigNames.Length; ++i)
             {
                 var rigIndex = i; // vital to capture the index here for the lambda below
-                menu.AddItem(CinemachineNewFreeLookEditor.m_OrbitNames[i], false, () =>
+                menu.AddItem(CinemachineFreeLookEditor.RigNames[i], false, () =>
                 {
                     SelectedRig = rigIndex;
                     var active = Selection.activeObject as GameObject;
                     if (active != null)
                     {
-                        var freelook = active.GetComponent<CmFreeLook>();
+                        var freelook = active.GetComponent<CinemachineFreeLook>();
                         if (freelook != null)
-                            CinemachineNewFreeLookEditor.SetSelectedRig(freelook, rigIndex);
+                            CinemachineFreeLookEditor.SetSelectedRig(freelook, rigIndex);
                     }
                 });
             }
             menu.DropDown(worldBound);
-#endif
         }
     }
 #endif

--- a/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
+++ b/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
@@ -179,75 +179,6 @@ namespace Cinemachine.Editor
     }
     
     [EditorToolbarElement(id, typeof(SceneView))]
-    class FreelookRigSelection : EditorToolbarDropdown
-    {
-        public const string id = "FreelookRigSelection/Dropdown";
-        public static int SelectedRig;
-        Texture2D[] m_Icons;
-
-        public FreelookRigSelection()
-        {
-            tooltip = "Freelook Rig Selection";
-            clicked += FreelookRigSelectionMenu;
-            EditorApplication.update += ShadowSelectedRigName;
-            EditorApplication.update += DisplayIfRequired;
-            
-            m_Icons = new Texture2D[]
-            {
-                AssetDatabase.LoadAssetAtPath<Texture2D>(ScriptableObjectUtility.CinemachineRealativeInstallPath
-                    + "/Editor/EditorResources/Handles/FreelookRigTop.png"),
-                AssetDatabase.LoadAssetAtPath<Texture2D>(ScriptableObjectUtility.CinemachineRealativeInstallPath
-                    + "/Editor/EditorResources/Handles/FreelookRigMiddle.png"),
-                AssetDatabase.LoadAssetAtPath<Texture2D>(ScriptableObjectUtility.CinemachineRealativeInstallPath
-                    + "/Editor/EditorResources/Handles/FreelookRigBottom.png"),
-            };
-        }
-
-        ~FreelookRigSelection()
-        {
-            clicked -= FreelookRigSelectionMenu;
-            EditorApplication.update -= ShadowSelectedRigName;
-            EditorApplication.update -= DisplayIfRequired;
-        }
-
-        Type m_FreelookRigSelectionType = typeof(FreelookRigSelection);
-        void DisplayIfRequired() => style.display = 
-            CinemachineSceneToolUtility.IsToolRequired(m_FreelookRigSelectionType) 
-                ? DisplayStyle.Flex : DisplayStyle.None;
-
-        // text is currently only visibly in Panel mode due to this bug: https://jira.unity3d.com/browse/STO-2278
-        void ShadowSelectedRigName()
-        {
-            var index = Mathf.Clamp(SelectedRig, 0, CinemachineFreeLookEditor.RigNames.Length - 1);
-            text = CinemachineFreeLookEditor.RigNames[index].text;
-            icon = m_Icons[index];
-        }
-
-        void FreelookRigSelectionMenu()
-        {
-            var menu = new GenericMenu();
-            for (var i = 0; i < CinemachineFreeLookEditor.RigNames.Length; ++i)
-            {
-                var rigIndex = i; // vital to capture the index here for the lambda below
-                menu.AddItem(CinemachineFreeLookEditor.RigNames[i], false, () =>
-                {
-                    SelectedRig = rigIndex;
-                    var active = Selection.activeObject as GameObject;
-                    if (active != null)
-                    {
-#pragma warning disable CS0618
-                        var freelook = active.GetComponent<CinemachineFreeLook>();
-#pragma warning restore CS0618
-                        if (freelook != null)
-                            CinemachineFreeLookEditor.SetSelectedRig(freelook, rigIndex);
-                    }
-                });
-            }
-            menu.DropDown(worldBound);
-        }
-    }
-    
-    [EditorToolbarElement(id, typeof(SceneView))]
     class OrbitalFollowOrbitSelection : EditorToolbarDropdown
     {
         public const string id = "OrbitalFollowOrbitSelection/Dropdown";
@@ -447,6 +378,7 @@ namespace Cinemachine.Editor
         }
     }
     
+#endif
     [EditorToolbarElement(id, typeof(SceneView))]
     class FreelookRigSelection : EditorToolbarDropdown
     {
@@ -458,8 +390,12 @@ namespace Cinemachine.Editor
         {
             tooltip = "Freelook Rig Selection";
             clicked += FreelookRigSelectionMenu;
+#if UNITY_2022_1_OR_NEWER
+            EditorApplication.update += DisplayIfRequired;
+#else
             CinemachineSceneToolUtility.RegisterToolHandlers(GetType(), isOn => {}, 
                 display => style.display = display ? DisplayStyle.Flex : DisplayStyle.None);
+#endif
             EditorApplication.update += ShadowSelectedRigName;
             
             m_Icons = new Texture2D[]
@@ -477,15 +413,25 @@ namespace Cinemachine.Editor
         {
             clicked -= FreelookRigSelectionMenu;
             EditorApplication.update -= ShadowSelectedRigName;
+#if UNITY_2022_1_OR_NEWER
+            EditorApplication.update -= DisplayIfRequired;
+#endif
         }
+
+#if UNITY_2022_1_OR_NEWER
+        Type m_FreelookRigSelectionType = typeof(FreelookRigSelection);
+        void DisplayIfRequired() => style.display = 
+            CinemachineSceneToolUtility.IsToolRequired(m_FreelookRigSelectionType) 
+                ? DisplayStyle.Flex : DisplayStyle.None;
+#endif
 
         void ShadowSelectedRigName()
         {
             var index = Mathf.Clamp(SelectedRig, 0, CinemachineFreeLookEditor.RigNames.Length - 1);
-            icon = m_Icons[index];
             text = CinemachineFreeLookEditor.RigNames[index].text;
+            icon = m_Icons[index];
         }
-        
+
         void FreelookRigSelectionMenu()
         {
             var menu = new GenericMenu();
@@ -498,7 +444,9 @@ namespace Cinemachine.Editor
                     var active = Selection.activeObject as GameObject;
                     if (active != null)
                     {
+#pragma warning disable CS0618
                         var freelook = active.GetComponent<CinemachineFreeLook>();
+#pragma warning restore CS0618
                         if (freelook != null)
                             CinemachineFreeLookEditor.SetSelectedRig(freelook, rigIndex);
                     }
@@ -507,6 +455,5 @@ namespace Cinemachine.Editor
             menu.DropDown(worldBound);
         }
     }
-#endif
 }
 #endif

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -796,7 +796,7 @@ namespace Cinemachine.Editor
         /// Draws Orbit handles (e.g. for freelook)
         /// </summary>
         /// <returns>Index of the rig being edited, or -1 if none</returns>
-        public static int OrbitControlHandle(
+        public static int OrbitControlHandleFreelook(
             CinemachineVirtualCameraBase vcam, SerializedProperty orbits)
         {
             var originalColor = Handles.color;
@@ -830,6 +830,80 @@ namespace Cinemachine.Editor
                     orbitRadius.floatValue += 
                         SliderHandleDelta(newRadiusHandlePos, radiusHandlePos, radiusHandleOffset);
                     orbits.serializedObject.ApplyModifiedProperties();
+                }
+
+                var isDragged = GUIUtility.hotControl == heightHandleId || GUIUtility.hotControl == radiusHandleId;
+                Handles.color = isDragged || HandleUtility.nearestControl == heightHandleId ||
+                    HandleUtility.nearestControl == radiusHandleId ? Handles.selectedColor : HelperLineDefaultColor;
+                if (GUIUtility.hotControl == heightHandleId || HandleUtility.nearestControl == heightHandleId)
+                {
+                    DrawLabel(heightHandlePos, "Height: " + orbitHeight.floatValue);
+                }
+                if (GUIUtility.hotControl == radiusHandleId || HandleUtility.nearestControl == radiusHandleId)
+                {
+                    DrawLabel(radiusHandlePos, "Radius: " + orbitRadius.floatValue);
+                }
+
+                Handles.DrawWireDisc(newHeightHandlePos, Vector3.up, orbitRadius.floatValue);
+                if (isDragged)
+                {
+                    draggedRig = rigIndex;
+                    minIndex = Mathf.Min(Mathf.Min(heightHandleId), radiusHandleId);
+                }
+            }
+            SoloOnDrag(draggedRig != -1, vcam, minIndex);
+
+            Handles.color = originalColor;
+            return draggedRig;
+        }
+
+        /// <summary>
+        /// Draws Orbit handles for OrbitalFollow
+        /// </summary>
+        /// <returns>Index of the rig being edited, or -1 if none</returns>
+        static Cinemachine3OrbitRig.Settings k_Settings = Cinemachine3OrbitRig.Settings.Default;
+        public static int OrbitControlHandleOrbitalFollow(
+            CinemachineVirtualCameraBase vcam, SerializedProperty orbitSetting)
+        {
+            var originalColor = Handles.color;
+            var followPos = vcam.Follow.position;
+            var draggedRig = -1;
+            var minIndex = 1;
+
+            SerializedProperty[] orbits =
+            {
+                orbitSetting.FindPropertyRelative(() => k_Settings.Top),
+                orbitSetting.FindPropertyRelative(() => k_Settings.Center),
+                orbitSetting.FindPropertyRelative(() => k_Settings.Bottom),
+            };
+            for (var rigIndex = 0; rigIndex < orbits.Length; ++rigIndex)
+            {
+                var orbit = orbits[rigIndex];
+                var orbitHeight = orbit.FindPropertyRelative("Height"); // TODO: use k_Settings
+                var orbitRadius = orbit.FindPropertyRelative("Radius"); 
+                
+                Handles.color = Handles.preselectionColor;
+                EditorGUI.BeginChangeCheck();
+            
+                var heightHandleId = GUIUtility.GetControlID(FocusType.Passive);
+                var heightHandlePos = followPos + Vector3.up * orbitHeight.floatValue;
+                var newHeightHandlePos = Handles.Slider(heightHandleId, heightHandlePos, Vector3.up, 
+                    CubeHandleCapSize(heightHandlePos), Handles.CubeHandleCap, 0.5f);
+                
+                var radiusHandleOffset = Vector3.right;
+                var radiusHandleId = GUIUtility.GetControlID(FocusType.Passive);
+                var radiusHandlePos = followPos + Vector3.up * orbitHeight.floatValue
+                    + radiusHandleOffset * orbitRadius.floatValue;
+                var newRadiusHandlePos = Handles.Slider(radiusHandleId, radiusHandlePos, radiusHandleOffset, 
+                    CubeHandleCapSize(radiusHandlePos), Handles.CubeHandleCap, 0.5f);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    orbitHeight.floatValue += 
+                        SliderHandleDelta(newHeightHandlePos, heightHandlePos, Vector3.up);
+                    orbitRadius.floatValue += 
+                        SliderHandleDelta(newRadiusHandlePos, radiusHandlePos, radiusHandleOffset);
+                    orbitSetting.serializedObject.ApplyModifiedProperties();
                 }
 
                 var isDragged = GUIUtility.hotControl == heightHandleId || GUIUtility.hotControl == radiusHandleId;

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -809,7 +809,7 @@ namespace Cinemachine.Editor
                 var orbitHeight = orbit.FindPropertyRelative("m_Height");
                 var orbitRadius = orbit.FindPropertyRelative("m_Radius");
                 
-                if (RigHandles(orbits.serializedObject, orbitHeight, orbitRadius, followPos, 
+                if (OrbitHandles(orbits.serializedObject, orbitHeight, orbitRadius, followPos, 
                         out var heightHandleId, out var radiusHandleId))
                 {
                     draggedRig = rigIndex;
@@ -848,7 +848,7 @@ namespace Cinemachine.Editor
                 var orbitRadius = 
                     orbit.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Top.Radius);
                 
-                if (RigHandles(orbitSetting.serializedObject, orbitHeight, orbitRadius, followPos, 
+                if (OrbitHandles(orbitSetting.serializedObject, orbitHeight, orbitRadius, followPos, 
                         out var heightHandleId, out var radiusHandleId))
                 {
                     draggedRig = rigIndex;
@@ -861,7 +861,7 @@ namespace Cinemachine.Editor
             return draggedRig;
         }
 
-        static bool RigHandles(SerializedObject orbit, 
+        static bool OrbitHandles(SerializedObject orbit, 
             SerializedProperty orbitHeight, SerializedProperty orbitRadius, Vector3 followPos,
             out int heightHandleId, out int radiusHandleId)
         {

--- a/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineSceneTools.cs
@@ -808,44 +808,9 @@ namespace Cinemachine.Editor
                 var orbit = orbits.GetArrayElementAtIndex(rigIndex);
                 var orbitHeight = orbit.FindPropertyRelative("m_Height");
                 var orbitRadius = orbit.FindPropertyRelative("m_Radius");
-                Handles.color = Handles.preselectionColor;
-                EditorGUI.BeginChangeCheck();
-            
-                var heightHandleId = GUIUtility.GetControlID(FocusType.Passive);
-                var heightHandlePos = followPos + Vector3.up * orbitHeight.floatValue;
-                var newHeightHandlePos = Handles.Slider(heightHandleId, heightHandlePos, Vector3.up, 
-                    CubeHandleCapSize(heightHandlePos), Handles.CubeHandleCap, 0.5f);
                 
-                var radiusHandleOffset = Vector3.right;
-                var radiusHandleId = GUIUtility.GetControlID(FocusType.Passive);
-                var radiusHandlePos = followPos + Vector3.up * orbitHeight.floatValue
-                    + radiusHandleOffset * orbitRadius.floatValue;
-                var newRadiusHandlePos = Handles.Slider(radiusHandleId, radiusHandlePos, radiusHandleOffset, 
-                    CubeHandleCapSize(radiusHandlePos), Handles.CubeHandleCap, 0.5f);
-
-                if (EditorGUI.EndChangeCheck())
-                {
-                    orbitHeight.floatValue += 
-                        SliderHandleDelta(newHeightHandlePos, heightHandlePos, Vector3.up);
-                    orbitRadius.floatValue += 
-                        SliderHandleDelta(newRadiusHandlePos, radiusHandlePos, radiusHandleOffset);
-                    orbits.serializedObject.ApplyModifiedProperties();
-                }
-
-                var isDragged = GUIUtility.hotControl == heightHandleId || GUIUtility.hotControl == radiusHandleId;
-                Handles.color = isDragged || HandleUtility.nearestControl == heightHandleId ||
-                    HandleUtility.nearestControl == radiusHandleId ? Handles.selectedColor : HelperLineDefaultColor;
-                if (GUIUtility.hotControl == heightHandleId || HandleUtility.nearestControl == heightHandleId)
-                {
-                    DrawLabel(heightHandlePos, "Height: " + orbitHeight.floatValue);
-                }
-                if (GUIUtility.hotControl == radiusHandleId || HandleUtility.nearestControl == radiusHandleId)
-                {
-                    DrawLabel(radiusHandlePos, "Radius: " + orbitRadius.floatValue);
-                }
-
-                Handles.DrawWireDisc(newHeightHandlePos, Vector3.up, orbitRadius.floatValue);
-                if (isDragged)
+                if (RigHandles(orbits.serializedObject, orbitHeight, orbitRadius, followPos, 
+                        out var heightHandleId, out var radiusHandleId))
                 {
                     draggedRig = rigIndex;
                     minIndex = Mathf.Min(Mathf.Min(heightHandleId), radiusHandleId);
@@ -861,7 +826,7 @@ namespace Cinemachine.Editor
         /// Draws Orbit handles for OrbitalFollow
         /// </summary>
         /// <returns>Index of the rig being edited, or -1 if none</returns>
-        static Cinemachine3OrbitRig.Settings k_Settings = Cinemachine3OrbitRig.Settings.Default;
+        static Cinemachine3OrbitRig.Settings s_Cinemachine3OrbitRigSettings = Cinemachine3OrbitRig.Settings.Default;
         public static int OrbitControlHandleOrbitalFollow(
             CinemachineVirtualCameraBase vcam, SerializedProperty orbitSetting)
         {
@@ -869,29 +834,47 @@ namespace Cinemachine.Editor
             var followPos = vcam.Follow.position;
             var draggedRig = -1;
             var minIndex = 1;
-
             SerializedProperty[] orbits =
             {
-                orbitSetting.FindPropertyRelative(() => k_Settings.Top),
-                orbitSetting.FindPropertyRelative(() => k_Settings.Center),
-                orbitSetting.FindPropertyRelative(() => k_Settings.Bottom),
+                orbitSetting.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Top),
+                orbitSetting.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Center),
+                orbitSetting.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Bottom),
             };
             for (var rigIndex = 0; rigIndex < orbits.Length; ++rigIndex)
             {
                 var orbit = orbits[rigIndex];
-                var orbitHeight = orbit.FindPropertyRelative("Height"); // TODO: use k_Settings
-                var orbitRadius = orbit.FindPropertyRelative("Radius"); 
+                var orbitHeight = 
+                    orbit.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Top.Height);
+                var orbitRadius = 
+                    orbit.FindPropertyRelative(() => s_Cinemachine3OrbitRigSettings.Top.Radius);
                 
-                Handles.color = Handles.preselectionColor;
+                if (RigHandles(orbitSetting.serializedObject, orbitHeight, orbitRadius, followPos, 
+                        out var heightHandleId, out var radiusHandleId))
+                {
+                    draggedRig = rigIndex;
+                    minIndex = Mathf.Min(Mathf.Min(heightHandleId), radiusHandleId);
+                }
+            }
+            SoloOnDrag(draggedRig != -1, vcam, minIndex);
+
+            Handles.color = originalColor;
+            return draggedRig;
+        }
+
+        static bool RigHandles(SerializedObject orbit, 
+            SerializedProperty orbitHeight, SerializedProperty orbitRadius, Vector3 followPos,
+            out int heightHandleId, out int radiusHandleId)
+        {
+            Handles.color = Handles.preselectionColor;
                 EditorGUI.BeginChangeCheck();
             
-                var heightHandleId = GUIUtility.GetControlID(FocusType.Passive);
+                heightHandleId = GUIUtility.GetControlID(FocusType.Passive);
                 var heightHandlePos = followPos + Vector3.up * orbitHeight.floatValue;
                 var newHeightHandlePos = Handles.Slider(heightHandleId, heightHandlePos, Vector3.up, 
                     CubeHandleCapSize(heightHandlePos), Handles.CubeHandleCap, 0.5f);
                 
                 var radiusHandleOffset = Vector3.right;
-                var radiusHandleId = GUIUtility.GetControlID(FocusType.Passive);
+                radiusHandleId = GUIUtility.GetControlID(FocusType.Passive);
                 var radiusHandlePos = followPos + Vector3.up * orbitHeight.floatValue
                     + radiusHandleOffset * orbitRadius.floatValue;
                 var newRadiusHandlePos = Handles.Slider(radiusHandleId, radiusHandlePos, radiusHandleOffset, 
@@ -903,7 +886,7 @@ namespace Cinemachine.Editor
                         SliderHandleDelta(newHeightHandlePos, heightHandlePos, Vector3.up);
                     orbitRadius.floatValue += 
                         SliderHandleDelta(newRadiusHandlePos, radiusHandlePos, radiusHandleOffset);
-                    orbitSetting.serializedObject.ApplyModifiedProperties();
+                    orbit.ApplyModifiedProperties();
                 }
 
                 var isDragged = GUIUtility.hotControl == heightHandleId || GUIUtility.hotControl == radiusHandleId;
@@ -919,16 +902,7 @@ namespace Cinemachine.Editor
                 }
 
                 Handles.DrawWireDisc(newHeightHandlePos, Vector3.up, orbitRadius.floatValue);
-                if (isDragged)
-                {
-                    draggedRig = rigIndex;
-                    minIndex = Mathf.Min(Mathf.Min(heightHandleId), radiusHandleId);
-                }
-            }
-            SoloOnDrag(draggedRig != -1, vcam, minIndex);
-
-            Handles.color = originalColor;
-            return draggedRig;
+                return isDragged;
         }
         
         static bool s_IsDragging;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -17,9 +17,8 @@ namespace Cinemachine
     [DisallowMultipleComponent]
     [ExecuteAlways]
     [ExcludeFromPreset]
-    [Obsolete("This is deprecated. Use Create -> Cinemachine -> FreeLook camera, or create a virtual camera with " +
-        "CinemachineOrbitalFollow body component, CinemachineComposer aim component, " +
-        "CinemachineFreeLookModifier extension, and InputAxisController")]
+    [Obsolete("This is deprecated. Use Create -> Cinemachine -> FreeLook camera, or " +
+        "create a virtual camera with CinemachineOrbitalFollow body component")]
     [AddComponentMenu("Cinemachine/CinemachineFreeLook")]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineFreeLook.html")]
     public class CinemachineFreeLook : CinemachineVirtualCameraBase

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -17,7 +17,9 @@ namespace Cinemachine
     [DisallowMultipleComponent]
     [ExecuteAlways]
     [ExcludeFromPreset]
-    [Obsolete("This is deprecated. Use CmFreelook instead.")]
+    [Obsolete("This is deprecated. Use Create -> Cinemachine -> FreeLook camera, or create a virtual camera with " +
+        "CinemachineOrbitalFollow body component, CinemachineComposer aim component, " +
+        "CinemachineFreeLookModifier extension, and InputAxisController")]
     [AddComponentMenu("Cinemachine/CinemachineFreeLook")]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineFreeLook.html")]
     public class CinemachineFreeLook : CinemachineVirtualCameraBase


### PR DESCRIPTION
### Purpose of this PR

Overlays fix for old freelook.

New overlays for Orbital Follow. Control and select orbits. Orbit selection works only for 3 ring, but could work for sphere too if we want it. The orbit selection directly affects the Vertical Axis value based on the Range and Center values (so it works for sphere too).

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested on 2021.3.0f1 and 2022.2.0a9