### PR TITLE
CMCL-891: Fix null output camera on first frame

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
-using UnityEngine.Serialization;
-using Object = System.Object;
 
 #if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
     #if CINEMACHINE_HDRP_7_3_1

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
+using Object = System.Object;
 
 #if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
     #if CINEMACHINE_HDRP_7_3_1
@@ -207,8 +208,16 @@ namespace Cinemachine
         public GameObject ControlledObject
         {
             get => m_TargetOverride == null ? gameObject : m_TargetOverride;
-            set => m_TargetOverride = value;
+            set
+            {
+                if (!ReferenceEquals(m_TargetOverride, value))
+                {
+                    m_TargetOverride = value;
+                    ControlledObject.TryGetComponent(out m_OutputCamera); // update output camera when target changes
+                }
+            }
         }
+
         private GameObject m_TargetOverride = null; // never use directly - use accessor
 
         /// <summary>Event with a CinemachineBrain parameter</summary>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -299,11 +299,15 @@ namespace Cinemachine
                 ManualUpdate();
         }
         
-        private void Start()
+        void Awake()
+        {
+            ControlledObject.TryGetComponent(out m_OutputCamera);
+        }
+        
+        void Start()
         {
             m_LastFrameUpdated = -1;
             UpdateVirtualCameras(CinemachineCore.UpdateFilter.Late, -1f);
-            ControlledObject.TryGetComponent(out m_OutputCamera);
         }
 
         private void OnGuiHandler()


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-891:
Fix bug on unreleased branches. Output camera is null on first frame.

Bug introduced by cfb93754283449a99b24d0119c0359c975e68c4a.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 


