### PR TITLE
CMCL-1004: test upgrader on Gigaya 

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -263,11 +263,7 @@ namespace Cinemachine.Editor
             {
                 foreach (var go in gameobjects)
                 {
-                    if (go == null)
-                    {
-                        continue; ;
-                    }
-                    if (go.name.Equals(name))
+                    if (go != null && go.name.Equals(name))
                         return go;
                 }
                 return null;
@@ -325,10 +321,10 @@ namespace Cinemachine.Editor
             }
         }
         
-        static List<string> s_IgnoreListGigaya = new() {}; // TODO: expose this to the user
 
         class SceneManager
         {
+            public List<string> s_IgnoreList = new() {}; // TODO: expose this to the user
             public int SceneCount { get; private set; }
             public string GetScenePath(int index) => m_AllScenePaths[index];
 
@@ -346,7 +342,7 @@ namespace Cinemachine.Editor
                     var sceneGuid = allSceneGuids[i];
                     var scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
                     var add = true;
-                    foreach (var ignore in s_IgnoreListGigaya)
+                    foreach (var ignore in s_IgnoreList)
                     {
                         if (scenePath.Contains(ignore))
                         {

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -113,6 +113,7 @@ namespace Cinemachine.Editor
                 var sceneCount = m_SceneManager.sceneCount;
                 for (var s = 0; s < sceneCount; ++s)
                 {
+                    Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                     
                     var allPrefabInstances = 
@@ -178,6 +179,7 @@ namespace Cinemachine.Editor
                 // from the linked converted copy of the prefab instance.
                 for (int s = 0; s < sceneCount; ++s)
                 {
+                    Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                     
                     foreach (var conversionLink in conversionLinks)
@@ -253,6 +255,7 @@ namespace Cinemachine.Editor
             var sceneCount = m_SceneManager.sceneCount;
             for (var s = 0; s < sceneCount; ++s)
             {
+                Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
                 var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                 
                 var timelineManager = new TimelineManager(activeScene);

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -88,7 +88,7 @@ namespace Cinemachine.Editor
                 "I made a backup, go ahead", "Cancel"))
             {
                 UpgradePrefabs();
-                // UpgradeInScenes();
+                UpgradeInScenes();
             }
         }
 
@@ -350,12 +350,12 @@ namespace Cinemachine.Editor
                 {
                     var sceneGuid = allSceneGuids[i];
                     var scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
-                    bool add = false;
+                    var add = true;
                     foreach (var ignore in s_IgnoreListGigaya)
                     {
-                        if (scenePath.Contains("Movement_Gym"))
+                        if (scenePath.Contains(ignore))
                         {
-                            add = true;
+                            add = false;
                             break;
                         }
                     }

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -113,7 +113,9 @@ namespace Cinemachine.Editor
                 var sceneCount = m_SceneManager.SceneCount;
                 for (var s = 0; s < sceneCount; ++s)
                 {
+#if DEBUG_HELPERS
                     Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
+#endif
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                     
                     var allPrefabInstances = 
@@ -179,7 +181,9 @@ namespace Cinemachine.Editor
                 // from the linked converted copy of the prefab instance.
                 for (int s = 0; s < sceneCount; ++s)
                 {
+#if DEBUG_HELPERS
                     Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
+#endif
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                     var allGameObjectsInScene = GetAllGameObjects();
                     foreach (var conversionLink in conversionLinks)
@@ -275,7 +279,9 @@ namespace Cinemachine.Editor
             var sceneCount = m_SceneManager.SceneCount;
             for (var s = 0; s < sceneCount; ++s)
             {
+#if DEBUG_HELPERS
                 Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
+#endif
                 var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
                 
                 var timelineManager = new TimelineManager(activeScene);
@@ -319,29 +325,7 @@ namespace Cinemachine.Editor
             }
         }
         
-        static List<string> s_IgnoreListGigaya = new()
-        { 
-            "Characters_Zoo.unity", 
-            "VFXSample.unity", 
-            "Scene_CharacterGym_Interactables.unity", 
-            "Scene_Dev_Character_RigAndFace.unity",
-            "Scene_Dev_DesignTestGameplayOverlayMap.unity",
-            "Scene_Dev_Glyphs.unity",
-            "Scene_Diorama.unity",
-            "Scene_Material_And_Polish.unity",
-            "Scene_02_OasisClimbIntoGigaya_Geo.unity",
-            "Scene_02_OasisClimbIntoGigaya_Mechanics.unity",
-            "Scene_Menu_Main.unity",
-            "QA_TestScene.unity",
-            "Scene_InnerHand_Geo.unity",
-            "Scene_InnerHand_Mechanics.unity",
-            "Scene_Oasis_Geo_Bckp.unity",
-            "SampleScene.unity",
-            "VFX_TestScene_v02.unity",
-            "StartingArea_Geo.unity",
-            "Logic.unity",
-            "Lighting.unity"
-        };
+        static List<string> s_IgnoreListGigaya = new() {}; // TODO: expose this to the user
 
         class SceneManager
         {
@@ -879,19 +863,6 @@ namespace Cinemachine.Editor
                 var prefabGuids = AssetDatabase.FindAssets($"t:prefab", new [] { "Assets" });
                 var allPrefabs = prefabGuids.Select(
                     g => AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(g))).ToList();
-                for (var i = allPrefabs.Count - 1; i >= 0; i--)
-                {
-                    var prefab = allPrefabs[i];
-                    var assetPath = AssetDatabase.GetAssetPath(prefab);
-                    foreach (var ignore in s_IgnoreListGigaya)
-                    {
-                        if (assetPath.Contains("DesignPrefabs/ActionCamerasAndTriggers"))
-                        {
-                            allPrefabs.RemoveAt(i);
-                            break;
-                        }
-                    }
-                }
 
                 // Select Prefab Assets containing CinemachineVirtualCameras or CinemachineFreeLooks.
                 m_PrefabAssets = new List<GameObject>();

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -193,6 +193,10 @@ namespace Cinemachine.Editor
                         if (prefabInstance == null || convertedCopy == null)
                             continue; // ignore, instance is not in this scene
                         
+                        // copy cm camera related properties (such as targets and lens)
+                        UnityEditorInternal.ComponentUtility.CopyComponent(convertedCopy.GetComponent<CmCamera>());
+                        UnityEditorInternal.ComponentUtility.PasteComponentValues(prefabInstance.GetComponent<CmCamera>());
+                        
                         var prefabInstanceComponents = 
                             prefabInstance.GetComponents<CinemachineComponentBase>();
                         var convertedComponents = 

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -181,7 +181,6 @@ namespace Cinemachine.Editor
                 {
                     Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
-
                     var allGameObjectsInScene = GetAllGameObjects();
                     foreach (var conversionLink in conversionLinks)
                     {
@@ -255,8 +254,20 @@ namespace Cinemachine.Editor
                 return all.Where(go => !EditorUtility.IsPersistent(go.transform.root.gameObject) && 
                     !(go.hideFlags == HideFlags.NotEditable || go.hideFlags == HideFlags.HideAndDontSave)).ToList();
             }
-            static GameObject Find(string name, List<GameObject> gameobjects) => 
-                gameobjects.FirstOrDefault(go => go.name.Equals(name));
+
+            static GameObject Find(string name, List<GameObject> gameobjects)
+            {
+                foreach (var go in gameobjects)
+                {
+                    if (go == null)
+                    {
+                        continue; ;
+                    }
+                    if (go.name.Equals(name))
+                        return go;
+                }
+                return null;
+            }
         }
 
         void UpgradeInScenes()

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -181,13 +181,12 @@ namespace Cinemachine.Editor
                 {
                     Debug.Log("Opening scene: " + m_SceneManager.GetScenePath(s));
                     var activeScene = EditorSceneManager.OpenScene(m_SceneManager.GetScenePath(s), OpenSceneMode.Single);
-                    
+
+                    var allGameObjectsInScene = GetAllGameObjects();
                     foreach (var conversionLink in conversionLinks)
                     {
-                        var prefabInstance = 
-                            GameObject.Find(conversionLink.originalGUIDName);
-                        var convertedCopy = 
-                            GameObject.Find(conversionLink.convertedGUIDName);
+                        var prefabInstance = Find(conversionLink.originalGUIDName, allGameObjectsInScene);
+                        var convertedCopy = Find(conversionLink.convertedGUIDName, allGameObjectsInScene);
                         if (prefabInstance == null || convertedCopy == null)
                             continue; // ignore, instance is not in this scene
                         
@@ -248,8 +247,18 @@ namespace Cinemachine.Editor
                     EditorSceneManager.SaveScene(activeScene);
                 }
             }
+            
+            // local functions
+            List<GameObject> GetAllGameObjects()
+            {
+                var all = (GameObject[])Resources.FindObjectsOfTypeAll(typeof(GameObject));
+                return all.Where(go => !EditorUtility.IsPersistent(go.transform.root.gameObject) && 
+                    !(go.hideFlags == HideFlags.NotEditable || go.hideFlags == HideFlags.HideAndDontSave)).ToList();
+            }
+            static GameObject Find(string name, List<GameObject> gameobjects) => 
+                gameobjects.FirstOrDefault(go => go.name.Equals(name));
         }
-        
+
         void UpgradeInScenes()
         {
             var sceneCount = m_SceneManager.SceneCount;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -28,7 +28,7 @@ namespace Cinemachine
             // This must run during the Body stage because CinemachineConfiner also runs during Body stage,
             // and CinemachinePixelPerfect needs to run before CinemachineConfiner as the confiner reads the
             // orthographic size. We also altered the script execution order to ensure this.
-            if (stage != CinemachineCore.Stage.Body)
+            if (stage != CinemachineCore.Stage.PositionControl)
                 return;
 
             var brain = CinemachineCore.Instance.FindPotentialTargetBrain(vcam);


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-1004

Code clean up, and
Bug fixes/features found by upgrading Gigaya project:
- Disabled components and gameobjects were not found in all cases.
- Prefabs are only searched for inside the Assets folder.
- Option for user to add scenes to ignore - this will come handy in UI. Scenes with corrupted prefab instances (e.g. prefab instance with a missing prefab source,  prefab instance with a missing script...) cannot be opened, and thus cannot be upgraded.

TODO:
- Gracefully handle scenes, prefabs and prefabs instances that are corrupted (e.g. missing scripts). For example, in the initialization phase, when caching scenes and prefab sources, list corrupted data for the user telling upgrader can't proceed until they are done.


### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 