### PR TITLE
CMCL-270: Added Lens Mode Override enable/disable to Brain, with default mode

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add flag for custom priority setting.
 - HDRP only: Added FocusDistance setting to lens
 - HDRP only: New AutoFocus extension.  Use instead of VolumeSettings for Focus Tracking.  Includes Automatic mode that queries depth buffer instead of tracking a specific target.
+- Added Lens Mode Override property to CM Brain.  When enabled, it allows CM cameras to override the lens mode (Perspective vs Ortho vs Physical).
 
 
 ## UNRELEASED

--- a/com.unity.cinemachine/Documentation~/CinemachineBrainProperties.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineBrainProperties.md
@@ -36,6 +36,12 @@ Cinemachine Brain holds the following key properties:
 | __Blend Update Method__ || When to resolve the blends and update the main camera.  |
 | | _Late Update_ | In MonoBehaviour LateUpdate. This is the recommended setting. |
 | | _Fixed Update_ | Use this setting only if your Update Method is FixedUpdate and you see judder when blending. |
+| __Lens Mode Override__ || When enabled, CM camras are permitted to override the camera's lens mode (Perspective vs Orthographic vs Physical).  |
+| __Default Mode__ || When Lens Mode Override is enabled and there is no CM camera actively overriding the lens mode, this lens mode will be pushed to the camera. |
+| | _None_ | If Lens Override Mode is enabled and Default Mode is set to _None_, there will be no default mode pushed to the Camera when the CM camera is not overriding the lens mode.  This setting is not recommended, because it can produce unpredictable results.  It's always best to have a default mode. |
+| | _Orthographic_ | Sets the __Projection__ property to __Orthographic__. |
+| | _Perspective_ | Sets the __Projection__ property to __Perspective__ and *disables* the __Physical Camera__ feature and properties. |
+| | _Physical_ | Sets the __Projection__ property to __Perspective__ and *enables* the __Physical Camera__ feature and properties. |
 | __Default Blend__ || The blend to use when you haven’t explicitly defined a blend between two Virtual Cameras. |
 | | _Cut_ | Zero-length blend. |
 | | _Ease In Out_ | S-shaped curve, giving a gentle and smooth transition. |

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -160,6 +160,24 @@ namespace Cinemachine
             + "the brain's transform is updated")]
         public BrainUpdateMethod m_BlendUpdateMethod = BrainUpdateMethod.LateUpdate;
 
+        /// <summary>Defines the settings for Lens Mode overriding</summary>
+        [Serializable] 
+        public struct LensModeOverrideSettings
+        {
+            /// <summary>If set, will enable CM cameras to override the lens mode of the camera</summary>
+            [Tooltip("If set, will enable CM cameras to override the lens mode of the camera")]
+            public bool Enabled;
+
+            /// <summary>Lens mode to use when no mode override is active</summary>
+            [Tooltip("Lens mode to use when no mode override is active")]
+            public LensSettings.OverrideModes DefaultMode;
+        }
+
+        /// <summary>Controls whether CM cameras can change the lens mode.</summary>
+        [FoldoutWithEnabledButton]
+        public LensModeOverrideSettings LensModeOverride 
+            = new LensModeOverrideSettings { DefaultMode = LensSettings.OverrideModes.Perspective };
+
         /// <summary>
         /// The blend which is used if you don't explicitly define a blend between two Virtual Cameras.
         /// </summary>
@@ -962,12 +980,25 @@ namespace Cinemachine
                     cam.farClipPlane = state.Lens.FarClipPlane;
                     cam.orthographicSize = state.Lens.OrthographicSize;
                     cam.fieldOfView = state.Lens.FieldOfView;
-                    cam.lensShift = state.Lens.LensShift;
-                    if (state.Lens.ModeOverride != LensSettings.OverrideModes.None)
-                        cam.orthographic = state.Lens.Orthographic;
-                    bool isPhysical = state.Lens.ModeOverride == LensSettings.OverrideModes.None 
-                        ? cam.usePhysicalProperties : state.Lens.IsPhysicalCamera;
-                    cam.usePhysicalProperties = isPhysical;
+
+                    bool isPhysical = cam.usePhysicalProperties;
+
+                    if (LensModeOverride.Enabled)
+                    {
+                        if (state.Lens.ModeOverride != LensSettings.OverrideModes.None)
+                        {
+                            isPhysical = state.Lens.IsPhysicalCamera;
+                            cam.orthographic = state.Lens.ModeOverride == LensSettings.OverrideModes.Orthographic;
+                        }
+                        else if (LensModeOverride.DefaultMode != LensSettings.OverrideModes.None)
+                        {
+                            isPhysical = LensModeOverride.DefaultMode == LensSettings.OverrideModes.Physical;
+                            cam.orthographic = LensModeOverride.DefaultMode == LensSettings.OverrideModes.Orthographic;
+                        }
+                        cam.usePhysicalProperties = isPhysical;
+                        cam.lensShift = state.Lens.LensShift;
+                    }
+
                     if (isPhysical)
                     {
                         cam.sensorSize = state.Lens.SensorSize;


### PR DESCRIPTION
### Purpose of this PR

CMCL-270: Lens mode override is confusing

Problem: when a vcam implements a lens mode override, it changes the main camera lens, so that subsequent vcams without a mode override will use the prior overridden mode, so the lens a vcam gets will depend on vcam activation order.  That's bad.

The PR adds a default lens mode to the CM brain, so that vcams without a mode override will get that default lens. 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
