### PR TITLE
CMCL-1003: Sensor size does not affect source control when not using physical camera

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Freelook had wrong heading at first frame, which could cause a slight jitter.
 - Bugfix: FramingTransposer and Composer had a slight rounding error in their Bias fields when the Screen X and Y fields were modified. 
 - Bugfix: Fixed spurious Z rotations during speherical blend.
+- Bugfix: SensorSize is not saved when not using physical camera.
 
 
 ## [2.9.0-pre.7] - 2022-03-29

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -20,7 +20,7 @@ namespace Cinemachine
     [ExcludeFromPreset]
     [AddComponentMenu("Cinemachine/CinemachineFreeLook")]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineFreeLook.html")]
-    public class CinemachineFreeLook : CinemachineVirtualCameraBase
+    public class CinemachineFreeLook : CinemachineVirtualCameraBase, ISerializationCallbackReceiver
     {
         /// <summary>Object for the camera children to look at (the aim target)</summary>
         [Tooltip("Object for the camera children to look at (the aim target).")]
@@ -880,5 +880,13 @@ namespace Cinemachine
                 m_CachedTension = m_SplineCurvature;
             }
         }
+
+        public void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.one;
+        }
+
+        public void OnAfterDeserialize() {}
     }
 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -56,7 +56,7 @@ namespace Cinemachine
     [ExcludeFromPreset]
     [AddComponentMenu("Cinemachine/CinemachineVirtualCamera")]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineVirtualCamera.html")]
-    public class CinemachineVirtualCamera : CinemachineVirtualCameraBase
+    public class CinemachineVirtualCamera : CinemachineVirtualCameraBase, ISerializationCallbackReceiver
     {
         /// <summary>The object that the camera wants to look at (the Aim target).
         /// The Aim component of the CinemachineComponent pipeline
@@ -622,5 +622,13 @@ namespace Cinemachine
                 return true;
             return m_ComponentPipeline != null && m_ComponentPipeline.Any(c => c != null && c.RequiresUserInput);
         }
+
+        public void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.zero;
+        }
+
+        public void OnAfterDeserialize() {}
     }
 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -626,7 +626,7 @@ namespace Cinemachine
         public void OnBeforeSerialize()
         {
             if (!m_Lens.IsPhysicalCamera) 
-                m_Lens.SensorSize = Vector2.zero;
+                m_Lens.SensorSize = Vector2.one;
         }
 
         public void OnAfterDeserialize() {}

--- a/com.unity.cinemachine/Runtime/Experimental/CinemachineNewFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Experimental/CinemachineNewFreeLook.cs
@@ -58,7 +58,7 @@ namespace Cinemachine
 
         /// <summary>Override settings for top and bottom rigs</summary>
         [Serializable]
-        public class Rig
+        public class Rig : ISerializationCallbackReceiver
         {
             public bool m_CustomLens;
             public LensSettings m_Lens;
@@ -204,6 +204,14 @@ namespace Cinemachine
                     p.m_FrequencyGain = m_FrequencyGain;
                 }
             }
+
+            public void OnBeforeSerialize()
+            {
+                if (!m_Lens.IsPhysicalCamera) 
+                    m_Lens.SensorSize = Vector2.one;
+            }
+
+            public void OnAfterDeserialize() {}
         }
 
         [SerializeField]

--- a/com.unity.cinemachine/Runtime/Experimental/CinemachineNewVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Experimental/CinemachineNewVirtualCamera.cs
@@ -16,7 +16,7 @@ namespace Cinemachine
     [DisallowMultipleComponent]
     [ExecuteAlways]
     [AddComponentMenu("Cinemachine/CinemachineNewVirtualCamera")]
-    public class CinemachineNewVirtualCamera : CinemachineVirtualCameraBase
+    public class CinemachineNewVirtualCamera : CinemachineVirtualCameraBase, ISerializationCallbackReceiver
     {
         /// <summary>Object for the camera children to look at (the aim target)</summary>
         [Tooltip("Object for the camera children to look at (the aim target).")]
@@ -439,6 +439,14 @@ namespace Cinemachine
                 }
             }
         }
+
+        public void OnBeforeSerialize()
+        {
+            if (!m_Lens.IsPhysicalCamera) 
+                m_Lens.SensorSize = Vector2.one;
+        }
+
+        public void OnAfterDeserialize() {}
     }
 }
 #endif


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-1003

- When not physical camera, sensor size is 0,0. We achieve with before serialize callback.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version