### PR TITLE
CMCL-896: remove m_ from public component members

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBasicMultiChannelPerlinEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBasicMultiChannelPerlinEditor.cs
@@ -18,7 +18,7 @@ namespace Cinemachine.Editor
             BeginInspector();
             bool needWarning = false;
             for (int i = 0; !needWarning && i < targets.Length; ++i)
-                needWarning = (targets[i] as CinemachineBasicMultiChannelPerlin).m_NoiseProfile == null;
+                needWarning = (targets[i] as CinemachineBasicMultiChannelPerlin).NoiseProfile == null;
             if (needWarning)
                 EditorGUILayout.HelpBox(
                     "A Noise Profile is required.  You may choose from among the NoiseSettings assets defined in the project.",

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
@@ -330,8 +330,8 @@ namespace Cinemachine.Editor
                 // noise then any specific settings differences can be accounted for in
                 // the FreeLookModifier by setting amplitude to 0
                 return a == null || b == null ||
-                    ((a.m_NoiseProfile == null || b.m_NoiseProfile == null || a.m_NoiseProfile == b.m_NoiseProfile)
-                        && a.m_PivotOffset == b.m_PivotOffset);
+                    ((a.NoiseProfile == null || b.NoiseProfile == null || a.NoiseProfile == b.NoiseProfile)
+                        && a.PivotOffset == b.PivotOffset);
             }
 
             static bool PublicFieldsEqual(CinemachineComponentBase a, CinemachineComponentBase b, params string[] ignoreList)
@@ -489,17 +489,17 @@ namespace Cinemachine.Editor
             var top = freelook.GetRig(0).GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
             var middle = freelook.GetRig(1).GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
             var bottom = freelook.GetRig(2).GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
-            var template = middle != null && middle.m_NoiseProfile != null 
-                ? middle : (top != null && top.m_NoiseProfile != null? top : bottom);
-            if (template == null || template.m_NoiseProfile == null)
+            var template = middle != null && middle.NoiseProfile != null 
+                ? middle : (top != null && top.NoiseProfile != null? top : bottom);
+            if (template == null || template.NoiseProfile == null)
                 return;
 
             var middleNoise = Undo.AddComponent<CinemachineBasicMultiChannelPerlin>(go);
             CopyValues(template, middleNoise);
 
             var middleSettings = GetNoiseSettings(middle);
-            middleNoise.m_AmplitudeGain = middleSettings.Amplitude;
-            middleNoise.m_FrequencyGain = middleSettings.Frequency;
+            middleNoise.AmplitudeGain = middleSettings.Amplitude;
+            middleNoise.FrequencyGain = middleSettings.Frequency;
 
             var topSettings = GetNoiseSettings(top);
             var bottomSettings = GetNoiseSettings(bottom);
@@ -523,8 +523,8 @@ namespace Cinemachine.Editor
                 var settings = new CinemachineFreeLookModifier.NoiseModifier.NoiseSettings();
                 if (noise != null)
                 {
-                    settings.Amplitude = noise.m_AmplitudeGain;
-                    settings.Frequency = noise.m_FrequencyGain;
+                    settings.Amplitude = noise.AmplitudeGain;
+                    settings.Frequency = noise.FrequencyGain;
                 }
                 return settings;
             }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
@@ -27,37 +27,41 @@ namespace Cinemachine
         [Tooltip("The asset containing the Noise Profile.  Define the frequencies and amplitudes "
             + "there to make a characteristic noise profile.  Make your own or just use one of the many presets.")]
         [FormerlySerializedAs("m_Definition")]
+        [FormerlySerializedAs("m_NoiseProfile")]
         [NoiseSettingsProperty]
-        public NoiseSettings m_NoiseProfile;
+        public NoiseSettings NoiseProfile;
 
         /// <summary>
         /// When rotating the camera, offset the camera's pivot position by this much (camera space)
         /// </summary>
         [Tooltip("When rotating the camera, offset the camera's pivot position by this much (camera space)")]
-        public Vector3 m_PivotOffset = Vector3.zero;
+        [FormerlySerializedAs("m_PivotOffset")]
+        public Vector3 PivotOffset = Vector3.zero;
 
         /// <summary>
         /// Gain to apply to the amplitudes defined in the settings asset.
         /// </summary>
         [Tooltip("Gain to apply to the amplitudes defined in the NoiseSettings asset.  1 is normal.  "
             + "Setting this to 0 completely mutes the noise.")]
-        public float m_AmplitudeGain = 1f;
+        [FormerlySerializedAs("m_AmplitudeGain")]
+        public float AmplitudeGain = 1f;
 
         /// <summary>
         /// Scale factor to apply to the frequencies defined in the settings asset.
         /// </summary>
         [Tooltip("Scale factor to apply to the frequencies defined in the NoiseSettings asset.  1 is normal.  "
             + "Larger magnitudes will make the noise shake more rapidly.")]
-        public float m_FrequencyGain = 1f;
+        [FormerlySerializedAs("m_FrequencyGain")]
+        public float FrequencyGain = 1f;
 
         (float, float) CinemachineFreeLookModifier.IModifiableNoise.NoiseAmplitudeFrequency 
         { 
-            get => (m_AmplitudeGain, m_FrequencyGain);
-            set { m_AmplitudeGain = value.Item1; m_FrequencyGain = value.Item2; }
+            get => (AmplitudeGain, FrequencyGain);
+            set { AmplitudeGain = value.Item1; FrequencyGain = value.Item2; }
         }
 
         /// <summary>True if the component is valid, i.e. it has a noise definition and is enabled.</summary>
-        public override bool IsValid { get { return enabled && m_NoiseProfile != null; } }
+        public override bool IsValid { get { return enabled && NoiseProfile != null; } }
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Noise stage</summary>
@@ -81,18 +85,18 @@ namespace Cinemachine
 
             if (TargetPositionCache.CacheMode == TargetPositionCache.Mode.Playback
                     && TargetPositionCache.HasCurrentTime)
-                mNoiseTime = TargetPositionCache.CurrentTime * m_FrequencyGain;
+                mNoiseTime = TargetPositionCache.CurrentTime * FrequencyGain;
             else
-                mNoiseTime += deltaTime * m_FrequencyGain;
+                mNoiseTime += deltaTime * FrequencyGain;
             curState.PositionCorrection += curState.CorrectedOrientation * NoiseSettings.GetCombinedFilterResults(
-                    m_NoiseProfile.PositionNoise, mNoiseTime, mNoiseOffsets) * m_AmplitudeGain;
+                    NoiseProfile.PositionNoise, mNoiseTime, mNoiseOffsets) * AmplitudeGain;
             Quaternion rotNoise = Quaternion.Euler(NoiseSettings.GetCombinedFilterResults(
-                    m_NoiseProfile.OrientationNoise, mNoiseTime, mNoiseOffsets) * m_AmplitudeGain);
-            if (m_PivotOffset != Vector3.zero)
+                    NoiseProfile.OrientationNoise, mNoiseTime, mNoiseOffsets) * AmplitudeGain);
+            if (PivotOffset != Vector3.zero)
             {
-                Matrix4x4 m = Matrix4x4.Translate(-m_PivotOffset);
+                Matrix4x4 m = Matrix4x4.Translate(-PivotOffset);
                 m = Matrix4x4.Rotate(rotNoise) * m;
-                m = Matrix4x4.Translate(m_PivotOffset) * m;
+                m = Matrix4x4.Translate(PivotOffset) * m;
                 curState.PositionCorrection += curState.CorrectedOrientation * m.MultiplyPoint(Vector3.zero);
             }
             curState.OrientationCorrection = curState.OrientationCorrection * rotNoise;
@@ -116,7 +120,7 @@ namespace Cinemachine
         void Initialize()
         {
             mInitialized = true;
-            mNoiseTime = CinemachineCore.CurrentTime * m_FrequencyGain;
+            mNoiseTime = CinemachineCore.CurrentTime * FrequencyGain;
             if (mNoiseOffsets == Vector3.zero)
                 ReSeed();
         }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Cinemachine.Utility;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Cinemachine
 {
@@ -17,7 +18,8 @@ namespace Cinemachine
         /// How much time it takes for the position to catch up to the target's position
         /// </summary>
         [Tooltip("How much time it takes for the position to catch up to the target's position")]
-        public float m_Damping = 0;
+        [FormerlySerializedAs("m_Damping")]
+        public float Damping = 0;
         Vector3 m_PreviousTargetPosition;
 
         /// <summary>True if component is enabled and has a LookAt defined</summary>
@@ -31,7 +33,7 @@ namespace Cinemachine
         /// Report maximum damping time needed for this component.
         /// </summary>
         /// <returns>Highest damping setting in this component</returns>
-        public override float GetMaxDampTime() { return m_Damping; }
+        public override float GetMaxDampTime() { return Damping; }
 
         /// <summary>Applies the composer rules and orients the camera accordingly</summary>
         /// <param name="curState">The current camera state</param>
@@ -45,7 +47,7 @@ namespace Cinemachine
             Vector3 dampedPos = FollowTargetPosition;
             if (deltaTime >= 0)
                 dampedPos = m_PreviousTargetPosition + VirtualCamera.DetachedFollowTargetDamp(
-                    dampedPos - m_PreviousTargetPosition, m_Damping, deltaTime);
+                    dampedPos - m_PreviousTargetPosition, Damping, deltaTime);
             m_PreviousTargetPosition = dampedPos;
             curState.RawPosition = dampedPos;
         }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
@@ -19,7 +19,8 @@ namespace Cinemachine
         /// </summary>
         [Tooltip("How much time it takes for the aim to catch up to the target's rotation")]
         [FormerlySerializedAs("m_AngularDamping")]
-        public float m_Damping = 0;
+        [FormerlySerializedAs("m_Damping")]
+        public float Damping = 0;
 
         Quaternion m_PreviousReferenceOrientation = Quaternion.identity;
 
@@ -34,7 +35,7 @@ namespace Cinemachine
         /// Report maximum damping time needed for this component.
         /// </summary>
         /// <returns>Highest damping setting in this component</returns>
-        public override float GetMaxDampTime() { return m_Damping; }
+        public override float GetMaxDampTime() { return Damping; }
 
         /// <summary>Orients the camera to match the Follow target's orientation</summary>
         /// <param name="curState">The current camera state</param>
@@ -47,7 +48,7 @@ namespace Cinemachine
             Quaternion dampedOrientation = FollowTargetRotation;
             if (deltaTime >= 0)
             {
-                float t = VirtualCamera.DetachedFollowTargetDamp(1, m_Damping, deltaTime);
+                float t = VirtualCamera.DetachedFollowTargetDamp(1, Damping, deltaTime);
                 dampedOrientation = Quaternion.Slerp(
                     m_PreviousReferenceOrientation, FollowTargetRotation, t);
             }


### PR DESCRIPTION
### Purpose of this PR

CMCL-896 part of API clenup.  Remove m_  from public members of remaining CM component classes

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

