### PR TITLE
Reduce amount of redundant calls to RepaintAllViews

### DIFF
--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -178,6 +178,8 @@ namespace Cinemachine.Editor
         {
             return ObjectFactory.CreateGameObject(name, types);
         }
+        
+        private static int m_lastRepaintFrame;
 
         /// <summary>
         /// Force a repaint of the Game View
@@ -185,6 +187,10 @@ namespace Cinemachine.Editor
         /// <param name="unused">Like it says</param>
         public static void RepaintGameView(UnityEngine.Object unused = null)
         {
+            if (m_lastRepaintFrame == Time.frameCount)
+                return;
+            m_lastRepaintFrame = Time.frameCount;
+
             EditorApplication.QueuePlayerLoopUpdate();
             UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
         }


### PR DESCRIPTION
Quick fix for laggy editor described here: https://github.com/Unity-Technologies/com.unity.cinemachine/issues/486

[Delete any line or section that does not apply]

### Purpose of this PR

[JIRA issue. Desc of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more.]

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
