### PR TITLE
CMCL-969: Release 2.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.8.7] - 2022-06-26
+- Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter. 
+
+
 ## [2.8.6] - 2022-03-05
 - Bugfix: A memory leak no longer occurs with PostProcessing if no PP layer is present on the camera.
 - Bugfix: Cinemachine no longer produces a compiler error in Unity Editor versions older than 2020 when an Input System package is installed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.8.7] - 2022-07-01
 - Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter. 
 - Bugfix: Fixed spurious Z rotations during speherical blend.
+- Bugfix: Blending speed was not set correctly, when blending back and forth between the same cameras.
 - Regression fix: POV is relative to its parent transform.
 
 ## [2.8.6] - 2022-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Blending speed was not set correctly, when blending back and forth between the same cameras.
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: AxisState.Recentering.RecenterNow() did not work reliably.
+- Bugfix: SensorSize is not saved when not using physical camera.
 
 
 ## [2.8.6] - 2022-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: AxisState.Recentering.RecenterNow() did not work reliably.
 - Bugfix: SensorSize is not saved when not using physical camera.
+- Bugfix: No redundant RepaintAllViews calls.
 
 
 ## [2.8.6] - 2022-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: AxisState.Recentering.RecenterNow() did not work reliably.
 - Bugfix: SensorSize is not saved when not using physical camera.
 - Bugfix: No redundant RepaintAllViews calls.
+- Bugfix: SaveDuringPlay works with ILists now.
 
 
 ## [2.8.6] - 2022-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: POV orientation was incorrect with World Up override
 - Added AutoEnable option to CinemachineInputHandler
 - Bugfix: 3rdPersonFollow shows a warning message when no follow target is assigned like the rest of the body components.
+- Bugfix: FadeOut sample scene shader was culling some objects incorrectly.
 
 
 ## [2.8.4] - 2021-12-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [2.8.7] - 2022-07-01
+## [2.8.7] - 2022-07-22
 - Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter. 
 - Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.
 - Bugfix: Fixed spurious Z rotations during speherical blend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.8.7] - 2022-07-01
 - Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter. 
+- Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.
 - Bugfix: Fixed spurious Z rotations during speherical blend.
 - Bugfix: Blending speed was not set correctly, when blending back and forth between the same cameras.
 - Regression fix: POV is relative to its parent transform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [2.8.7] - 2022-06-26
+## [2.8.7] - 2022-07-01
 - Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter. 
 - Bugfix: Fixed spurious Z rotations during speherical blend.
-
+- Regression fix: POV is relative to its parent transform.
 
 ## [2.8.6] - 2022-05-03
 - Bugfix: A memory leak no longer occurs with PostProcessing if no PP layer is present on the camera.

--- a/Editor/Utility/InspectorUtility.cs
+++ b/Editor/Utility/InspectorUtility.cs
@@ -154,6 +154,8 @@ namespace Cinemachine.Editor
         {
             return ObjectFactory.CreateGameObject(name, types);
         }
+        
+        private static int m_lastRepaintFrame;
 
         /// <summary>
         /// Force a repaint of the Game View
@@ -161,6 +163,10 @@ namespace Cinemachine.Editor
         /// <param name="unused">Like it says</param>
         public static void RepaintGameView(UnityEngine.Object unused = null)
         {
+            if (m_lastRepaintFrame == Time.frameCount)
+                return;
+            m_lastRepaintFrame = Time.frameCount;
+
             EditorApplication.QueuePlayerLoopUpdate();
             UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
         }

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -524,6 +524,10 @@ namespace Cinemachine
 
             // Used by Timeline Preview for overriding the current value of deltaTime
             public float deltaTimeOverride;
+
+            // Used for blend reversal.  Range is 0...1,
+            // representing where the blend started when reversed mid-blend
+            public float blendStartPosition;
         }
 
         // Current game state is always frame 0, overrides are subsequent frames
@@ -681,6 +685,7 @@ namespace Cinemachine
             // Are we transitioning cameras?
             var activeCamera = TopCameraFromPriorityQueue();
             var outGoingCamera = frame.blend.CamB;
+
             if (activeCamera != outGoingCamera)
             {
                 // Do we need to create a game-play blend?
@@ -689,7 +694,9 @@ namespace Cinemachine
                 {
                     // Create a blend (curve will be null if a cut)
                     var blendDef = LookupBlend(outGoingCamera, activeCamera);
-                    if (blendDef.BlendCurve != null && blendDef.BlendTime > 0)
+                    float blendDuration = blendDef.BlendTime;
+                    float blendStartPosition = 0;
+                    if (blendDef.BlendCurve != null && blendDuration > UnityVectorExtensions.Epsilon)
                     {
                         if (frame.blend.IsComplete)
                             frame.blend.CamA = outGoingCamera;  // new blend
@@ -697,15 +704,17 @@ namespace Cinemachine
                         {
                             // Special case: if backing out of a blend-in-progress
                             // with the same blend in reverse, adjust the blend time
+                            // to cancel out the progress made in the opposite direction
                             if ((frame.blend.CamA == activeCamera 
                                     || (frame.blend.CamA as BlendSourceVirtualCamera)?.Blend.CamB == activeCamera) 
-                                && frame.blend.CamB == outGoingCamera 
-                                && frame.blend.Duration <= blendDef.BlendTime)
+                                && frame.blend.CamB == outGoingCamera)
                             {
-                                blendDef.m_Time = 
-                                    (frame.blend.TimeInBlend / frame.blend.Duration) * blendDef.BlendTime;
+                                // How far have we blended?  That is what we must undo
+                                var progress = frame.blendStartPosition 
+                                    + (1 - frame.blendStartPosition) * frame.blend.TimeInBlend / frame.blend.Duration;
+                                blendDuration *= progress;
+                                blendStartPosition = 1 - progress;
                             }
-
                             // Chain to existing blend
                             frame.blend.CamA = new BlendSourceVirtualCamera(
                                 new CinemachineBlend(
@@ -715,8 +724,9 @@ namespace Cinemachine
                         }
                     }
                     frame.blend.BlendCurve = blendDef.BlendCurve;
-                    frame.blend.Duration = blendDef.BlendTime;
+                    frame.blend.Duration = blendDuration;
                     frame.blend.TimeInBlend = 0;
+                    frame.blendStartPosition = blendStartPosition;
                 }
                 // Set the current active camera
                 frame.blend.CamB = activeCamera;

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -141,7 +141,7 @@ namespace Cinemachine
                 var extra = GetExtraState<VcamExtraState>(vcam);
                 Vector3 displacement;
                 if (m_ConfineScreenEdges && state.Lens.Orthographic)
-                    displacement = ConfineScreenEdges(vcam, ref state);
+                    displacement = ConfineScreenEdges(ref state);
                 else
                     displacement = ConfinePoint(state.CorrectedPosition);
 
@@ -273,21 +273,22 @@ namespace Cinemachine
         }
 
         // Camera must be orthographic
-        private Vector3 ConfineScreenEdges(CinemachineVirtualCameraBase vcam, ref CameraState state)
+        Vector3 ConfineScreenEdges(ref CameraState state)
         {
-            Quaternion rot = Quaternion.Inverse(state.CorrectedOrientation);
-            float dy = state.Lens.OrthographicSize;
-            float dx = dy * state.Lens.Aspect;
-            Vector3 vx = (rot * Vector3.right) * dx;
-            Vector3 vy = (rot * Vector3.up) * dy;
+            var rot = state.CorrectedOrientation;
+            var dy = state.Lens.OrthographicSize;
+            var dx = dy * state.Lens.Aspect;
+            var vx = (rot * Vector3.right) * dx;
+            var vy = (rot * Vector3.up) * dy;
 
-            Vector3 displacement = Vector3.zero;
-            Vector3 camPos = state.CorrectedPosition;
-            Vector3 lastD = Vector3.zero;
+            var displacement = Vector3.zero;
+            var camPos = state.CorrectedPosition;
+            var lastD = Vector3.zero;
+
             const int kMaxIter = 12;
-            for (int i = 0; i < kMaxIter; ++i)
+            for (var i = 0; i < kMaxIter; ++i)
             {
-                Vector3 d = ConfinePoint((camPos - vy) - vx);
+                var d = ConfinePoint((camPos - vy) - vx);
                 if (d.AlmostZero())
                     d = ConfinePoint((camPos + vy) + vx);
                 if (d.AlmostZero())

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -841,5 +841,12 @@ namespace Cinemachine
                 m_CachedTension = m_SplineCurvature;
             }
         }
+        
+        // This prevents the sensor size from dirtying the scene in the event of aspect ratio change
+        internal override void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.one;
+        }
     }
 }

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -646,7 +646,8 @@ namespace Cinemachine
 
         private int LocateExistingRigs(string[] rigNames, bool forceOrbital)
         {
-            m_CachedXAxisHeading = 0;
+            m_CachedXAxisHeading = m_XAxis.Value;
+            m_LastHeadingUpdateFrame = -1;
             mOrbitals = new CinemachineOrbitalTransposer[rigNames.Length];
             m_Rigs = new CinemachineVirtualCamera[rigNames.Length];
             int rigsFound = 0;
@@ -682,13 +683,17 @@ namespace Cinemachine
         }
 
         float m_CachedXAxisHeading;
+        float m_LastHeadingUpdateFrame;
 
         float UpdateXAxisHeading(CinemachineOrbitalTransposer orbital, float deltaTime, Vector3 up)
         {
             if (this == null)   
                 return 0; // deleted
-            if (mOrbitals != null && mOrbitals[1] == orbital)
+
+            // Update the axis only once per frame
+            if (m_LastHeadingUpdateFrame != Time.frameCount)
             {
+                m_LastHeadingUpdateFrame = Time.frameCount;
                 var oldValue = m_XAxis.Value;
                 m_CachedXAxisHeading = orbital.UpdateHeading(
                     PreviousStateIsValid ? deltaTime : -1, up,

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -629,5 +629,12 @@ namespace Cinemachine
                 return true;
             return m_ComponentPipeline != null && m_ComponentPipeline.Any(c => c != null && c.RequiresUserInput);
         }
+        
+        // This prevents the sensor size from dirtying the scene in the event of aspect ratio change
+        internal override void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.one;
+        }
     }
 }

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -138,7 +138,7 @@ namespace Cinemachine
                 rot = parent.rotation * rot;
                 up = parent.up;
             }
-            rot = Quaternion.FromToRotation(up, curState.ReferenceUp) * rot;
+            rot = Quaternion.FromToRotation(curState.ReferenceUp, up) * rot;
             curState.RawOrientation = rot;
         }
 

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -24,7 +24,7 @@ namespace Cinemachine
         public static readonly int kStreamingVersion = 20170927;
 
         /// <summary>Human-readable Cinemachine Version</summary>
-        public static readonly string kVersionString = "2.8.6";
+        public static readonly string kVersionString = "2.8.7";
 
         /// <summary>
         /// Stages in the Cinemachine Component pipeline, used for

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -28,7 +28,7 @@ namespace Cinemachine
     /// Unity cameras simultaneously.
     /// </summary>
     [SaveDuringPlay]
-    public abstract class CinemachineVirtualCameraBase : MonoBehaviour, ICinemachineCamera
+    public abstract class CinemachineVirtualCameraBase : MonoBehaviour, ICinemachineCamera, ISerializationCallbackReceiver
     {
         /// <summary>Inspector control - Use for hiding sections of the Inspector UI.</summary>
         [HideInInspector, SerializeField, NoSaveDuringPlay]
@@ -858,5 +858,23 @@ namespace Cinemachine
         /// <summary>Get LookAt target as CinemachineVirtualCameraBase, 
         /// or null if target is not a CinemachineVirtualCameraBase</summary>
         public CinemachineVirtualCameraBase LookAtTargetAsVcam => m_CachedLookAtTargetVcam;
+
+        /// <summary>Pre-Serialization handler - delegates to derived classes</summary>
+        void ISerializationCallbackReceiver.OnBeforeSerialize() => OnBeforeSerialize();
+
+        /// <summary>Post-Serialization handler - performs legacy upgrade</summary>
+        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        {
+            if (m_StreamingVersion < CinemachineCore.kStreamingVersion)
+                LegacyUpgrade(m_StreamingVersion);
+            m_StreamingVersion = CinemachineCore.kStreamingVersion;
+        }
+        
+        /// <summary>
+        /// Override this to handle any upgrades necessitated by a streaming version change
+        /// </summary>
+        /// <param name="streamedVersion">The version that was streamed</param>
+        internal protected virtual void LegacyUpgrade(int streamedVersion) {}
+        internal virtual void OnBeforeSerialize() {}
     }
 }

--- a/Runtime/Experimental/CinemachineNewFreeLook.cs
+++ b/Runtime/Experimental/CinemachineNewFreeLook.cs
@@ -58,7 +58,7 @@ namespace Cinemachine
 
         /// <summary>Override settings for top and bottom rigs</summary>
         [Serializable]
-        public class Rig
+        public class Rig : ISerializationCallbackReceiver
         {
             public bool m_CustomLens;
             public LensSettings m_Lens;
@@ -204,6 +204,15 @@ namespace Cinemachine
                     p.m_FrequencyGain = m_FrequencyGain;
                 }
             }
+
+            // This prevents the sensor size from dirtying the scene in the event of aspect ratio change
+            void ISerializationCallbackReceiver.OnBeforeSerialize()
+            {
+                if (!m_Lens.IsPhysicalCamera) 
+                    m_Lens.SensorSize = Vector2.one;
+            }
+
+            void ISerializationCallbackReceiver.OnAfterDeserialize() {}
         }
 
         [SerializeField]

--- a/Runtime/Experimental/CinemachineNewVirtualCamera.cs
+++ b/Runtime/Experimental/CinemachineNewVirtualCamera.cs
@@ -444,6 +444,13 @@ namespace Cinemachine
                 }
             }
         }
+        
+        // This prevents the sensor size from dirtying the scene in the event of aspect ratio change
+        internal override void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.one;
+        }
     }
 }
 #endif

--- a/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Serialization;
 
 #if CINEMACHINE_HDRP
     using System.Collections.Generic;

--- a/Samples~/Cinemachine Example Scenes/Scenes/FadeOutNearbyObjects/FadeOut.shader
+++ b/Samples~/Cinemachine Example Scenes/Scenes/FadeOutNearbyObjects/FadeOut.shader
@@ -9,7 +9,7 @@ Shader "Custom/FadeOut" {
         Tags { "Queue"="Transparent" "RenderType"="Transparent" }
  
     Pass {
-        ZWrite On
+        ZWrite Off
         ColorMask 0
     }
    

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -3,17 +3,17 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.8.5"
+            "PackageVersion": "2.8.6"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.8.5"
+            "PackageVersion": "2.8.6"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.8.5"
+            "PackageVersion": "2.8.6"
         }
     ],
     "WarningExceptions": []

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -3,17 +3,17 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.8.6"
+            "PackageVersion": "2.8.7"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.8.6"
+            "PackageVersion": "2.8.7"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.8.6"
+            "PackageVersion": "2.8.7"
         }
     ],
     "WarningExceptions": []

--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
     "category": "cinematography",
     "dependencies": {
     },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Unity-Technologies/upm-package-cinemachine",
-        "revision": "679387cb1fa822190b530bdbb8ea0945f508b5f6"
-    },
     "samples": [
         {
             "displayName": "Cinemachine Example Scenes",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.8.6",
+    "version": "2.8.7",
     "unity": "2019.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR

**Backports for these**

- [x] CMCL-923 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/448
- [x] CMCL-1006 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/469
- [x] CMCL-1014 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/474
- [x] CMCL-1003 -> CMCL-931 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/492
- [x] Backport of https://github.com/Unity-Technologies/com.unity.cinemachine/pull/487
- [x] CMCL-824 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/407
- [x] CMCL-1068 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/507

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version
- [x] Updated package version
