### PR TITLE
CMCL-906: 3rdPersonFollow does not warn user when no Follow Target

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## UNRELEASED
 - Bugfix: Confiner2D confines to midpoint when camera window is bigger than the axis aligned bounding box of the input confiner.
+- Bugfix: 3rdPersonFollow shows a warning message when no follow target is assigned like the rest of the body components.
 
 
 ## [2.9.0-pre.7] - 2022-03-29

--- a/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -35,6 +35,19 @@ namespace Cinemachine.Editor
                 Gizmos.color = originalGizmoColour;
             }
         }
+        
+        public override void OnInspectorGUI()
+        {
+            BeginInspector();
+            bool needWarning = false;
+            for (int i = 0; !needWarning && i < targets.Length; ++i)
+                needWarning = (targets[i] as Cinemachine3rdPersonFollow).FollowTarget == null;
+            if (needWarning)
+                EditorGUILayout.HelpBox(
+                    "3rd Person Follow requires a Follow Target.  Change Body to Do Nothing if you don't want a Follow target.",
+                    MessageType.Warning);
+            DrawRemainingPropertiesInInspector();
+        }
 
 #if UNITY_2021_2_OR_NEWER
         protected virtual void OnEnable()


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-906
Fixed: ThirdPersonFollow does not display a warning message like the rest of the components when no follow target is assigned.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x[ Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
