### PR TITLE
CMCL-926: fadeout sample bug fix

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## UNRELEASED
 - Bugfix: Confiner2D confines to midpoint when camera window is bigger than the axis aligned bounding box of the input confiner.
 - Bugfix: 3rdPersonFollow shows a warning message when no follow target is assigned like the rest of the body components.
+- Bugfix: FadeOut sample scene shader was culling some objects incorrectly.
 
 
 ## [2.9.0-pre.7] - 2022-03-29

--- a/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/FadeOutNearbyObjects/FadeOut.shader
+++ b/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/FadeOutNearbyObjects/FadeOut.shader
@@ -9,7 +9,7 @@ Shader "Custom/FadeOut" {
         Tags { "Queue"="Transparent" "RenderType"="Transparent" }
  
     Pass {
-        ZWrite On
+        ZWrite Off
         ColorMask 0
     }
    


### PR DESCRIPTION
### Purpose of this PR

https://jira.unity3d.com/browse/CMCL-926
FadeOut sample scene was culling objects incorrectly. 

Forum:
https://forum.unity.com/threads/cinemachine-zoom-and-drag-zoom-transparency.1280192/#post-8126003

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version