### PR TITLE
Dev/cm3 combine vcam targets

### DIFF
--- a/com.unity.cinemachine/Editor/Experimental/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Experimental/CmCameraEditor.cs
@@ -20,7 +20,7 @@ namespace Cinemachine.Editor
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(cam);
             if (brain != null)
             {
-                cam.m_Lens = brain.CurrentCameraState.Lens;
+                cam.Lens = brain.CurrentCameraState.Lens;
                 cam.transform.position = brain.transform.position;
                 cam.transform.rotation = brain.transform.rotation;
             }
@@ -30,7 +30,7 @@ namespace Cinemachine.Editor
         static void AdoptSceneViewCameraSettings(MenuCommand command)
         {
             var cam = command.context as CmCamera;
-            cam.m_Lens = CinemachineMenu.MatchSceneViewCamera(cam.transform);
+            cam.Lens = CinemachineMenu.MatchSceneViewCamera(cam.transform);
         }
 
         void OnEnable()
@@ -68,7 +68,7 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.m_Transitions)));
             
             ux.AddHeader("Camera");
-            var lensProperty = serializedTarget.FindProperty(() => Target.m_Lens);
+            var lensProperty = serializedTarget.FindProperty(() => Target.Lens);
             ux.Add(new PropertyField(lensProperty));
 
             var modeOverrideProperty = lensProperty.FindPropertyRelative("ModeOverride");
@@ -87,8 +87,7 @@ namespace Cinemachine.Editor
             ux.AddHeader("Procedural Motion");
             m_CameraUtility.AddSaveDuringPlayToggle(ux);
             m_CameraUtility.AddGameViewGuidesToggle(ux);
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.m_Follow)));
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.m_LookAt)));
+            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.Target)));
             m_CameraUtility.AddPipelineDropdowns(ux);
 
             //ux.AddHeader("Extensions");
@@ -109,13 +108,13 @@ namespace Cinemachine.Editor
             if (CinemachineSceneToolUtility.IsToolActive(typeof(FoVTool)))
             {
                 CinemachineSceneToolHelpers.FovToolHandle(cmCam, 
-                    new SerializedObject(cmCam).FindProperty(() => cmCam.m_Lens), 
-                    cmCam.m_Lens, Target.m_Lens.UseHorizontalFOV);
+                    new SerializedObject(cmCam).FindProperty(() => cmCam.Lens), 
+                    cmCam.Lens, Target.Lens.UseHorizontalFOV);
             }
             else if (CinemachineSceneToolUtility.IsToolActive(typeof(FarNearClipTool)))
             {
                 CinemachineSceneToolHelpers.NearFarClipHandle(cmCam,
-                    new SerializedObject(cmCam).FindProperty(() => cmCam.m_Lens));
+                    new SerializedObject(cmCam).FindProperty(() => cmCam.Lens));
             }
             Handles.color = originalColor;
         }

--- a/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
+++ b/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
@@ -59,7 +59,7 @@ namespace Cinemachine.Editor
             // We give the camera a couple of children as an example of setup
             var childVcam1 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
             var childVcam2 = CreateDefaultVirtualCamera(parentObject: blendListCamera.gameObject);
-            childVcam2.m_Lens.FieldOfView = 10;
+            childVcam2.Lens.FieldOfView = 10;
 
             // Set up initial instruction set
             blendListCamera.m_Instructions = new CinemachineBlendListCamera.Instruction[2];
@@ -105,7 +105,7 @@ namespace Cinemachine.Editor
                 "Dolly Track", command.context as GameObject, false);
             var vcam = CreateCinemachineObject<CmCamera>(
                 "Cm Camera", command.context as GameObject, true);
-            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            vcam.Lens = MatchSceneViewCamera(vcam.transform);
 
             vcam.gameObject.AddComponent<CinemachineComposer>();
             var trackedDolly = vcam.gameObject.AddComponent<CinemachineTrackedDolly>();
@@ -128,7 +128,7 @@ namespace Cinemachine.Editor
             CinemachineEditorAnalytics.SendCreateEvent("Target Group Camera");
             var vcam = CreateCinemachineObject<CmCamera>(
                 "Cm Camera", command.context as GameObject, false);
-            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            vcam.Lens = MatchSceneViewCamera(vcam.transform);
 
             vcam.gameObject.AddComponent<CinemachineGroupComposer>();
             vcam.gameObject.AddComponent<CinemachineTransposer>();
@@ -157,7 +157,7 @@ namespace Cinemachine.Editor
             CinemachineEditorAnalytics.SendCreateEvent("2D Camera");
             var vcam = CreateCinemachineObject<CmCamera>(
                 "Cm Camera", command.context as GameObject, true);
-            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            vcam.Lens = MatchSceneViewCamera(vcam.transform);
 
             vcam.gameObject.AddComponent<CinemachineFramingTransposer>();
         }
@@ -202,7 +202,7 @@ namespace Cinemachine.Editor
             string name = "Cm Camera", GameObject parentObject = null, bool select = false)
         {
             var vcam = CreateCinemachineObject<CmCamera>(name, parentObject, select);
-            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            vcam.Lens = MatchSceneViewCamera(vcam.transform);
 
             return vcam;
         }
@@ -214,7 +214,7 @@ namespace Cinemachine.Editor
             string name = "Cm Camera", GameObject parentObject = null, bool select = false)
         {
             var vcam = CreateCinemachineObject<CmCamera>(name, parentObject, select);
-            vcam.m_Lens = MatchSceneViewCamera(vcam.transform);
+            vcam.Lens = MatchSceneViewCamera(vcam.transform);
             return vcam;
         }
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
@@ -1,0 +1,137 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
+
+namespace Cinemachine.Editor
+{
+    [CustomPropertyDrawer(typeof(CameraTarget))]
+    internal sealed class CameraTargetPropertyDrawer : PropertyDrawer
+    {
+        CameraTarget def;
+
+        // old IMGUI implementation must remain until no more IMGUI inspectors are using it
+        public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            rect.height = EditorGUIUtility.singleLineHeight;
+            DrawTargetPropertyOnGUI(rect, property.FindPropertyRelative(() => def.TrackingTarget), property);
+            if (property.FindPropertyRelative(() => def.CustomLookAtTarget).boolValue)
+            {
+                rect.y += rect.height + EditorGUIUtility.standardVerticalSpacing;
+                DrawTargetPropertyOnGUI(rect, property.FindPropertyRelative(() => def.LookAtTarget), property);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            var height = EditorGUIUtility.singleLineHeight;
+            if (property.FindPropertyRelative(() => def.CustomLookAtTarget).boolValue)
+                height += height + EditorGUIUtility.standardVerticalSpacing;
+            return height;
+        }
+
+        void DrawTargetPropertyOnGUI(Rect rect, SerializedProperty property, SerializedProperty mainProperty)
+        {
+            const float hSpace = 2;
+            float iconSize = rect.height + 4;
+            rect.width -= iconSize + hSpace;
+            EditorGUI.PropertyField(rect, property);
+            rect.x += rect.width + hSpace; rect.width = iconSize;
+
+            var target = property.objectReferenceValue as Transform;
+            if (GUI.Button(rect, EditorGUIUtility.IconContent("_Popup"), GUI.skin.label))
+            {
+                GenericMenu menu = new GenericMenu();
+                menu.AddItem(new GUIContent("Convert to TargetGroup"), false, () =>
+                {
+                    if (target != null && target.GetComponent<CinemachineTargetGroup>() == null)
+                    {
+                        GameObject go = ObjectFactory.CreateGameObject("Target Group", typeof(CinemachineTargetGroup));
+                        var group = go.GetComponent<CinemachineTargetGroup>();
+                   
+                        group.m_RotationMode = CinemachineTargetGroup.RotationMode.GroupAverage;
+                        group.AddMember(target, 1, 1);
+                        property.objectReferenceValue = group.Transform;
+                        property.serializedObject.ApplyModifiedProperties();
+                    }
+                });
+                var customProp = mainProperty.FindPropertyRelative(() => def.CustomLookAtTarget);
+                var isCustom = customProp.boolValue;
+                menu.AddItem(new GUIContent("Use Custom LookAt Target"), isCustom, () =>
+                {
+                    customProp.boolValue = !isCustom;
+                    customProp.serializedObject.ApplyModifiedProperties();
+                });
+                menu.ShowAsContext();
+            }
+        }
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var ux = new VisualElement();
+            var follow = ux.AddChild(CreateTargetProperty(property.FindPropertyRelative(() => def.TrackingTarget), property));
+            var lookAt = ux.AddChild(CreateTargetProperty(property.FindPropertyRelative(() => def.LookAtTarget), property));
+            
+            var customProp = property.FindPropertyRelative(() => def.CustomLookAtTarget);
+            TrackCustomProp(customProp);
+            ux.TrackPropertyValue(customProp, TrackCustomProp);
+            void TrackCustomProp(SerializedProperty p) => lookAt.SetVisible(p.boolValue);
+
+            return ux;
+        }
+
+        VisualElement CreateTargetProperty(SerializedProperty property, SerializedProperty mainProperty)
+        {
+            var customProp = mainProperty.FindPropertyRelative(() => def.CustomLookAtTarget);
+
+            var row = new VisualElement { style = { flexDirection = FlexDirection.Row }};
+            row.Add(new PropertyField(property) { style = { flexGrow = 1 }});
+            var button = new Button { style = 
+            { 
+                backgroundImage = (StyleBackground)EditorGUIUtility.IconContent("_Popup").image,
+                width = InspectorUtility.SingleLineHeight, height = InspectorUtility.SingleLineHeight,
+                alignSelf = Align.Center,
+                paddingRight = 0, borderRightWidth = 0, marginRight = 0
+            }};
+            row.Add(button);
+
+            var manipulator = new ContextualMenuManipulator((evt) => 
+            {
+                evt.menu.AppendAction("Convert to TargetGroup", 
+                    (action) => 
+                    {
+                        var go = ObjectFactory.CreateGameObject("Target Group", typeof(CinemachineTargetGroup));
+                        var group = go.GetComponent<CinemachineTargetGroup>();
+                        var target = property.objectReferenceValue as Transform;
+                   
+                        group.m_RotationMode = CinemachineTargetGroup.RotationMode.GroupAverage;
+                        group.AddMember(target, 1, 1);
+                        property.objectReferenceValue = group.Transform;
+                        property.serializedObject.ApplyModifiedProperties();
+                    }, 
+                    (status) => 
+                    {
+                        var target = property.objectReferenceValue as Transform;
+                        var disable = target == null || target.TryGetComponent<CinemachineTargetGroup>(out var _);
+                        return disable ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal;
+                    }
+                );
+                evt.menu.AppendAction("Use Custom LookAt Target", 
+                    (action) => 
+                    {
+                        customProp.boolValue = !customProp.boolValue;
+                        customProp.serializedObject.ApplyModifiedProperties();
+                    }, 
+                    (status) => 
+                    {
+                        return customProp.boolValue ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal;
+                    }
+                );  
+            });
+            manipulator.activators.Clear();
+            manipulator.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
+            button.AddManipulator(manipulator);
+            return row;
+        }
+    }
+}

--- a/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs.meta
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 839dc049a7a3bd242a923dc9293caa66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Editor/Utility/CinemachineEditorAnalytics.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineEditorAnalytics.cs
@@ -99,7 +99,7 @@ namespace Cinemachine.Editor
             var vcam = vcamBase as CmCamera;
             if (vcam != null)
             {
-                vcamData.SetTransitionsAndLens(vcam.m_Transitions, vcam.m_Lens);
+                vcamData.SetTransitionsAndLens(vcam.m_Transitions, vcam.Lens);
                 vcamData.SetComponents(vcam.GetComponents<CinemachineComponentBase>());
                 vcamDatas.Add(vcamData);
                 return;
@@ -194,10 +194,10 @@ namespace Cinemachine.Editor
                         var componentName = GetTypeName(cmComps[i].GetType(), ref custom_component_count);
                         switch (cmComps[i].Stage)
                         {
-                            case CinemachineCore.Stage.Body:
+                            case CinemachineCore.Stage.PositionControl:
                                 body_component = componentName;
                                 break;
-                            case CinemachineCore.Stage.Aim:
+                            case CinemachineCore.Stage.RotationControl:
                                 aim_component = componentName;
                                 break;
                             case CinemachineCore.Stage.Noise:

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -252,10 +252,9 @@ namespace Cinemachine.Editor
                     s_StageData[i] = new StageData
                     {
                         Stage = stage,
-                        Name = stage.ToString(),
+                        Name = ObjectNames.NicifyVariableName(stage.ToString()),
                         Types = new List<Type>() { null }, // first item is "none"
-                        Choices = new List<string>() 
-                            { (stage == CinemachineCore.Stage.Aim || stage == CinemachineCore.Stage.Body) ? "Do nothing" : "none" }
+                        Choices = new List<string>() { "none" }
                     };
                 }
 
@@ -357,8 +356,8 @@ namespace Cinemachine.Editor
                 // This is painful, but it won't happen too often
                 var pos = 0;
                 if (MoveComponentToPosition(pos, SortOrder.Camera, s_componentCache)) ++pos;
-                if (MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.Body, s_componentCache)) ++pos;
-                if (MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.Aim, s_componentCache)) ++pos;
+                if (MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.PositionControl, s_componentCache)) ++pos;
+                if (MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.RotationControl, s_componentCache)) ++pos;
                 if (MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.Noise, s_componentCache)) ++pos;
                 MoveComponentToPosition(pos, SortOrder.Pipeline + (int)CinemachineCore.Stage.Finalize, s_componentCache);
                 // leave everything else where it is

--- a/com.unity.cinemachine/Editor/Utility/VcamStageEditor.cs
+++ b/com.unity.cinemachine/Editor/Utility/VcamStageEditor.cs
@@ -31,7 +31,7 @@ namespace Cinemachine.Editor
                 var stageTypes = new List<Type>[Enum.GetValues(typeof(CinemachineCore.Stage)).Length];
                 for (int i = 0; i < stageTypes.Length; ++i)
                 {
-                    sStageData[i].Name = ((CinemachineCore.Stage)i).ToString();
+                    sStageData[i].Name = ObjectNames.NicifyVariableName(((CinemachineCore.Stage)i).ToString());
                     stageTypes[i] = new List<Type>();
                 }
 
@@ -53,16 +53,8 @@ namespace Cinemachine.Editor
                     sStageData[i].types = stageTypes[i].ToArray();
                     var names = new GUIContent[sStageData[i].types.Length];
                     for (int n = 0; n < names.Length; ++n)
-                    {
-                        if (n == 0)
-                        {
-                            bool useSimple = (i == (int)CinemachineCore.Stage.Aim) ||
-                                (i == (int)CinemachineCore.Stage.Body);
-                            names[n] = new GUIContent((useSimple) ? "Do nothing" : "none");
-                        }
-                        else
-                            names[n] = new GUIContent(InspectorUtility.NicifyClassName(sStageData[i].types[n].Name));
-                    }
+                        names[n] = new GUIContent(
+                            n == 0 ? "none" : InspectorUtility.NicifyClassName(sStageData[i].types[n].Name));
                     sStageData[i].PopupOptions = names;
                 }
             }
@@ -281,7 +273,7 @@ namespace Cinemachine.Editor
             VcamStageEditor.SetComponentDelegate setComponent)
         {
             m_subeditors = new VcamStageEditor[(int)CinemachineCore.Stage.Finalize];
-            for (CinemachineCore.Stage stage = CinemachineCore.Stage.Body;
+            for (CinemachineCore.Stage stage = CinemachineCore.Stage.PositionControl;
                 stage < CinemachineCore.Stage.Finalize; ++stage)
             {
                 var ed = new VcamStageEditor(stage);

--- a/com.unity.cinemachine/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -125,7 +125,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (stage == CinemachineCore.Stage.Body)
+            if (stage == CinemachineCore.Stage.PositionControl)
             {
                 // Raycast to establish what we're actually aiming at
                 var player = vcam.Follow;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCameraOffset.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCameraOffset.cs
@@ -21,7 +21,7 @@ public class CinemachineCameraOffset : CinemachineExtension
     /// When to apply the offset
     /// </summary>
     [Tooltip("When to apply the offset")]
-    public CinemachineCore.Stage m_ApplyAfter = CinemachineCore.Stage.Aim;
+    public CinemachineCore.Stage m_ApplyAfter = CinemachineCore.Stage.RotationControl;
 
     /// <summary>
     /// If applying offset after aim, re-adjust the aim to preserve the screen position
@@ -45,7 +45,7 @@ public class CinemachineCameraOffset : CinemachineExtension
         if (stage == m_ApplyAfter)
         {
             bool preserveAim = m_PreserveComposition
-                && state.HasLookAt && stage > CinemachineCore.Stage.Body;
+                && state.HasLookAt && stage > CinemachineCore.Stage.PositionControl;
 
             Vector3 screenOffset = Vector2.zero;
             if (preserveAim)

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
@@ -272,7 +272,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (stage == CinemachineCore.Stage.Body)
+            if (stage == CinemachineCore.Stage.PositionControl)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 extra.targetObscured = false;
@@ -340,7 +340,7 @@ namespace Cinemachine
                 }
             }
             // Rate the shot after the aim was set
-            if (stage == CinemachineCore.Stage.Aim)
+            if (stage == CinemachineCore.Stage.RotationControl)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 extra.targetObscured = IsTargetOffscreen(state) || CheckForTargetObstructions(state);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner.cs
@@ -136,7 +136,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (IsValid && stage == CinemachineCore.Stage.Body)
+            if (IsValid && stage == CinemachineCore.Stage.PositionControl)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 Vector3 displacement;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -118,7 +118,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam, 
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (stage == CinemachineCore.Stage.Body)
+            if (stage == CinemachineCore.Stage.PositionControl)
             {
                 var aspectRatio = state.Lens.Aspect;
                 if (!m_shapeCache.ValidateCache(

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
@@ -74,7 +74,7 @@ namespace Cinemachine
 
             // Set the zoom after the body has been positioned, but before the aim,
             // so that composer can compose using the updated fov.
-            if (stage == CinemachineCore.Stage.Body)
+            if (stage == CinemachineCore.Stage.PositionControl)
             {
                 // Try to reproduce the target width
                 float targetWidth = Mathf.Max(m_Width, 0);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -637,7 +637,7 @@ namespace Cinemachine
                 rig.m_ExcludedPropertiesInInspector = m_CommonLens
                     ? new string[] { "m_Script", "Header", "Extensions", "m_Priority", "m_Transitions", "m_Follow", "m_StandbyUpdate", "m_Lens" }
                     : new string[] { "m_Script", "Header", "Extensions", "m_Priority", "m_Transitions", "m_Follow", "m_StandbyUpdate" };
-                rig.m_LockStageInInspector = new CinemachineCore.Stage[] { CinemachineCore.Stage.Body };
+                rig.m_LockStageInInspector = new CinemachineCore.Stage[] { CinemachineCore.Stage.PositionControl };
             }
 #endif
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -177,9 +177,9 @@ namespace Cinemachine
             // Can't add components during OnValidate
             if (ValidatingStreamVersion < 20170927)
             {
-                if (Follow != null && GetCinemachineComponent(CinemachineCore.Stage.Body) == null)
+                if (Follow != null && GetCinemachineComponent(CinemachineCore.Stage.PositionControl) == null)
                     AddCinemachineComponent<CinemachineHardLockToTarget>();
-                if (LookAt != null && GetCinemachineComponent(CinemachineCore.Stage.Aim) == null)
+                if (LookAt != null && GetCinemachineComponent(CinemachineCore.Stage.RotationControl) == null)
                     AddCinemachineComponent<CinemachineHardLookAt>();
             }
         }
@@ -495,7 +495,7 @@ namespace Cinemachine
             if (m_ComponentPipeline == null)
             {
                 state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
-                for (var stage = CinemachineCore.Stage.Body; stage <= CinemachineCore.Stage.Finalize; ++stage)
+                for (var stage = CinemachineCore.Stage.PositionControl; stage <= CinemachineCore.Stage.Finalize; ++stage)
                     InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
             }
             else
@@ -506,14 +506,14 @@ namespace Cinemachine
 
                 int componentIndex = 0;
                 CinemachineComponentBase postAimBody = null;
-                for (var stage = CinemachineCore.Stage.Body; stage <= CinemachineCore.Stage.Finalize; ++stage)
+                for (var stage = CinemachineCore.Stage.PositionControl; stage <= CinemachineCore.Stage.Finalize; ++stage)
                 {
                     var c = componentIndex < m_ComponentPipeline.Length 
                         ? m_ComponentPipeline[componentIndex] : null;
                     if (c != null && stage == c.Stage)
                     {
                         ++componentIndex;
-                        if (stage == CinemachineCore.Stage.Body && c.BodyAppliesAfterAim)
+                        if (stage == CinemachineCore.Stage.PositionControl && c.BodyAppliesAfterAim)
                         {
                             postAimBody = c;
                             continue; // do the body stage of the pipeline after Aim
@@ -522,7 +522,7 @@ namespace Cinemachine
                     }
                     InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
 
-                    if (stage == CinemachineCore.Stage.Aim)
+                    if (stage == CinemachineCore.Stage.RotationControl)
                     {
                         if (c == null)
                             state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
@@ -530,7 +530,7 @@ namespace Cinemachine
                         if (postAimBody != null)
                         {
                             postAimBody.MutateCameraState(ref state, deltaTime);
-                            InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Body, ref state, deltaTime);
+                            InvokePostPipelineStageCallback(this, CinemachineCore.Stage.PositionControl, ref state, deltaTime);
                         }
                     }
                 }

--- a/com.unity.cinemachine/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -14,7 +14,7 @@ namespace Cinemachine
     /// </summary>
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class Cinemachine3rdPersonFollow : CinemachineComponentBase
         , CinemachineFreeLookModifier.IModifierValueSource
         , CinemachineFreeLookModifier.IModifiablePositionDamping
@@ -165,7 +165,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.PositionControl; } }
 
 #if CINEMACHINE_PHYSICS
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineComposer.cs
@@ -17,7 +17,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Aim)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.RotationControl)]
     public class CinemachineComposer : CinemachineComponentBase
     {
         /// <summary>Target offset from the object's center in LOCAL space which
@@ -132,7 +132,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.RotationControl; } }
 
         /// <summary>Internal API for inspector</summary>
         public Vector3 TrackedPoint { get; private set; }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineFramingTransposer.cs
@@ -30,7 +30,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineFramingTransposer : CinemachineComponentBase
         , CinemachineFreeLookModifier.IModifiablePositionDamping
         , CinemachineFreeLookModifier.IModifiableDistance
@@ -339,7 +339,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Body stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.PositionControl; } }
 
         /// <summary>FramingTransposer's algorithm tahes camera orientation as input, 
         /// so even though it is a Body component, it must apply after Aim</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineGroupComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineGroupComposer.cs
@@ -16,7 +16,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Aim)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.RotationControl)]
     public class CinemachineGroupComposer : CinemachineComposer
     {
         /// <summary>How much of the screen to fill with the bounding box of the targets.</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
@@ -11,7 +11,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineHardLockToTarget : CinemachineComponentBase
     {
         /// <summary>
@@ -26,7 +26,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.PositionControl; } }
 
         /// <summary>
         /// Report maximum damping time needed for this component.

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
@@ -10,7 +10,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Aim)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.RotationControl)]
     public class CinemachineHardLookAt : CinemachineComponentBase
     {
         /// <summary>True if component is enabled and has a LookAt defined</summary>
@@ -18,7 +18,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.RotationControl; } }
 
         /// <summary>Applies the composer rules and orients the camera accordingly</summary>
         /// <param name="curState">The current camera state</param>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -13,7 +13,7 @@ namespace Cinemachine
     /// </summary>
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineOrbitalFollow 
         : CinemachineComponentBase, IInputAxisTarget
         , CinemachineFreeLookModifier.IModifierValueSource
@@ -189,7 +189,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Body stage</summary>
-        public override CinemachineCore.Stage Stage => CinemachineCore.Stage.Body;
+        public override CinemachineCore.Stage Stage => CinemachineCore.Stage.PositionControl;
 
         /// <summary>
         /// Report maximum damping time needed for this component.

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -32,7 +32,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineOrbitalTransposer : CinemachineTransposer
     {
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
@@ -15,7 +15,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Aim)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.RotationControl)]
     public class CinemachinePOV : CinemachineComponentBase, CinemachineFreeLookModifier.IModifierValueSource
     {
         /// <summary>
@@ -81,7 +81,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.RotationControl; } }
 
         private void OnValidate()
         {

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
@@ -12,7 +12,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Aim)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.RotationControl)]
     public class CinemachineSameAsFollowTarget : CinemachineComponentBase
     {
         /// <summary>
@@ -29,7 +29,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.RotationControl; } }
 
         /// <summary>
         /// Report maximum damping time needed for this component.

--- a/com.unity.cinemachine/Runtime/Components/CinemachineTrackedDolly.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineTrackedDolly.cs
@@ -17,7 +17,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineTrackedDolly : CinemachineComponentBase
     {
         /// <summary>The path to which the camera will be constrained.  This must be non-null.</summary>
@@ -174,7 +174,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Body stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.PositionControl; } }
 
         /// <summary>
         /// Report maximum damping time needed for this component.

--- a/com.unity.cinemachine/Runtime/Components/CinemachineTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineTransposer.cs
@@ -16,7 +16,7 @@ namespace Cinemachine
     [DocumentationSorting(DocumentationSortingAttribute.Level.UserRef)]
     [AddComponentMenu("")] // Don't display in add component menu
     [SaveDuringPlay]
-    [CameraPipelineAttribute(CinemachineCore.Stage.Body)]
+    [CameraPipelineAttribute(CinemachineCore.Stage.PositionControl)]
     public class CinemachineTransposer : CinemachineComponentBase
     {
         /// <summary>
@@ -171,7 +171,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Body stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.PositionControl; } }
 
         /// <summary>
         /// Report maximum damping time needed for this component.

--- a/com.unity.cinemachine/Runtime/Core/CameraTarget.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraTarget.cs
@@ -1,0 +1,30 @@
+using System;
+using UnityEngine;
+
+namespace Cinemachine
+{
+    /// <summary>
+    /// Structure for holding the procedural motion targets for a CmCamera.
+    /// The main TrackingTarget is used by default for all object tracking.  Optionally, a second
+    /// LookAt target can be provided to make the camera follow one object while
+    /// pointing at another.
+    /// </summary>
+    [Serializable]
+    public struct CameraTarget
+    {
+        /// <summary>Object for the camera to follow</summary>
+        [Tooltip("Object for the camera to follow")]
+        public Transform TrackingTarget;
+
+        /// <summary>Optional secondary object for the camera to look at</summary>
+        [Tooltip("Object for the camera to look at")]
+        public Transform LookAtTarget;
+
+        /// <summary>
+        /// If false, TrackingTarget will be used for all object tracking.  
+        /// If true, thenb LookAtTarget is used for rotation tracking and 
+        /// TrackingTarget is used only for position tracking.
+        /// </summary>
+        public bool CustomLookAtTarget;
+    }
+}

--- a/com.unity.cinemachine/Runtime/Core/CameraTarget.cs.meta
+++ b/com.unity.cinemachine/Runtime/Core/CameraTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40561d76a7aecca4c99c957236b9f2a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -30,10 +30,10 @@ namespace Cinemachine
         public enum Stage
         {
             /// <summary>Second stage: position the camera in space</summary>
-            Body,
+            PositionControl,
 
             /// <summary>Third stage: orient the camera to point at the target</summary>
-            Aim,
+            RotationControl,
 
             /// <summary>Final pipeline stage: apply noise (this is done separately, in the
             /// Correction channel of the CameraState)</summary>

--- a/com.unity.cinemachine/Runtime/Impulse/CinemachineImpulseListener.cs
+++ b/com.unity.cinemachine/Runtime/Impulse/CinemachineImpulseListener.cs
@@ -22,7 +22,7 @@ namespace Cinemachine
         /// </summary>
         [Tooltip("When to apply the impulse reaction.  Default is after the Noise stage.  "
             + "Modify this if necessary to influence the ordering of extension effects")]
-        public CinemachineCore.Stage m_ApplyAfter = CinemachineCore.Stage.Aim; // legacy compatibility setting
+        public CinemachineCore.Stage m_ApplyAfter = CinemachineCore.Stage.RotationControl; // legacy compatibility setting
 
         /// <summary>
         /// Impulse events on channels not included in the mask will be ignored.

--- a/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/2D/MouseScrollZoom2D.cs
+++ b/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/2D/MouseScrollZoom2D.cs
@@ -20,7 +20,7 @@ namespace Cinemachine.Examples
         void Awake()
         {
             m_VirtualCamera = GetComponent<CmCamera>();
-            m_OriginalOrthoSize = m_VirtualCamera.m_Lens.OrthographicSize;
+            m_OriginalOrthoSize = m_VirtualCamera.Lens.OrthographicSize;
 
 #if UNITY_EDITOR
             // This code shows how to play nicely with the VirtualCamera's SaveDuringPlay functionality
@@ -37,7 +37,7 @@ namespace Cinemachine.Examples
         
         void RestoreOriginalOrthographicSize()
         {
-            m_VirtualCamera.m_Lens.OrthographicSize = m_OriginalOrthoSize;
+            m_VirtualCamera.Lens.OrthographicSize = m_OriginalOrthoSize;
         }
 #endif
 
@@ -49,8 +49,8 @@ namespace Cinemachine.Examples
         void Update()
         {
 #if ENABLE_LEGACY_INPUT_MANAGER
-            float zoom = m_VirtualCamera.m_Lens.OrthographicSize + Input.mouseScrollDelta.y * ZoomMultiplier;
-            m_VirtualCamera.m_Lens.OrthographicSize = Mathf.Clamp(zoom, MinZoom, MaxZoom);
+            float zoom = m_VirtualCamera.Lens.OrthographicSize + Input.mouseScrollDelta.y * ZoomMultiplier;
+            m_VirtualCamera.Lens.OrthographicSize = Mathf.Clamp(zoom, MinZoom, MaxZoom);
 #else
             InputSystemHelper.EnableBackendsWarningMessage();
 #endif

--- a/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/Scripting/ScriptingExample.cs
+++ b/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/Scripting/ScriptingExample.cs
@@ -32,7 +32,7 @@ public class ScriptingExample : MonoBehaviour
         freelook.gameObject.AddComponent<CinemachineOrbitalFollow>();
         freelook.gameObject.AddComponent<CinemachineComposer>();
         freelook.gameObject.AddComponent<InputAxisController>();
-        vcam.Follow = GameObject.Find("Cylinder").transform;
+        freelook.Follow = GameObject.Find("Cylinder").transform;
         freelook.LookAt = GameObject.Find("Cylinder/Sphere").transform;
         freelook.m_Priority = 11;
     }

--- a/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/Scripting/ScriptingExample.cs
+++ b/com.unity.cinemachine/Samples~/Cinemachine Example Scenes/Scenes/Scripting/ScriptingExample.cs
@@ -17,7 +17,7 @@ public class ScriptingExample : MonoBehaviour
 
         // Create a virtual camera that looks at object "Cube", and set some settings
         vcam = new GameObject("VirtualCamera").AddComponent<CmCamera>();
-        vcam.m_LookAt = GameObject.Find("Cube").transform;
+        vcam.Follow = GameObject.Find("Cube").transform;
         vcam.m_Priority = 10;
         vcam.gameObject.transform.position = new Vector3(0, 1, 0);
 
@@ -32,8 +32,8 @@ public class ScriptingExample : MonoBehaviour
         freelook.gameObject.AddComponent<CinemachineOrbitalFollow>();
         freelook.gameObject.AddComponent<CinemachineComposer>();
         freelook.gameObject.AddComponent<InputAxisController>();
-        freelook.m_LookAt = GameObject.Find("Cylinder/Sphere").transform;
-        freelook.m_Follow = GameObject.Find("Cylinder").transform;
+        vcam.Follow = GameObject.Find("Cylinder").transform;
+        freelook.LookAt = GameObject.Find("Cylinder/Sphere").transform;
         freelook.m_Priority = 11;
     }
 


### PR DESCRIPTION
### Purpose of this PR

- Combine LookAt and Follow targets so that by default only one target is needed.  Optionally, one can add a separate lookAt target by clicking here:
![image](https://user-images.githubusercontent.com/6424658/169628135-5a918904-4d7c-4940-bbe7-14e26b100c25.png)

- Rename Stages: Body --> PositionControl, Aim --> RotationControl
- Rename CmCamera fields: m_Lens -> Lens, m_Transitions --> Transitions, m_LookAt/m_Follow --> Target
