### PR TITLE
CMCL-883: No gizmos while using handles 3rdPersonFollow

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -11,6 +11,9 @@ namespace Cinemachine.Editor
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(Cinemachine3rdPersonFollow))]
         static void Draw3rdPersonGizmos(Cinemachine3rdPersonFollow target, GizmoType selectionType)
         {
+            if (CinemachineSceneToolUtility.IsToolActive(typeof(FollowOffsetTool)))
+                return; // don't draw gizmo when using handles
+            
             if (target.IsValid)
             {
                 var isLive = CinemachineCore.Instance.IsLive(target.VirtualCamera);


### PR DESCRIPTION
### Purpose of this PR
Swap noted that we should remove the 3rdPersonFollow gizmos when using the handles as their are confusing/overlapping with the rig handles.

### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 