### PR TITLE
CMCL-1000: Focus Distance and AutoFocus

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - FreeLook refactor: CinemachineFreeLook is now CmCamera with FreeLook Modifier.
 - Combine Follow and LookAt Targets to single Tracking Target with optional LookAt Target.
 - Add flag for custom priority setting.
+- HDRP only: Added FocusDistance setting to lens
+- HDRP only: New AutoFocus extension.  Use instead of VolumeSettings for Focus Tracking.  Includes Automatic mode that queries depth buffer instead of tracking a specific target.
 
 
 ## UNRELEASED

--- a/com.unity.cinemachine/Editor/Experimental/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Experimental/CmCameraEditor.cs
@@ -11,8 +11,6 @@ namespace Cinemachine.Editor
         CmCamera Target => target as CmCamera;
         CmCameraInspectorUtility m_CameraUtility = new CmCameraInspectorUtility();
 
-        static bool s_AdvancedLensExpanded;
-
         [MenuItem("CONTEXT/CmCamera/Adopt Game View Camera Settings")]
         static void AdoptGameViewCameraSettings(MenuCommand command)
         {
@@ -70,19 +68,6 @@ namespace Cinemachine.Editor
             ux.AddHeader("Camera");
             var lensProperty = serializedTarget.FindProperty(() => Target.Lens);
             ux.Add(new PropertyField(lensProperty));
-
-            var modeOverrideProperty = lensProperty.FindPropertyRelative("ModeOverride");
-            var advanced = ux.AddChild(new Foldout() { text = "Advanced", value = s_AdvancedLensExpanded });
-            advanced.RegisterValueChangedCallback((evt) => 
-            {
-                s_AdvancedLensExpanded = evt.newValue;
-                evt.StopPropagation();
-            });
-            advanced.Add(new HelpBox("Setting a mode override here implies changes to the Camera component when "
-                + "Cinemachine activates this CM Camera, and the changes will remain after the CM "
-                + "Camera deactivation. If you set a mode override in any CM Camera, you should set "
-                + "one in all CM Cameras.", HelpBoxMessageType.Info));
-            advanced.Add(new PropertyField(modeOverrideProperty));
 
             ux.AddHeader("Procedural Motion");
             m_CameraUtility.AddSaveDuringPlayToggle(ux);

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
@@ -34,6 +34,8 @@ namespace Cinemachine.PostFX.Editor
             var mode = (CinemachineAutoFocus.FocusTrackingMode)focusTargetProp.intValue;
             if (mode != CinemachineAutoFocus.FocusTrackingMode.CustomTarget)
                 excluded.Add(FieldPath(x => x.CustomTarget));
+            if (mode != CinemachineAutoFocus.FocusTrackingMode.ScreenCenter)
+                excluded.Add(FieldPath(x => x.AutoDetectionRadius));
             if (mode == CinemachineAutoFocus.FocusTrackingMode.None)
             {
                 excluded.Add(FieldPath(x => x.FocusOffset));

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
@@ -1,0 +1,45 @@
+    using UnityEditor;
+    using System.Collections.Generic;
+
+namespace Cinemachine.PostFX.Editor
+{
+    [CustomEditor(typeof(CinemachineAutoFocus))]
+    public sealed class CinemachineAutoFocusEditor : Cinemachine.Editor.BaseEditor<CinemachineAutoFocus>
+    {
+#if !CINEMACHINE_HDRP
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox(
+                "This component is only valid for HDRP projects.",
+                MessageType.Warning);
+        }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox(
+                "Note: focus control requires an active Volume containing a Depth Of Field override "
+                    + "having Focus Mode activated and set to Physical Camera, "
+                    + "and Focus Distance Mode activated and set to Camera",
+                MessageType.Info);
+
+            base.OnInspectorGUI();
+        }
+
+        /// <summary>Get the property names to exclude in the inspector.</summary>
+        /// <param name="excluded">Add the names to this list</param>
+        protected override void GetExcludedPropertiesInInspector(List<string> excluded)
+        {
+            base.GetExcludedPropertiesInInspector(excluded);
+            var focusTargetProp  = FindProperty(x => x.FocusTarget);
+            var mode = (CinemachineAutoFocus.FocusTrackingMode)focusTargetProp.intValue;
+            if (mode != CinemachineAutoFocus.FocusTrackingMode.CustomTarget)
+                excluded.Add(FieldPath(x => x.CustomTarget));
+            if (mode == CinemachineAutoFocus.FocusTrackingMode.None)
+            {
+                excluded.Add(FieldPath(x => x.FocusOffset));
+                excluded.Add(FieldPath(x => x.Damping));
+            }
+        }
+#endif
+    }
+}

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs.meta
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef969b61b6f6df4419ea83c42719409b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
@@ -1,17 +1,32 @@
-#if CINEMACHINE_POST_PROCESSING_V2
 using UnityEngine;
 using UnityEditor;
+using System.Collections.Generic;
+
+#if CINEMACHINE_POST_PROCESSING_V2
 using UnityEngine.Rendering.PostProcessing;
 using UnityEditor.Rendering.PostProcessing;
-using System.Collections.Generic;
 #endif
 
 namespace Cinemachine.PostFX.Editor
 {
-#if CINEMACHINE_POST_PROCESSING_V2
     [CustomEditor(typeof(CinemachinePostProcessing))]
     public sealed class CinemachinePostProcessingEditor : Cinemachine.Editor.BaseEditor<CinemachinePostProcessing>
     {
+#if !CINEMACHINE_POST_PROCESSING_V2
+        public override void OnInspectorGUI()
+        {
+    #if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+            EditorGUILayout.HelpBox(
+                "This component is not valid for HDRP and URP projects.  Use the CinemachineVolumeSettings component instead.",
+                MessageType.Warning);
+    #else
+            EditorGUILayout.HelpBox(
+                "This component requires the PostProcessing package, which can be downloaded from the Package Manager.\n\n"
+                + "Note: For HDRP and URP projects, use the CinemachineVolumeSettings component instead.",
+                MessageType.Warning);
+    #endif
+        }
+#else
         SerializedProperty m_Profile;
         SerializedProperty m_FocusTracking;
 
@@ -62,6 +77,11 @@ namespace Cinemachine.PostFX.Editor
 
         public override void OnInspectorGUI()
         {
+#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+            EditorGUILayout.HelpBox(
+                "This component is not valid for HDRP and URP projects.  Use the CinemachineVolumeSettings component instead.",
+                MessageType.Warning);
+#endif
             BeginInspector();
             DrawRemainingPropertiesInInspector();
 
@@ -209,6 +229,6 @@ namespace Cinemachine.PostFX.Editor
             AssetDatabase.Refresh();
             return profile;
         }
-    }
 #endif
+    }
 }

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -95,7 +95,8 @@ namespace Cinemachine.PostFX.Editor
                         MessageType.Warning);
 #else
                 {
-                    valid = dof.active && dof.focusDistance.overrideState
+                    valid = dof.active 
+                        && (dof.focusDistance.overrideState || dof.focusDistanceMode == FocusDistanceMode.Camera)
                         && dof.focusMode.overrideState && dof.focusMode == DepthOfFieldMode.UsePhysicalCamera;
                 }
                 if (!valid)

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -1,29 +1,31 @@
-#if CINEMACHINE_HDRP
     using UnityEngine;
     using UnityEditor;
     using UnityEngine.Rendering;
     using UnityEditor.Rendering;
     using System.Collections.Generic;
+#if CINEMACHINE_HDRP
     #if CINEMACHINE_HDRP_7_3_1
         using UnityEngine.Rendering.HighDefinition;
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
 #elif CINEMACHINE_LWRP_7_3_1
-    using UnityEngine;
-    using UnityEditor;
-    using UnityEngine.Rendering;
-    using UnityEditor.Rendering;
-    using System.Collections.Generic;
     using UnityEngine.Rendering.Universal;
 #endif
 
 namespace Cinemachine.PostFX.Editor
 {
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
     [CustomEditor(typeof(CinemachineVolumeSettings))]
     public sealed class CinemachineVolumeSettingsEditor : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
     {
+#if !(CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1)
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox(
+                "This component is only valid for HDRP and URP projects.",
+                MessageType.Warning);
+        }
+#else
         SerializedProperty m_Profile;
         SerializedProperty m_FocusTracking;
 
@@ -235,6 +237,6 @@ namespace Cinemachine.PostFX.Editor
             AssetDatabase.Refresh();
             return profile;
         }
-    }
 #endif
+    }
 }

--- a/com.unity.cinemachine/Editor/PropertyDrawers/CameraPriorityPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CameraPriorityPropertyDrawer.cs
@@ -40,7 +40,8 @@ namespace Cinemachine.Editor
             row.Left.Add(new Label("Priority") { tooltip = property.tooltip, style = { alignSelf = Align.Center, flexGrow = 0 }});
             row.Right.Add(new PropertyField(customProp, "") 
                 { tooltip = property.tooltip, style = { alignSelf = Align.Center, flexGrow = 0, marginRight = 5 }});
-            var defaultLabel = row.Right.AddChild(new Label("(using default)") { style = { alignSelf = Align.Center, flexGrow = 0 }});
+            var defaultLabel = row.Right.AddChild(new Label("(using default)") 
+                { style = { alignSelf = Align.Center, flexGrow = 0, unityFontStyleAndWeight = FontStyle.Italic }});
             var valueField = row.Right.AddChild(new InspectorUtility.CompactPropertyField(
                 property.FindPropertyRelative(() => def.Priority), "Value") { style = { flexGrow = 1 }});
 

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -341,7 +341,7 @@ namespace Cinemachine.Editor
                         && Mathf.Approximately(a.SensorSize.y, b.SensorSize.y)
                         && a.GateFit == b.GateFit
 #if CINEMACHINE_HDRP
-                        && Mathf.Approximately(a.iso, b.iso)
+                        && Mathf.Approximately(a.Iso, b.Iso)
                         && Mathf.Approximately(a.ShutterSpeed, b.ShutterSpeed)
                         && Mathf.Approximately(a.Aperture, b.Aperture)
                         && a.BladeCount == b.BladeCount

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -968,11 +968,12 @@ namespace Cinemachine
                     bool isPhysical = state.Lens.ModeOverride == LensSettings.OverrideModes.None 
                         ? cam.usePhysicalProperties : state.Lens.IsPhysicalCamera;
                     cam.usePhysicalProperties = isPhysical;
-                    if (isPhysical && state.Lens.IsPhysicalCamera)
+                    if (isPhysical)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
 #if CINEMACHINE_HDRP
+                        cam.focusDistance = state.Lens.FocusDistance;
                         cam.iso = state.Lens.Iso;
                         cam.shutterSpeed = state.Lens.ShutterSpeed;
                         cam.aperture = state.Lens.Aperture;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -28,7 +28,7 @@ namespace Cinemachine
             // This must run during the Body stage because CinemachineConfiner also runs during Body stage,
             // and CinemachinePixelPerfect needs to run before CinemachineConfiner as the confiner reads the
             // orthographic size. We also altered the script execution order to ensure this.
-            if (stage != CinemachineCore.Stage.Body)
+            if (stage != CinemachineCore.Stage.PositionControl)
                 return;
 
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(vcam);

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -109,7 +109,7 @@ namespace Cinemachine
 
         /// <summary>
         /// For physical cameras, this is the actual size of the image sensor (in mm); it is used to 
-        /// convert between focal length and field of vue.  For nonphysical cameras, it is the aspect ratio.
+        /// convert between focal length and field of view.  For nonphysical cameras, it is the aspect ratio.
         /// </summary>
         public Vector2 SensorSize
         { 
@@ -160,6 +160,7 @@ namespace Cinemachine
         public float ShutterSpeed;
         [RangeSlider(Camera.kMinAperture, Camera.kMaxAperture)]
         public float Aperture;
+        public float FocusDistance;
         [RangeSlider(Camera.kMinBladeCount, Camera.kMaxBladeCount)]
         public int BladeCount;
         [MinMaxRangeSlider(Camera.kMinAperture, Camera.kMaxAperture)]

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
@@ -1,0 +1,133 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+using UnityEngine.Rendering;
+using Cinemachine.Utility;
+
+#if CINEMACHINE_HDRP
+using UnityEngine.Rendering.HighDefinition;
+#endif
+
+namespace Cinemachine.PostFX
+{
+#if !CINEMACHINE_HDRP
+    /// <summary>
+    /// This behaviour will drive the CmCamera Lens's FocusDistance setting.
+    /// It can be used to hold focus onto a specific object, or to auto-detect what is in front
+    /// of the camera and focus on that.
+    /// 
+    /// This component is only available in HDRP projects.
+    /// </summary>
+    [AddComponentMenu("")] // Hide in menu
+    public class CinemachineAutoFocus : MonoBehaviour {}
+#else
+    /// <summary>
+    /// This behaviour will drive the CmCamera Lens's FocusDistance setting.
+    /// It can be used to hold focus onto a specific object, or to auto-detect what is in front
+    /// of the camera and focus on that.
+    /// 
+    /// This component is only available in HDRP projects.
+    /// </summary>
+    [ExecuteAlways]
+    [AddComponentMenu("")] // Hide in menu
+    [SaveDuringPlay]
+    [DisallowMultipleComponent]
+    [HelpURL(Documentation.BaseURL + "manual/CinemachineAutoFocus.html")]
+    public class CinemachineAutoFocus : CinemachineExtension
+    {
+        /// <summary>The reference object for focus tracking</summary>
+        public enum FocusTrackingMode
+        {
+            /// <summary>No focus tracking</summary>
+            None,
+            /// <summary>Focus offset is relative to the LookAt target</summary>
+            LookAtTarget,
+            /// <summary>Focus offset is relative to the Follow target</summary>
+            FollowTarget,
+            /// <summary>Focus offset is relative to the Custom target set here</summary>
+            CustomTarget,
+            /// <summary>Focus offset is relative to the camera</summary>
+            Camera,
+            /// <summary>Focus will be on whatever is located in the depth buffer 
+            /// at the center of the screen</summary>
+            Automatic
+        };
+
+        /// <summary>The camera's focus disttance will be set to the distance from the selected 
+        /// target to the camera.  The Focus Offset field will then modify that distance</summary>
+        [Tooltip("The camera's focus disttance will be set to the distance from the selected "
+            + "target to the camera.  The Focus Offset field will then modify that distance.")]
+        public FocusTrackingMode FocusTarget;
+
+        /// <summary>The target to use if Focus Target is set to Custom Target</summary>
+        [Tooltip("The target to use if Focus Target is set to Custom Target")]
+        public Transform CustomTarget;
+
+        /// <summary>Offsets the sharpest point away from the focus target location</summary>
+        [Tooltip("Offsets the sharpest point away from the focus target location.")]
+        public float FocusOffset;
+
+        /// <summary>
+        /// Set this to make the focus adjust gradually to the desired setting.  The
+        /// value corresponds approximately to the time the focus will take to adjust to the new value.
+        /// </summary>
+        [Tooltip("The value corresponds approximately to the time the focus will take to adjust to the new value.")]
+        public float Damping;
+
+        /// <summary>Apply PostProcessing effects</summary>
+        /// <param name="vcam">The virtual camera being processed</param>
+        /// <param name="stage">The current pipeline stage</param>
+        /// <param name="state">The current virtual camera state</param>
+        /// <param name="deltaTime">The current applicable deltaTime</param>
+        protected override void PostPipelineStageCallback(
+            CinemachineVirtualCameraBase vcam,
+            CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
+        {
+            // Set the focus after the camera has been fully positioned
+            if (stage == CinemachineCore.Stage.Finalize && FocusTarget != FocusTrackingMode.None)
+            {
+                float focusDistance = 0;
+                Transform focusTarget = null;
+                switch (FocusTarget)
+                {
+                    default: 
+                        break;
+                    case FocusTrackingMode.LookAtTarget: 
+                        focusDistance = (state.FinalPosition - state.ReferenceLookAt).magnitude; 
+                        break;
+                    case FocusTrackingMode.FollowTarget: 
+                        focusTarget = VirtualCamera.Follow; 
+                        break;
+                    case FocusTrackingMode.CustomTarget: 
+                        focusTarget = CustomTarget; 
+                        break;
+                    case FocusTrackingMode.Automatic:
+                        focusDistance = FetchAutoFocusDistance();
+                        break;
+                }
+                if (focusTarget != null)
+                    focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
+
+                focusDistance = Mathf.Max(0, focusDistance + FocusOffset);
+
+                // Apply damping
+                var extra = GetExtraState<VcamExtraState>(vcam);
+                if (deltaTime >= 0 && vcam.PreviousStateIsValid)
+                    focusDistance = extra.CurrentFocusDistance + Damper.Damp(
+                        focusDistance - extra.CurrentFocusDistance, Damping, deltaTime);
+                extra.CurrentFocusDistance = focusDistance;
+                state.Lens.FocusDistance = focusDistance;                            
+            }
+        }
+
+        class VcamExtraState
+        {
+            public float CurrentFocusDistance;
+        }
+
+        float FetchAutoFocusDistance()
+        {
+            return 0; // GML todo
+        }
+#endif
+    }
+}

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs.meta
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7362d5a2f8ea3347bfcc808a1e9290e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 5f2a108eb023faf43a809979fd3d38f2, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs.meta
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs.meta
@@ -3,7 +3,9 @@ guid: a7362d5a2f8ea3347bfcc808a1e9290e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - CustomTarget: {instanceID: 0}
+  - m_ComputeShader: {fileID: 7200000, guid: 70bb111e26536f54da7584ae418a9ed8, type: 3}
   executionOrder: 0
   icon: {fileID: 2800000, guid: 5f2a108eb023faf43a809979fd3d38f2, type: 3}
   userData: 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -200,8 +200,9 @@ namespace Cinemachine.PostFX
                                 if (focusTarget != null)
                                     focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
                             }
-                            dof.focusDistance.value = Mathf.Max(0, focusDistance);
-                            
+                            focusDistance = Mathf.Max(0, focusDistance);
+                            dof.focusDistance.value = focusDistance;
+                            state.Lens.FocusDistance = focusDistance;                            
                             profile.isDirty = true;
                         }
                     }

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -202,7 +202,9 @@ namespace Cinemachine.PostFX
                             }
                             focusDistance = Mathf.Max(0, focusDistance);
                             dof.focusDistance.value = focusDistance;
-                            state.Lens.FocusDistance = focusDistance;                            
+#if CINEMACHINE_HDRP_7_3_1
+                            state.Lens.FocusDistance = focusDistance;
+#endif
                             profile.isDirty = true;
                         }
                     }

--- a/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.compute
+++ b/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.compute
@@ -1,0 +1,124 @@
+﻿#pragma kernel CSMain
+
+#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+
+// 16 samples, won't handle a different number
+static const uint kSampleCount = 16;
+static const float2 kDiskKernel[kSampleCount] = {
+    float2(0,0),
+    float2(0.54545456,0),
+    float2(0.16855472,0.5187581),
+    float2(-0.44128203,0.3206101),
+    float2(-0.44128197,-0.3206102),
+    float2(0.1685548,-0.5187581),
+    float2(1,0),
+    float2(0.809017,0.58778524),
+    float2(0.30901697,0.95105654),
+    float2(-0.30901703,0.9510565),
+    float2(-0.80901706,0.5877852),
+    float2(-1,0),
+    float2(-0.80901694,-0.58778536),
+    float2(-0.30901664,-0.9510566),
+    float2(0.30901712,-0.9510565),
+    float2(0.80901694,-0.5877853),
+};
+// Kernel above taken from PostProcessing/Shaders/Builtins/DiskKernels.hlsl
+
+struct FocusDistanceParams
+{
+	uint VoteBias;			// 0...15
+	float DepthTolerance;	// 0.02
+	float SampleRadius;		// 0.02
+	float SamplePosX;		// 0
+	float SamplePosY;		// 0
+	float DefaultFocusDistance;	// current focus distance
+};
+
+struct FocusDistanceOutput
+{
+	float FocusDistance;
+};
+
+RWStructuredBuffer<FocusDistanceParams> _FocusDistanceParams;// : register(u2);
+RWStructuredBuffer<FocusDistanceOutput> _FocusDistanceOutput;// : register(u3);
+
+[numthreads(1,1,1)]
+void CSMain(uint3 id : SV_DispatchThreadID)
+{
+	// Settings
+	FocusDistanceParams params = _FocusDistanceParams[0];
+
+	float sampleKernelSize = params.SampleRadius;
+	float depthTolerance = params.DepthTolerance;
+	uint voteBias = params.VoteBias;
+	float2 kernelPos = float2(params.SamplePosX, params.SamplePosY);
+
+	// Buckets
+	float depths[kSampleCount] = { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1 };
+	uint votes[kSampleCount] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+	// Init the first bucket with the current target depth
+	// Even though it might actually not be hit by any sample, and
+	// in a rare case cause the last sample to not get a bucket.
+	// No votes for now.
+	depths[0] = params.DefaultFocusDistance;
+
+	uint mostVotes = 0;
+	uint biggestBucket = 0;
+	for (uint i = 0; i < kSampleCount; i++)
+	{
+		float2 offset = kernelPos + kDiskKernel[i] * sampleKernelSize + float2(0.5, 0.5);
+		float depth = LOAD_TEXTURE2D_X_LOD(_CameraDepthTexture, int2(offset.xy * _ScreenSize.xy), 0).r;
+
+		// Convert to distance units
+		depth = LinearEyeDepth(depth, _ZBufferParams);
+
+		// TODO: Any depth that would result in effective focus at infinity should be
+		// clamped here into one value. Otherwise we're unnecesarily spreading them over buckets
+		// and decreasing their voting power. Need to figure out what that focus distance is from DoF params.
+		// depth = min(_FocusDistanceToInfinity, depth);
+		// Alternatively: bucket based on raw depth and only convert the output to linear.
+
+		// Find an empty bucket or add to a bucket that's close enough
+		for (uint j = 0; j < kSampleCount; j++)
+		{
+			float bucket = depths[j];
+
+			// New bucket, claim it
+			if (bucket < 0)
+			{
+				depths[j] = depth;
+				votes[j] += 1;
+				if (votes[j] > mostVotes)
+				{
+					mostVotes = votes[j];
+					biggestBucket = j;
+				}
+				break;
+			}
+
+			// Belongs to this bucket, upvote
+			if (abs(bucket - depth) <= depthTolerance)
+			{
+				votes[j] += 1;
+				if (votes[j] > mostVotes)
+				{
+					mostVotes = votes[j];
+					biggestBucket = j;
+				}
+				break;
+			}
+		}
+	}
+
+	// If the bucket with the most votes got considerably more votes (i.e. more by voteBias) than
+	// the current target focus distance, set it as the new target focus distance.
+	// Clamp the vote bias to the most votes value - if the buckets are too small, we can't be too sticky.
+	float targetFocusDistance = params.DefaultFocusDistance;
+	voteBias = min(mostVotes - 1, voteBias);
+	if (mostVotes > votes[0] + voteBias)
+		targetFocusDistance = depths[biggestBucket];
+
+	_FocusDistanceOutput[0].FocusDistance = targetFocusDistance;
+}

--- a/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.compute.meta
+++ b/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70bb111e26536f54da7584ae418a9ed8
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 8196
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs
@@ -40,8 +40,11 @@ namespace Cinemachine.PostFX
         [Tooltip("If true, then the focus distance will be pushed to the camera's focusDistance field.")]
         public bool PushToCamera = true;
 
+        /// <summary>Initialize this with the current focus distance, to be used as a default value</summary>
+        public float CurrentFocusDistance;
+
         /// <summary>This holds the computed output.  Clients can read it as desired</summary>
-        public float ComputedFocusDistance;
+        public float ComputedFocusDistance { get; private set; }
 
         // Same As FocusDistance.compute
         struct FocusDistanceParams
@@ -99,7 +102,8 @@ namespace Cinemachine.PostFX
             m_FocusDistanceParams[0].SampleRadius = KernelRadius;
             m_FocusDistanceParams[0].SamplePosX = ScreenPosition.x;
             m_FocusDistanceParams[0].SamplePosY = ScreenPosition.y;
-            m_FocusDistanceParams[0].DefaultFocusDistance = ComputedFocusDistance;
+            m_FocusDistanceParams[0].DefaultFocusDistance 
+                = (PushToCamera || CurrentFocusDistance <= 0) ? Camera.focusDistance : CurrentFocusDistance;
 
             m_FocusDistanceParamsCB.SetData(m_FocusDistanceParams);
             ctx.cmd.SetComputeBufferParam(ComputeShader, 0, Uniforms._FocusDistanceParams, m_FocusDistanceParamsCB);

--- a/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs
@@ -1,0 +1,116 @@
+#if CINEMACHINE_HDRP
+using UnityEngine;
+using UnityEngine.Rendering.HighDefinition;
+using UnityEngine.Rendering;
+
+namespace Cinemachine.PostFX
+{
+    internal class FocusDistance : CustomPass
+    {
+        static class Uniforms
+        {
+            internal const string _FocusDistanceParams = "_FocusDistanceParams";
+            internal const string _FocusDistanceOutput = "_FocusDistanceOutput";
+            internal const string FocusDistanceKeyword = "FOCUS_DISTANCE";
+        }
+
+        [Tooltip("Stickier auto focus is more stable (less switching back and forth as tiny "
+            + "grass blades cross the camera), but requires looking at a bigger uniform-ish area to switch focus to it.")]
+        [Range(0, 1)]
+        public float Stickiness = 0.4f;
+
+        [Range(0, 1)]
+        public float KernelRadius = 0.02f;
+
+        [Range(0, 1)]
+        public float DepthTolerance = 0.02f;
+
+        public Vector2 ScreenPosition;
+
+        public ComputeShader m_ComputeShader;
+        public Camera m_Camera;
+        public bool PushToCamera = true;
+
+        public float ComputedFocusDistance;
+
+
+        // Same As FocusDistance.compute
+        struct FocusDistanceParams
+        {
+            public uint  VoteBias;		    // 0...15
+            public float DepthTolerance;	// 0.02
+            public float SampleRadius;		// 0.02
+            public float SamplePosX;		// 0
+            public float SamplePosY;		// 0
+            public float DefaultFocusDistance; // current focus distance
+        };
+        ComputeBuffer m_FocusDistanceParamsCB;
+        FocusDistanceParams[] m_FocusDistanceParams = new FocusDistanceParams[1];
+
+        // Same As FocusDistance.compute
+        struct FocusDistanceOutput
+        {
+            public float FocusDistance;
+        }
+        ComputeBuffer m_FocusDistanceOutputCB;
+        FocusDistanceOutput[] m_FocusDistanceOutput = new FocusDistanceOutput[1];
+
+        // It can be used to configure render targets and their clear state. Also to create temporary render target textures.
+        // When empty this render pass will render to the active camera render target.
+        // You should never call CommandBuffer.SetRenderTarget. Instead call <c>ConfigureTarget</c> and <c>ConfigureClear</c>.
+        // The render pipeline will ensure target setup and clearing happens in an performance manner.
+        protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd)
+        {
+            if (m_FocusDistanceParamsCB == null)
+                m_FocusDistanceParamsCB = new ComputeBuffer(1, 6 * 4); // sizeof(FocusDistanceParams)
+            if (m_FocusDistanceOutputCB == null)
+                m_FocusDistanceOutputCB = new ComputeBuffer(1, 1 * 4); // sizeof(FocusDistanceOutput)
+        }
+
+        protected override void Cleanup()
+        {
+            if (m_FocusDistanceParamsCB != null)
+                m_FocusDistanceParamsCB.Release();
+            m_FocusDistanceParamsCB = null;
+            if (m_FocusDistanceOutputCB != null)
+                m_FocusDistanceOutputCB.Release();
+            m_FocusDistanceOutputCB = null;
+        }
+
+        protected override void Execute(CustomPassContext ctx)
+        {
+            if (m_Camera == null || m_ComputeShader == null || ctx.hdCamera.camera != m_Camera)
+                return;
+
+            ctx.cmd.BeginSample(Uniforms.FocusDistanceKeyword);
+            ctx.cmd.EnableShaderKeyword(Uniforms.FocusDistanceKeyword);
+
+            m_FocusDistanceParams[0].VoteBias = (uint)Mathf.RoundToInt(Stickiness * 15.0f);
+            m_FocusDistanceParams[0].DepthTolerance = DepthTolerance;
+            m_FocusDistanceParams[0].SampleRadius = KernelRadius;
+            m_FocusDistanceParams[0].SamplePosX = ScreenPosition.x;
+            m_FocusDistanceParams[0].SamplePosY = ScreenPosition.y;
+            m_FocusDistanceParams[0].DefaultFocusDistance = ComputedFocusDistance;
+
+            m_FocusDistanceParamsCB.SetData(m_FocusDistanceParams);
+            ctx.cmd.SetComputeBufferParam(m_ComputeShader, 0, Uniforms._FocusDistanceParams, m_FocusDistanceParamsCB);
+            ctx.cmd.SetComputeBufferParam(m_ComputeShader, 0, Uniforms._FocusDistanceOutput, m_FocusDistanceOutputCB);
+            ctx.cmd.DispatchCompute(m_ComputeShader, 0, 1, 1, 1);
+            ctx.cmd.SetGlobalBuffer(Uniforms._FocusDistanceOutput, m_FocusDistanceOutputCB);
+            ctx.cmd.EndSample(Uniforms.FocusDistanceKeyword);
+
+            // Read back the output when complete
+            ctx.cmd.RequestAsyncReadback(m_FocusDistanceOutputCB, (req) =>
+            {
+                if (m_FocusDistanceOutputCB != null && m_Camera != null)
+                {
+                    m_FocusDistanceOutputCB.GetData(m_FocusDistanceOutput);
+                    ComputedFocusDistance = m_FocusDistanceOutput[0].FocusDistance;
+                    if (PushToCamera)
+                        m_Camera.focusDistance = ComputedFocusDistance;
+                }
+            });
+        }
+    }
+}
+#endif

--- a/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs.meta
+++ b/com.unity.cinemachine/Runtime/PostProcessing/FocusDistance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8975705260499d4fbdb579697c171f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1000: AutoFocus extension and move focusDistance to camera (HDRP-only)
- Added FocusDistance setting to lens
- New AutoFocus extension.  Use instead of VolumeSettings for Focus Tracking.  Includes Automatic mode that queries depth buffer instead of tracking a specific target.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Low

### Comments to reviewers

HDRP is required for this.
Should test also with non-HDRP to make sure nothing has broken.

Implementation of Automatic focus is a little tricky: it requires a Custom Pass in rendering that runs a compute shader.  This pass is installed in a dynamically-created DontSave component on the main camera, and is enabled/disabled according to how many live vcams need it.  We want to disable it as much as possible because it impacts performance.

