### PR TITLE
CMCL-0000: fixed screenguides drawing, added warning icons to CmCamera inspector

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineComposerEditor.cs
@@ -68,11 +68,7 @@ namespace Cinemachine.Editor
         protected virtual void OnGUI()
         {
             // Draw the camera guides
-            if (Target == null || !CinemachineSettings.CinemachineCoreSettings.ShowInGameGuides)
-                return;
-
-            // If inspector is collapsed in the vcam editor, don't draw the guides
-            if (!VcamStageEditor.ActiveEditorRegistry.IsActiveEditor(this))
+            if (Target == null || !CinemachineSettings.CinemachineCoreSettings.ShowInGameGuides || !Target.isActiveAndEnabled)
                 return;
 
             // Don't draw the guides if rendering to texture

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFramingTransposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFramingTransposerEditor.cs
@@ -137,11 +137,7 @@ namespace Cinemachine.Editor
         protected virtual void OnGUI()
         {
             // Draw the camera guides
-            if (Target == null || !CinemachineSettings.CinemachineCoreSettings.ShowInGameGuides)
-                return;
-
-            // If inspector is collapsed in the vcam editor, don't draw the guides
-            if (!VcamStageEditor.ActiveEditorRegistry.IsActiveEditor(this))
+            if (Target == null || !CinemachineSettings.CinemachineCoreSettings.ShowInGameGuides || !Target.isActiveAndEnabled)
                 return;
 
             CinemachineBrain brain = CinemachineCore.Instance.FindPotentialTargetBrain(Target.VirtualCamera);

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -189,7 +189,7 @@ namespace Cinemachine.Editor
             public FovPropertyControl(SerializedProperty property, bool hideLabel) 
             {
                 m_Property = property;
-                ShortLabel = new Label("(fov)") { style = { alignSelf = Align.Center }};
+                ShortLabel = new Label("(fov)") { style = { alignSelf = Align.Center, opacity = 0.5f }};
                 ShortLabel.AddToClassList("unity-base-field__label--with-dragger");
 
                 var orthoProp = property.FindPropertyRelative(() => m_LensSettingsDef.OrthographicSize);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -192,8 +192,7 @@ namespace Cinemachine.Editor
                         flexGrow = 0,
                         backgroundImage = (StyleBackground)EditorGUIUtility.IconContent("console.warnicon.sml").image,
                         width = InspectorUtility.SingleLineHeight, height = InspectorUtility.SingleLineHeight,
-                        alignSelf = Align.Center,
-                        //paddingRight = 0, borderRightWidth = 0, marginRight = 0
+                        alignSelf = Align.Center
                     }
                 });
                 warningIcon.SetVisible(false);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -23,7 +23,7 @@ namespace Cinemachine.Editor
 
         public bool IsPrefab { get; private set; }
 
-        /// <summary>Call from Inspector's OnEnsable</summary>
+        /// <summary>Call from Inspector's OnEnable</summary>
         public void OnEnable(UnityEngine.Object[] targets)
         {
             Targets = targets;
@@ -35,6 +35,7 @@ namespace Cinemachine.Editor
         public void OnDisable()
         {
             EditorApplication.update -= UpdateCameraStatus;
+            EditorApplication.update -= RefreshPipelinDropdowns;
             Undo.undoRedoPerformed -= UpdateCameraState;
             if (Target != null && CinemachineBrain.SoloCamera == (ICinemachineCamera)Target)
             {
@@ -120,7 +121,7 @@ namespace Cinemachine.Editor
             if (m_SoloButton != null)
                 m_SoloButton.style.color = color;
 
-            // Refrest the game view if solo and not playing
+            // Refresh the game view if solo and not playing
             if (isSolo && !Application.isPlaying)
                 InspectorUtility.RepaintGameView();
         }
@@ -134,21 +135,24 @@ namespace Cinemachine.Editor
             var targets = Targets; // capture for lambda
 
             // Add a dropdown for each pipeline stage
+            m_pipelineItems = new List<PipelineStageItem>();
             for (int i = 0; i < PipelineStageMenu.s_StageData.Length; ++i)
             {
                 // Skip empty categories
                 if (PipelineStageMenu.s_StageData[i].Types.Count < 2)
                     continue;
 
+                var row = ux.AddChild(new InspectorUtility.LeftRightContainer());
                 int currentSelection = PipelineStageMenu.GetSelectedComponent(
                     i, cmCam.GetCinemachineComponent((CinemachineCore.Stage)i));
                 var stage = i; // capture for lambda
                 var dropdown = new DropdownField
                 {
                     name = PipelineStageMenu.s_StageData[stage].Name + " selector",
-                    label = PipelineStageMenu.s_StageData[stage].Name,
+                    label = "",
                     choices = PipelineStageMenu.s_StageData[stage].Choices,
-                    index = currentSelection
+                    index = currentSelection,
+                    style = { flexGrow = 1 }
                 };
                 dropdown.AddToClassList(InspectorUtility.kAlignFieldClass);
                 dropdown.RegisterValueChangedCallback((evt) => 
@@ -178,7 +182,54 @@ namespace Cinemachine.Editor
                         return 0;
                     }
                 });
-                ux.Add(dropdown);
+                row.Left.Add(new Label(PipelineStageMenu.s_StageData[stage].Name) 
+                    { style = { flexGrow = 1, alignSelf = Align.Center }});
+                var warningIcon = row.Left.AddChild(new Label 
+                { 
+                    tooltip = "Component is disabled or has a problem",
+                    style = 
+                    { 
+                        flexGrow = 0,
+                        backgroundImage = (StyleBackground)EditorGUIUtility.IconContent("console.warnicon.sml").image,
+                        width = InspectorUtility.SingleLineHeight, height = InspectorUtility.SingleLineHeight,
+                        alignSelf = Align.Center,
+                        //paddingRight = 0, borderRightWidth = 0, marginRight = 0
+                    }
+                });
+                warningIcon.SetVisible(false);
+                row.Right.Add(dropdown);
+
+                m_pipelineItems.Add(new PipelineStageItem
+                {
+                    Stage = (CinemachineCore.Stage)i,
+                    Dropdown = dropdown,
+                    WarningIcon = warningIcon
+                });
+            }
+            EditorApplication.update += RefreshPipelinDropdowns;
+        }
+
+        struct PipelineStageItem
+        {
+            public CinemachineCore.Stage Stage;
+            public DropdownField Dropdown;
+            public Label WarningIcon;
+        }
+        List<PipelineStageItem> m_pipelineItems;
+
+        void RefreshPipelinDropdowns()
+        {
+            var cmCam = Target as CmCamera;
+            if (cmCam == null)
+                return;
+            for (int i = 0; i < m_pipelineItems.Count; ++i)
+            {
+                var item = m_pipelineItems[i];
+                var c = cmCam.GetCinemachineComponent(item.Stage);
+                int selection = PipelineStageMenu.GetSelectedComponent((int)item.Stage, c);
+                item.Dropdown.value = PipelineStageMenu.s_StageData[(int)item.Stage].Choices[selection];
+                
+                item.WarningIcon.SetVisible(c != null && !c.IsValid);
             }
         }
 
@@ -231,7 +282,7 @@ namespace Cinemachine.Editor
             // Extensions
             public static List<Type> s_ExtentionTypes;
             public static List<string> s_ExtentionNames;
-        
+
             public static int GetSelectedComponent(int stage, CinemachineComponentBase component)
             {
                 if (component != null)
@@ -335,7 +386,7 @@ namespace Cinemachine.Editor
         /// <summary>
         /// This is only for aesthetics, sort order does not affect camera logic.
         /// Behaviours should be sorted like this:
-        /// CmCamera, Body, Aim, Noise, Finalize, Extensions, everything else.
+        /// CmCamera, PositionControl, RotationControl, Noise, Finalize, Extensions, everything else.
         /// </summary>
         public void SortComponents()
         {

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -135,7 +135,7 @@ namespace Cinemachine.Editor
             var targets = Targets; // capture for lambda
 
             // Add a dropdown for each pipeline stage
-            m_pipelineItems = new List<PipelineStageItem>();
+            m_PipelineItems = new List<PipelineStageItem>();
             for (int i = 0; i < PipelineStageMenu.s_StageData.Length; ++i)
             {
                 // Skip empty categories
@@ -198,7 +198,7 @@ namespace Cinemachine.Editor
                 warningIcon.SetVisible(false);
                 row.Right.Add(dropdown);
 
-                m_pipelineItems.Add(new PipelineStageItem
+                m_PipelineItems.Add(new PipelineStageItem
                 {
                     Stage = (CinemachineCore.Stage)i,
                     Dropdown = dropdown,
@@ -214,16 +214,16 @@ namespace Cinemachine.Editor
             public DropdownField Dropdown;
             public Label WarningIcon;
         }
-        List<PipelineStageItem> m_pipelineItems;
+        List<PipelineStageItem> m_PipelineItems;
 
         void RefreshPipelinDropdowns()
         {
             var cmCam = Target as CmCamera;
             if (cmCam == null)
                 return;
-            for (int i = 0; i < m_pipelineItems.Count; ++i)
+            for (int i = 0; i < m_PipelineItems.Count; ++i)
             {
-                var item = m_pipelineItems[i];
+                var item = m_PipelineItems[i];
                 var c = cmCam.GetCinemachineComponent(item.Stage);
                 int selection = PipelineStageMenu.GetSelectedComponent((int)item.Stage, c);
                 item.Dropdown.value = PipelineStageMenu.s_StageData[(int)item.Stage].Choices[selection];


### PR DESCRIPTION
- Screen guides were not being drawn for CmCameras.  Fixed.
- Greyed out lens collapsed label to make it less weird.
- Added warning icons to CmCamera inspector when components are disabled or invalid:

![image](https://user-images.githubusercontent.com/6424658/170544284-07943a8d-b86a-430b-8329-f2ecddc83fe1.png)
