### PR TITLE
CMCL-0000: added changelog for redundant view repaints

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added Lens Mode Override property to CM Brain.  When enabled, it allows CM cameras to override the lens mode (Perspective vs Ortho vs Physical).
 - Added Unity Spline support.  Old Cinemachine Paths are deprecated in favour of Unity Splines.
 - Added customizable Auto Dolly to cameras and Spline Cart.
+- Bugfix: No redundant RepaintAllViews calls.
 
 
 ## UNRELEASED


### PR DESCRIPTION
Missing changelog added for https://github.com/Unity-Technologies/com.unity.cinemachine/pull/487