### PR TITLE
CMCL-923: Freelook jitter after enable

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -698,8 +698,9 @@ namespace Cinemachine
                 // Allow externally-driven values to work in this mode
                 if (m_BindingMode == CinemachineTransposer.BindingMode.SimpleFollowWithWorldUp)
                     m_XAxis.Value = oldValue;
+                return m_CachedXAxisHeading;
             }
-            return m_CachedXAxisHeading;
+            return m_XAxis.Value;
         }
 
         void PushSettingsToRigs()

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -374,7 +374,7 @@ namespace Cinemachine
 
                 Vector3 rawOffset = EffectiveOffset;
                 Vector3 offset = headingRot * rawOffset;
-                // Freelook jitter is caused by heading being 0 on the first frame.
+                // Freelook jitter is caused by heading being 0 on the first frame after enabling freelook.
                 // This can causes a slight jitter (I don't see it with my eyes, the user claims that it is noticable)
 
                 // Track the target, with damping

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -374,6 +374,8 @@ namespace Cinemachine
 
                 Vector3 rawOffset = EffectiveOffset;
                 Vector3 offset = headingRot * rawOffset;
+                // Freelook jitter is caused by heading being 0 on the first frame.
+                // This can causes a slight jitter (I don't see it with my eyes, the user claims that it is noticable)
 
                 // Track the target, with damping
                 TrackTarget(deltaTime, curState.ReferenceUp, offset, out Vector3 pos, out Quaternion orient);


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-923
Freelook jitter caused on first frame after enabling. This is due to the heading being 0 on first frame. Freelook overrides Orbital Transposer's delegate with `UpdateXAxisHeading`, which returns `m_CachedXAxisHeading` when mOrbitals is null (first frame after enabling freelook). `m_CachedXAxisHeading` is 0 by default.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
High

### Comments to reviewers
Maybe there was a reason to return m_CachedXAxisHeading instead of Axis.Value. @glabute 

### Package version
