### PR TITLE
CMCL-0000: Remove advanced foldout from lens

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -57,7 +57,6 @@ namespace Cinemachine.Editor
         }
 
         static bool s_PhysicalExapnded;
-        static bool s_AdvancedLensExpanded;
 
         static List<string> m_PresetOptions;
         static List<string> m_PhysicalPresetOptions;
@@ -159,16 +158,10 @@ namespace Cinemachine.Editor
 #endif
 
             var modeOverrideProperty = property.FindPropertyRelative("ModeOverride");
-            var advanced = foldout.AddChild(new Foldout() { text = "Advanced", value = s_AdvancedLensExpanded });
-            advanced.RegisterValueChangedCallback((evt) => 
-            {
-                s_AdvancedLensExpanded = evt.newValue;
-                evt.StopPropagation();
-            });
-            var modeHelp = advanced.AddChild(
+            var modeHelp = foldout.AddChild(
                 new HelpBox("Lens Mode Override must be enabled in the CM Brain for Mode Override to take effect", 
-                    HelpBoxMessageType.Info));
-            advanced.Add(new PropertyField(modeOverrideProperty));
+                    HelpBoxMessageType.Warning));
+            foldout.Add(new PropertyField(modeOverrideProperty));
 
             // GML: This is rather evil.  Is there a better (event-driven) way?
             DoUpdate();
@@ -182,7 +175,11 @@ namespace Cinemachine.Editor
                 //physicalNote.SetVisible(modeOverrideProperty.intValue == (int)LensSettings.OverrideModes.None);
                 fovControl.Update(true);
                 fovControl2.Update(false);
-                modeHelp.SetVisible(s_AdvancedLensExpanded && modeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None);
+
+                var brainHasModeOverride = CinemachineCore.Instance.BrainCount > 0 
+                    && CinemachineCore.Instance.GetActiveBrain(0).LensModeOverride.Enabled;
+                modeHelp.SetVisible(!brainHasModeOverride
+                    && modeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None);
             }
 
             return ux;
@@ -521,6 +518,8 @@ namespace Cinemachine.Editor
         static readonly GUIContent PhysicalPropertiesLabel = new GUIContent("Physical Properties", "Physical properties of the lens");
         static readonly GUIContent AdvancedLabel = new GUIContent("Advanced");
         static readonly string AdvancedHelpboxMessage = "Lens Mode Override must be enabled in the CM Brain for Mode Override to take effect";
+
+        static bool s_AdvancedLensExpanded;
 
         struct Snapshot
         {

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
@@ -388,11 +388,8 @@ namespace Cinemachine.Editor
                 {
                     freeLookModifier.Modifiers.Add(new CinemachineFreeLookModifier.LensModifier
                     {
-                        Lens = new CinemachineFreeLookModifier.TopBottomRigs<LensSettings>
-                        {
-                            Top = freelook.GetRig(0).m_Lens,
-                            Bottom = freelook.GetRig(2).m_Lens,
-                        }
+                        Top = freelook.GetRig(0).m_Lens,
+                        Bottom = freelook.GetRig(2).m_Lens
                     });
                 }
             }

--- a/com.unity.cinemachine/Editor/Utility/SerializedPropertyHelper.cs
+++ b/com.unity.cinemachine/Editor/Utility/SerializedPropertyHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Cinemachine.Utility;
 using UnityEditor;
 
 namespace Cinemachine.Editor
@@ -63,10 +64,18 @@ namespace Cinemachine.Editor
         public static object GetPropertyValue(SerializedProperty property)
         {
             var targetObject = property.serializedObject.targetObject;
-            var targetObjectClassType = targetObject.GetType();
-            var field = targetObjectClassType.GetField(property.propertyPath);
+            var field = targetObject.GetType().GetField(property.propertyPath);
             if (field != null)
                 return field.GetValue(targetObject);
+
+            var paths = property.propertyPath.Split('.');
+            if (paths.Length > 1)
+            {
+                var fieldOwner = ReflectionHelpers.GetParentObject(property.propertyPath, targetObject);
+                field = fieldOwner.GetType().GetField(paths[paths.Length-1]);
+                if (field != null)
+                    return field.GetValue(fieldOwner);
+            }
             return null;
         }
     }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
@@ -194,22 +194,30 @@ public class CinemachineFreeLookModifier : CinemachineExtension
     public class LensModifier : Modifier
     {
         /// <summary>Values for the top and bottom rigs</summary>
-        [HideFoldout]
-        public TopBottomRigs<LensSettings> Lens;
+        /// <summary>Settings for top orbit</summary>
+        [Tooltip("Value to take at the top of the axis range")]
+        [LensSettingsHideModeOverrideProperty]
+        public LensSettings Top;
 
+        /// <summary>Settings for bottom orbit</summary>
+        [Tooltip("Value to take at the bottom of the axis range")]
+        [LensSettingsHideModeOverrideProperty]
+        public LensSettings Bottom;
+        
         /// <summary>Called from OnValidate to calidate this component</summary>
         /// <param name="vcam">the virtual camera owner</param>
         public override void Validate(CinemachineVirtualCameraBase vcam) 
         {
-            Lens.Top.Validate();
-            Lens.Bottom.Validate();
+            Top.Validate();
+            Bottom.Validate();
         }
 
         /// <summary>Called when the modifier is created.  Initialize fields with appropriate values.</summary>
         /// <param name="vcam">the virtual camera owner</param>
         public override void Reset(CinemachineVirtualCameraBase vcam) 
         {
-            Lens.Top = Lens.Bottom = vcam == null ? LensSettings.Default : vcam.State.Lens;
+            Top = Bottom = vcam == null ? LensSettings.Default : vcam.State.Lens;
+            Top.ModeOverride = Bottom.ModeOverride = LensSettings.OverrideModes.None;
         }
 
         /// <summary>
@@ -226,10 +234,13 @@ public class CinemachineFreeLookModifier : CinemachineExtension
             CinemachineVirtualCameraBase vcam, 
             ref CameraState state, float deltaTime, float modifierValue) 
         {
+            Top.SnapshotCameraReadOnlyProperties(ref state.Lens);
+            Bottom.SnapshotCameraReadOnlyProperties(ref state.Lens);
+            Top.ModeOverride = Bottom.ModeOverride = LensSettings.OverrideModes.None;
             if (modifierValue >= 0)
-                state.Lens.Lerp(Lens.Top, modifierValue);
+                state.Lens.Lerp(Top, modifierValue);
             else
-                state.Lens.Lerp(Lens.Bottom, -modifierValue);
+                state.Lens.Lerp(Bottom, -modifierValue);
         }
     }
     

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
@@ -79,6 +79,12 @@ namespace Cinemachine
     }
 
     /// <summary>
+    /// Property applied to LensSetting properties.  
+    /// Will cause the property drawer to hide the ModeOverride setting.
+    /// </summary>
+    public sealed class LensSettingsHideModeOverridePropertyAttribute : PropertyAttribute { }
+
+    /// <summary>
     /// Property applied to Vcam Target fields.  Used for custom drawing in the inspector.
     /// </summary>
     public sealed class VcamTargetPropertyAttribute : PropertyAttribute { }

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -238,7 +238,7 @@ namespace Cinemachine
                     m_SensorSize = new Vector2(camera.aspect, 1f);
                 LensShift = Vector2.zero;
             }
-#if UNITY_EDITOR && UNITY_2019_1_OR_NEWER
+#if UNITY_EDITOR
             // This should really be a global setting, but for now there is no better way than this!
             var p = new UnityEditor.SerializedObject(camera).FindProperty("m_FOVAxisMode");
             UseHorizontalFOV = (p != null && p.intValue == (int)Camera.FieldOfViewAxis.Horizontal);


### PR DESCRIPTION
- Lens property drawer: take override mode out of advanced foldout.  Display warning only when necessary
- Rotation composer editor: remove evil refresh hack
- Bugfix: Lens FreeLook modifier was not observing lens override mode of vcam