### PR TITLE
CMCL-1066: Cleanup ICinemachineCamera API

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineBlenderSettings))]
-    internal sealed class CinemachineBlenderSettingsEditor : BaseEditor<CinemachineBlenderSettings>
+    sealed class CinemachineBlenderSettingsEditor : BaseEditor<CinemachineBlenderSettings>
     {
         ReorderableList m_BlendList;
-        const string kNoneLabel = "(none)";
-        string[] mCameraCandidates;
-        Dictionary<string, int> mCameraIndexLookup;
+        const string k_NoneLabel = "(none)";
+        string[] m_CameraCandidates;
+        Dictionary<string, int> m_CameraIndexLookup;
 
         /// <summary>
         /// Called when building the Camera popup menus, to get the domain of possible
@@ -44,8 +44,8 @@ namespace Cinemachine.Editor
 
         void UpdateCameraCandidates()
         {
-            List<string> vcams = new List<string>();
-            mCameraIndexLookup = new Dictionary<string, int>();
+            var vcams = new List<string>();
+            m_CameraIndexLookup = new Dictionary<string, int>();
 
             CinemachineVirtualCameraBase[] candidates;
             if (GetAllVirtualCameras != null)
@@ -56,28 +56,19 @@ namespace Cinemachine.Editor
                 candidates = Resources.FindObjectsOfTypeAll(
                         typeof(CinemachineVirtualCameraBase)) as CinemachineVirtualCameraBase[];
 
-                for (int i = 0; i < candidates.Length; ++i)
+                for (var i = 0; i < candidates.Length; ++i)
                     if (candidates[i].ParentCamera != null)
                         candidates[i] = null;
             }
-            vcams.Add(kNoneLabel);
+            vcams.Add(k_NoneLabel);
             vcams.Add(CinemachineBlenderSettings.kBlendFromAnyCameraLabel);
             foreach (CinemachineVirtualCameraBase c in candidates)
                 if (c != null && !vcams.Contains(c.Name))
                     vcams.Add(c.Name);
 
-            mCameraCandidates = vcams.ToArray();
-            for (int i = 0; i < mCameraCandidates.Length; ++i)
-                mCameraIndexLookup[mCameraCandidates[i]] = i;
-        }
-
-        private int GetCameraIndex(string name)
-        {
-            if (name == null || mCameraIndexLookup == null)
-                return 0;
-            if (!mCameraIndexLookup.ContainsKey(name))
-                return 0;
-            return mCameraIndexLookup[name];
+            m_CameraCandidates = vcams.ToArray();
+            for (int i = 0; i < m_CameraCandidates.Length; ++i)
+                m_CameraIndexLookup[m_CameraCandidates[i]] = i;
         }
 
         void DrawVcamSelector(Rect r, SerializedProperty prop)
@@ -89,11 +80,20 @@ namespace Cinemachine.Editor
                 GUI.color = new Color(1, 193.0f/255.0f, 7.0f/255.0f); // the "warning" icon color
             EditorGUI.PropertyField(r, prop, GUIContent.none);
             r.x += r.width; r.width = EditorGUIUtility.singleLineHeight;
-            int sel = EditorGUI.Popup(r, current, mCameraCandidates);
+            int sel = EditorGUI.Popup(r, current, m_CameraCandidates);
             if (current != sel)
-                prop.stringValue = (mCameraCandidates[sel] == kNoneLabel) 
-                    ? string.Empty : mCameraCandidates[sel];
+                prop.stringValue = (m_CameraCandidates[sel] == k_NoneLabel) 
+                    ? string.Empty : m_CameraCandidates[sel];
             GUI.color = oldColor;
+            
+            int GetCameraIndex(string propName)
+            {
+                if (propName == null || m_CameraIndexLookup == null)
+                    return 0;
+                if (!m_CameraIndexLookup.ContainsKey(propName))
+                    return 0;
+                return m_CameraIndexLookup[propName];
+            }
         }
         
         void SetupBlendList()
@@ -103,15 +103,15 @@ namespace Cinemachine.Editor
                     true, true, true, true);
 
             // Needed for accessing string names of fields
-            CinemachineBlenderSettings.CustomBlend def = new CinemachineBlenderSettings.CustomBlend();
-            CinemachineBlendDefinition def2 = new CinemachineBlendDefinition();
+            var def = new CinemachineBlenderSettings.CustomBlend();
+            var def2 = new CinemachineBlendDefinition();
 
-            float vSpace = 2;
-            float hSpace = 3;
+            const float vSpace = 2f;
+            const float hSpace = 3f;
             float floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
             m_BlendList.drawHeaderCallback = (Rect rect) =>
                 {
-                    rect.width -= (EditorGUIUtility.singleLineHeight + 2 * hSpace);
+                    rect.width -= EditorGUIUtility.singleLineHeight + 2 * hSpace;
                     rect.width /= 3;
                     rect.x += EditorGUIUtility.singleLineHeight;
                     EditorGUI.LabelField(rect, "From");

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -50,9 +50,8 @@ namespace Cinemachine.Editor
 
             // Show the active camera and blend
             GUI.enabled = false;
-            ICinemachineCamera vcam = Target.ActiveVirtualCamera;
-            Transform activeCam = (vcam != null && vcam.VirtualCameraGameObject != null)
-                ? vcam.VirtualCameraGameObject.transform : null;
+            var vcam = Target.ActiveVirtualCamera as CinemachineVirtualCameraBase;
+            Transform activeCam = vcam != null ? vcam.transform : null;
             EditorGUILayout.ObjectField("Live Camera", activeCam, typeof(Transform), true);
             EditorGUILayout.DelayedTextField(
                 "Live Blend", Target.ActiveBlend != null

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
     public sealed class CinemachineBrainEditor : BaseEditor<CinemachineBrain>
     {
         EmbeddeAssetEditor<CinemachineBlenderSettings> m_BlendsEditor;
-        bool mEventsExpanded = false;
+        bool m_EventsExpanded = false;
 
         /// <summary>Obsolete, do not use.  Use the overload, which is more performant</summary>
         /// <returns>List of property names to exclude</returns>
@@ -31,13 +31,15 @@ namespace Cinemachine.Editor
             excluded.Add(FieldPath(x => x.m_CustomBlends));
         }
 
-        private void OnEnable()
+        void OnEnable()
         {
-            m_BlendsEditor = new EmbeddeAssetEditor<CinemachineBlenderSettings>(FieldPath(x => x.m_CustomBlends), this);
-            m_BlendsEditor.OnChanged = (CinemachineBlenderSettings b) => { InspectorUtility.RepaintGameView(); };
+            m_BlendsEditor = new EmbeddeAssetEditor<CinemachineBlenderSettings>(FieldPath(x => x.m_CustomBlends), this)
+            {
+                OnChanged = (CinemachineBlenderSettings b) => { InspectorUtility.RepaintGameView(); }
+            };
         }
 
-        private void OnDisable()
+        void OnDisable()
         {
             if (m_BlendsEditor != null)
                 m_BlendsEditor.OnDisable();
@@ -69,8 +71,8 @@ namespace Cinemachine.Editor
                     Target.gameObject.name + " Blends", "asset", string.Empty,
                     "Custom Blends", false);
 
-                mEventsExpanded = EditorGUILayout.Foldout(mEventsExpanded, "Events", true);
-                if (mEventsExpanded)
+                m_EventsExpanded = EditorGUILayout.Foldout(m_EventsExpanded, "Events", true);
+                if (m_EventsExpanded)
                 {
                     EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraCutEvent));
                     EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraActivatedEvent));
@@ -80,7 +82,7 @@ namespace Cinemachine.Editor
         }
 
         [DrawGizmo(GizmoType.Selected | GizmoType.NonSelected, typeof(CinemachineBrain))]
-        private static void DrawBrainGizmos(CinemachineBrain brain, GizmoType drawType)
+        static void DrawBrainGizmos(CinemachineBrain brain, GizmoType drawType)
         {
             if (brain.OutputCamera != null && brain.m_ShowCameraFrustum && brain.isActiveAndEnabled)
             {
@@ -103,14 +105,14 @@ namespace Cinemachine.Editor
                 ortho = brain.OutputCamera.orthographic;
             }
 
-            Matrix4x4 originalMatrix = Gizmos.matrix;
-            Color originalGizmoColour = Gizmos.color;
+            var originalMatrix = Gizmos.matrix;
+            var originalGizmoColour = Gizmos.color;
             
             Gizmos.color = color;
             Gizmos.matrix = transform;
             if (ortho)
             {
-                Vector3 size = new Vector3(
+                var size = new Vector3(
                         aspect * lens.OrthographicSize * 2,
                         lens.OrthographicSize * 2,
                         lens.FarClipPlane - lens.NearClipPlane);
@@ -141,7 +143,7 @@ namespace Cinemachine.Editor
                 return;
 
             CameraState state = vcam.State;
-            Gizmos.DrawIcon(state.FinalPosition, kGizmoFileName, true);
+            Gizmos.DrawIcon(state.FinalPosition, s_GizmoFileName, true);
 
             DrawCameraFrustumGizmo(
                 CinemachineCore.Instance.FindPotentialTargetBrain(vcam),
@@ -155,21 +157,21 @@ namespace Cinemachine.Editor
         }
 
 #if UNITY_2019_1_OR_NEWER
-        static string kGizmoFileName = "Packages/com.unity.cinemachine/Gizmos/cm_logo.png";
+        static string s_GizmoFileName = "Packages/com.unity.cinemachine/Gizmos/cm_logo.png";
 #else
-        static string kGizmoFileName = "Cinemachine/cm_logo_lg.png";
+        static string s_GizmoFileName = "Cinemachine/cm_logo_lg.png";
         [InitializeOnLoad]
         static class InstallGizmos
         {
             static InstallGizmos()
             {
-                string srcFile = ScriptableObjectUtility.CinemachineInstallPath + "/Gizmos/" + kGizmoFileName;
+                string srcFile = ScriptableObjectUtility.CinemachineInstallPath + "/Gizmos/" + s_GizmoFileName;
                 if (File.Exists(srcFile))
                 {
                     string dstFile = Application.dataPath + "/Gizmos";
                     if (!Directory.Exists(dstFile))
                         Directory.CreateDirectory(dstFile);
-                    dstFile += "/" + kGizmoFileName;
+                    dstFile += "/" + s_GizmoFileName;
                     if (!File.Exists(dstFile)
                         || (File.GetLastWriteTime(dstFile) < File.GetLastWriteTime(srcFile)
                             && (File.GetAttributes(dstFile) & FileAttributes.ReadOnly) == 0))

--- a/com.unity.cinemachine/Editor/Editors/CinemachineColliderEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineColliderEditor.cs
@@ -12,7 +12,7 @@ namespace Cinemachine.Editor
 #if CINEMACHINE_PHYSICS
     [CustomEditor(typeof(CinemachineCollider))]
     [CanEditMultipleObjects]
-    internal sealed class CinemachineColliderEditor : BaseEditor<CinemachineCollider>
+    sealed class CinemachineColliderEditor : BaseEditor<CinemachineCollider>
     {
         /// <summary>Get the property names to exclude in the inspector.</summary>
         /// <param name="excluded">Add the names to this list</param>
@@ -49,7 +49,7 @@ namespace Cinemachine.Editor
         }
 
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineCollider))]
-        private static void DrawColliderGizmos(CinemachineCollider collider, GizmoType type)
+        static void DrawColliderGizmos(CinemachineCollider collider, GizmoType type)
         {
             CinemachineVirtualCameraBase vcam = (collider != null) ? collider.VirtualCamera : null;
             if (vcam != null && collider.enabled)

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -8,7 +8,7 @@ namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachinePositionComposer))]
     [CanEditMultipleObjects]
-    internal class CinemachinePositionComposerEditor : UnityEditor.Editor
+    class CinemachinePositionComposerEditor : UnityEditor.Editor
     {
         CinemachineScreenComposerGuides m_ScreenGuideEditor;
         GameViewEventCatcher m_GameViewEventCatcher;
@@ -155,7 +155,7 @@ namespace Cinemachine.Editor
         }
 
         [DrawGizmo(GizmoType.Active | GizmoType.InSelectionHierarchy, typeof(CinemachinePositionComposer))]
-        private static void DrawGroupComposerGizmos(CinemachinePositionComposer target, GizmoType selectionType)
+        static void DrawGroupComposerGizmos(CinemachinePositionComposer target, GizmoType selectionType)
         {
             // Show the group bounding box, as viewed from the camera position
             if (target.AbstractFollowTargetGroup != null

--- a/com.unity.cinemachine/Editor/Helpers/CinemachineTriggerActionEditor.cs
+++ b/com.unity.cinemachine/Editor/Helpers/CinemachineTriggerActionEditor.cs
@@ -12,29 +12,28 @@ namespace Cinemachine.Editor
 {
 #if CINEMACHINE_PHYSICS || CINEMACHINE_PHYSICS_2D
     [CustomEditor(typeof(CinemachineTriggerAction))]
-    internal class CinemachineTriggerActionEditor : BaseEditor<CinemachineTriggerAction>
+    class CinemachineTriggerActionEditor : BaseEditor<CinemachineTriggerAction>
     {
-        CinemachineTriggerAction.ActionSettings def
-            = new CinemachineTriggerAction.ActionSettings(); // to access name strings
+        CinemachineTriggerAction.ActionSettings m_Def = new(); // to access name strings
 
-        static bool mEnterExpanded;
-        static bool mExitExpanded;
+        static bool s_EnterExpanded;
+        static bool s_ExitExpanded;
 
-        SerializedProperty[] mRepeatProperties = new SerializedProperty[2];
-        GUIContent mRepeatLabel;
-        GUIContent[] mRepeatSubLabels = new GUIContent[2];
+        SerializedProperty[] m_RepeatProperties = new SerializedProperty[2];
+        GUIContent m_RepeatLabel;
+        GUIContent[] m_RepeatSubLabels = new GUIContent[2];
 
-        GUIStyle mFoldoutStyle;
+        GUIStyle m_FoldoutStyle;
 
-        private void OnEnable()
+        void OnEnable()
         {
-            mRepeatProperties[0] = FindProperty(x => x.SkipFirst);
-            mRepeatProperties[1] = FindProperty(x => x.Repeating);
-            mRepeatLabel = new GUIContent(
-                mRepeatProperties[0].displayName, mRepeatProperties[0].tooltip);
-            mRepeatSubLabels[0] = GUIContent.none;
-            mRepeatSubLabels[1] = new GUIContent(
-                mRepeatProperties[1].displayName, mRepeatProperties[1].tooltip);
+            m_RepeatProperties[0] = FindProperty(x => x.SkipFirst);
+            m_RepeatProperties[1] = FindProperty(x => x.Repeating);
+            m_RepeatLabel = new GUIContent(
+                m_RepeatProperties[0].displayName, m_RepeatProperties[0].tooltip);
+            m_RepeatSubLabels[0] = GUIContent.none;
+            m_RepeatSubLabels[1] = new GUIContent(
+                m_RepeatProperties[1].displayName, m_RepeatProperties[1].tooltip);
         }
 
         /// <summary>Get the property names to exclude in the inspector.</summary>
@@ -53,44 +52,44 @@ namespace Cinemachine.Editor
             BeginInspector();
             DrawRemainingPropertiesInInspector();
             InspectorUtility.MultiPropertyOnLine(
-                EditorGUILayout.GetControlRect(), mRepeatLabel,
-                mRepeatProperties, mRepeatSubLabels);
+                EditorGUILayout.GetControlRect(), m_RepeatLabel,
+                m_RepeatProperties, m_RepeatSubLabels);
             EditorGUILayout.Space();
-            mEnterExpanded = DrawActionSettings(FindProperty(x => x.OnObjectEnter), mEnterExpanded);
-            mExitExpanded = DrawActionSettings(FindProperty(x => x.OnObjectExit), mExitExpanded);
+            s_EnterExpanded = DrawActionSettings(FindProperty(x => x.OnObjectEnter), s_EnterExpanded);
+            s_ExitExpanded = DrawActionSettings(FindProperty(x => x.OnObjectExit), s_ExitExpanded);
         }
 
         bool DrawActionSettings(SerializedProperty property, bool expanded)
         {
-            if (mFoldoutStyle == null)
-                mFoldoutStyle = new GUIStyle(EditorStyles.foldout) { fontStyle = FontStyle.Bold };
+            if (m_FoldoutStyle == null)
+                m_FoldoutStyle = new GUIStyle(EditorStyles.foldout) { fontStyle = FontStyle.Bold };
 
             Rect r = EditorGUILayout.GetControlRect();
-            expanded = EditorGUI.Foldout(r, expanded, property.displayName, true, mFoldoutStyle);
+            expanded = EditorGUI.Foldout(r, expanded, property.displayName, true, m_FoldoutStyle);
             if (expanded)
             {
-                SerializedProperty actionProp = property.FindPropertyRelative(() => def.Action);
+                SerializedProperty actionProp = property.FindPropertyRelative(() => m_Def.Action);
                 EditorGUILayout.PropertyField(actionProp);
 
-                SerializedProperty targetProp = property.FindPropertyRelative(() => def.Target);
+                SerializedProperty targetProp = property.FindPropertyRelative(() => m_Def.Target);
                 bool isCustom = (actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.ActionModes.Custom);
                 if (!isCustom)
                     EditorGUILayout.PropertyField(targetProp);
 
                 bool isBoost = actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.ActionModes.PriorityBoost;
                 if (isBoost)
-                    EditorGUILayout.PropertyField(property.FindPropertyRelative(() => def.BoostAmount));
+                    EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_Def.BoostAmount));
 
 #if CINEMACHINE_TIMELINE
                 bool isPlay = actionProp.intValue == (int)CinemachineTriggerAction.ActionSettings.ActionModes.Play;
                 if (isPlay)
                 {
-                    SerializedProperty[] props = new SerializedProperty[2]
+                    var props = new SerializedProperty[2]
                     {
-                        property.FindPropertyRelative(() => def.StartTime),
-                        property.FindPropertyRelative(() => def.Mode)
+                        property.FindPropertyRelative(() => m_Def.StartTime),
+                        property.FindPropertyRelative(() => m_Def.Mode)
                     };
-                    GUIContent[] sublabels = new GUIContent[2]
+                    var sublabels = new GUIContent[2]
                     {
                         GUIContent.none, new GUIContent("s", props[1].tooltip)
                     };
@@ -134,13 +133,13 @@ namespace Cinemachine.Editor
 
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("This event will be invoked.  Add calls to custom methods here:");
-                EditorGUILayout.PropertyField(property.FindPropertyRelative(() => def.Event));
+                EditorGUILayout.PropertyField(property.FindPropertyRelative(() => m_Def.Event));
             }
             property.serializedObject.ApplyModifiedProperties();
             return expanded;
         }
 
-        T GetTargetComponent<T>(UnityEngine.Object obj) where T : Behaviour
+        static T GetTargetComponent<T>(UnityEngine.Object obj) where T : Behaviour
         {
             UnityEngine.Object currentTarget = obj;
             if (currentTarget != null)

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
@@ -10,7 +10,7 @@ using UnityEditor.Rendering.PostProcessing;
 namespace Cinemachine.PostFX.Editor
 {
     [CustomEditor(typeof(CinemachinePostProcessing))]
-    public sealed class CinemachinePostProcessingEditor : Cinemachine.Editor.BaseEditor<CinemachinePostProcessing>
+    sealed class CinemachinePostProcessingEditor : Cinemachine.Editor.BaseEditor<CinemachinePostProcessing>
     {
 #if !CINEMACHINE_POST_PROCESSING_V2
         public override void OnInspectorGUI()
@@ -40,11 +40,11 @@ namespace Cinemachine.PostFX.Editor
                      + "/Editor/EditorResources/PostProcessLayer.png");
             m_ProfileLabel = new GUIContent("Profile", texture, "A reference to a profile asset");
 
-            m_FocusTracking = FindProperty(x => x.m_FocusTracking);
-            m_Profile = FindProperty(x => x.m_Profile);
+            m_FocusTracking = FindProperty(x => x.FocusTracking);
+            m_Profile = FindProperty(x => x.Profile);
 
             m_EffectList = new EffectListEditor(this);
-            RefreshEffectListEditor(Target.m_Profile);
+            RefreshEffectListEditor(Target.Profile);
         }
 
         void OnDisable()
@@ -69,10 +69,10 @@ namespace Cinemachine.PostFX.Editor
             base.GetExcludedPropertiesInInspector(excluded);
             var mode = (CinemachinePostProcessing.FocusTrackingMode)m_FocusTracking.intValue;
             if (mode != CinemachinePostProcessing.FocusTrackingMode.CustomTarget)
-                excluded.Add(FieldPath(x => x.m_FocusTarget));
+                excluded.Add(FieldPath(x => x.FocusTarget));
             if (mode == CinemachinePostProcessing.FocusTrackingMode.None)
-                excluded.Add(FieldPath(x => x.m_FocusOffset));
-            excluded.Add(FieldPath(x => x.m_Profile));
+                excluded.Add(FieldPath(x => x.FocusOffset));
+            excluded.Add(FieldPath(x => x.Profile));
         }
 
         public override void OnInspectorGUI()
@@ -90,7 +90,7 @@ namespace Cinemachine.PostFX.Editor
             {
                 bool valid = false;
                 DepthOfField dof;
-                if (Target.m_Profile != null && Target.m_Profile.TryGetSettings(out dof))
+                if (Target.Profile != null && Target.Profile.TryGetSettings(out dof))
                     valid = dof.enabled && dof.active && dof.focusDistance.overrideState;
                 if (!valid)
                     EditorGUILayout.HelpBox(
@@ -202,8 +202,7 @@ namespace Cinemachine.PostFX.Editor
         // Copied from UnityEditor.Rendering.PostProcessing.ProfileFactory.CreatePostProcessProfile() because it's internal
         static PostProcessProfile CreatePostProcessProfile(UnityEngine.SceneManagement.Scene scene, string targetName)
         {
-            var path = string.Empty;
-
+            string path;
             if (string.IsNullOrEmpty(scene.path))
             {
                 path = "Assets/";

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -16,7 +16,7 @@
 namespace Cinemachine.PostFX.Editor
 {
     [CustomEditor(typeof(CinemachineVolumeSettings))]
-    public sealed class CinemachineVolumeSettingsEditor : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
+    sealed class CinemachineVolumeSettingsEditor : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
     {
 #if !(CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1)
         public override void OnInspectorGUI()
@@ -41,10 +41,10 @@ namespace Cinemachine.PostFX.Editor
             m_NewLabel = new GUIContent("New", "Create a new profile.");
             m_CloneLabel = new GUIContent("Clone", "Create a new profile and copy the content of the currently assigned profile.");
 
-            m_FocusTracking = FindProperty(x => x.m_FocusTracking);
-            m_Profile = FindProperty(x => x.m_Profile);
+            m_FocusTracking = FindProperty(x => x.FocusTracking);
+            m_Profile = FindProperty(x => x.Profile);
 
-            RefreshVolumeComponentEditor(Target.m_Profile);
+            RefreshVolumeComponentEditor(Target.Profile);
         }
 
         void OnDisable()
@@ -69,10 +69,10 @@ namespace Cinemachine.PostFX.Editor
             base.GetExcludedPropertiesInInspector(excluded);
             var mode = (CinemachineVolumeSettings.FocusTrackingMode)m_FocusTracking.intValue;
             if (mode != CinemachineVolumeSettings.FocusTrackingMode.CustomTarget)
-                excluded.Add(FieldPath(x => x.m_FocusTarget));
+                excluded.Add(FieldPath(x => x.FocusTarget));
             if (mode == CinemachineVolumeSettings.FocusTrackingMode.None)
-                excluded.Add(FieldPath(x => x.m_FocusOffset));
-            excluded.Add(FieldPath(x => x.m_Profile));
+                excluded.Add(FieldPath(x => x.FocusOffset));
+            excluded.Add(FieldPath(x => x.Profile));
         }
 
         public override void OnInspectorGUI()
@@ -84,7 +84,7 @@ namespace Cinemachine.PostFX.Editor
             {
                 bool valid = false;
                 DepthOfField dof;
-                if (Target.m_Profile != null && Target.m_Profile.TryGet(out dof))
+                if (Target.Profile != null && Target.Profile.TryGet(out dof))
 #if CINEMACHINE_LWRP_7_3_1 && !CINEMACHINE_HDRP
                 {
                     valid = dof.active && dof.focusDistance.overrideState
@@ -210,7 +210,7 @@ namespace Cinemachine.PostFX.Editor
         // Copied from UnityEditor.Rendering.PostProcessing.ProfileFactory.CreateVolumeProfile() because it's internal
         static VolumeProfile CreateVolumeProfile(UnityEngine.SceneManagement.Scene scene, string targetName)
         {
-            var path = string.Empty;
+            string path;
 
             if (string.IsNullOrEmpty(scene.path))
             {

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotClipEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotClipEditor.cs
@@ -1,139 +1,135 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
-
-#if CINEMACHINE_TIMELINE && UNITY_2019_2_OR_NEWER
+#if CINEMACHINE_TIMELINE
 
 using UnityEngine.Timeline;
 using UnityEditor.Timeline;
-using Cinemachine;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Playables;
 
-[CustomTimelineEditor(typeof(CinemachineShot))]
-public class CinemachineShotClipEditor : ClipEditor
+namespace Cinemachine.Editor
 {
-    [InitializeOnLoad]
-    class EditorInitialize 
-    { 
-        static EditorInitialize() { CinemachineMixer.GetMasterPlayableDirector = GetMasterDirector; } 
-        static PlayableDirector GetMasterDirector() { return TimelineEditor.masterDirector; }
-    }
-    public delegate double TimelineGlobalToLocalTimeDelegate(double globalTime);
-    public static TimelineGlobalToLocalTimeDelegate TimelineGlobalToLocalTime = DefaultTimeConversion;
-#if CINEMACHINE_TIMELINE_1_5_0
-    static double DefaultTimeConversion(double time) { return TimelineEditor.GetInspectedTimeFromMasterTime(time); }
-#else
-    static double DefaultTimeConversion(double time) { return time; }
-#endif
-
-    public override ClipDrawOptions GetClipOptions(TimelineClip clip)
+    [CustomTimelineEditor(typeof(CinemachineShot))]
+    class CinemachineShotClipEditor : ClipEditor
     {
-        var shotClip = (CinemachineShot) clip.asset;
-        var clipOptions = base.GetClipOptions(clip);
-        if (shotClip != null)
-        {
-            var director = TimelineEditor.inspectedDirector;
-            if (director != null)
-            {
-                var vcam = shotClip.VirtualCamera.Resolve(director);
-                if (vcam == null)
-                    clipOptions.errorText = "A virtual camera must be assigned";
-                else
-                    clipOptions.tooltip = vcam.Name;
+        [InitializeOnLoad]
+        class EditorInitialize 
+        { 
+            static EditorInitialize() { CinemachineMixer.GetMasterPlayableDirector = GetMasterDirector; } 
+            static PlayableDirector GetMasterDirector() { return TimelineEditor.masterDirector; }
+        }
+        public delegate double TimelineGlobalToLocalTimeDelegate(double globalTime);
+        public static TimelineGlobalToLocalTimeDelegate TimelineGlobalToLocalTime = DefaultTimeConversion;
+    #if CINEMACHINE_TIMELINE_1_5_0
+        static double DefaultTimeConversion(double time) { return TimelineEditor.GetInspectedTimeFromMasterTime(time); }
+    #else
+        static double DefaultTimeConversion(double time) { return time; }
+    #endif
 
+        public override ClipDrawOptions GetClipOptions(TimelineClip clip)
+        {
+            var shotClip = (CinemachineShot) clip.asset;
+            var clipOptions = base.GetClipOptions(clip);
+            if (shotClip != null)
+            {
+                var director = TimelineEditor.inspectedDirector;
+                if (director != null)
+                {
+                    var vcam = shotClip.VirtualCamera.Resolve(director);
+                    if (vcam == null)
+                        clipOptions.errorText = "A virtual camera must be assigned";
+                    else
+                        clipOptions.tooltip = vcam.Name;
+
+                }
+            }
+            return clipOptions;
+        }
+
+        public override void OnClipChanged(TimelineClip clip)
+        {
+            var shotClip = (CinemachineShot)clip.asset;
+            if (shotClip == null)
+                return;
+            if (shotClip.DisplayName != null && shotClip.DisplayName.Length != 0)
+                clip.displayName = shotClip.DisplayName;
+            else
+            {
+                var director = TimelineEditor.inspectedDirector;
+                if (director != null)
+                {
+                    var vcam = shotClip.VirtualCamera.Resolve(director);
+                    if (vcam != null)
+                        clip.displayName = vcam.Name;
+                }
             }
         }
-        return clipOptions;
-    }
 
-    public override void OnClipChanged(TimelineClip clip)
-    {
-        var shotClip = (CinemachineShot)clip.asset;
-        if (shotClip == null)
-            return;
-        if (shotClip.DisplayName != null && shotClip.DisplayName.Length != 0)
-            clip.displayName = shotClip.DisplayName;
-        else
+        public override void OnCreate(TimelineClip clip, TrackAsset track, TimelineClip clonedFrom)
         {
-            var director = TimelineEditor.inspectedDirector;
-            if (director != null)
+            base.OnCreate(clip, track, clonedFrom);
+            if (CinemachineShotEditor.AutoCreateShotFromSceneView)
             {
-                var vcam = shotClip.VirtualCamera.Resolve(director);
-                if (vcam != null)
-                    clip.displayName = vcam.Name;
+                var asset = clip.asset as CinemachineShot;
+                var vcam = CinemachineShotEditor.CreatePassiveVcamFromSceneView();
+                var d = TimelineEditor.inspectedDirector;
+                if (d != null && d.GetReferenceValue(asset.VirtualCamera.exposedName, out bool idValid) == null)
+                {
+                    asset.VirtualCamera.exposedName = System.Guid.NewGuid().ToString();
+                    d.SetReferenceValue(asset.VirtualCamera.exposedName, vcam);
+                }
             }
         }
-    }
 
-    public override void OnCreate(TimelineClip clip, TrackAsset track, TimelineClip clonedFrom)
-    {
-        base.OnCreate(clip, track, clonedFrom);
-        if (CinemachineShotEditor.AutoCreateShotFromSceneView)
+        GUIContent m_Uncached = new GUIContent("UNCACHED");
+
+        public override void DrawBackground(TimelineClip clip, ClipBackgroundRegion region)
         {
-            var asset = clip.asset as CinemachineShot;
-            var vcam = CinemachineShotEditor.CreatePassiveVcamFromSceneView();
-            var d = TimelineEditor.inspectedDirector;
-            if (d != null && d.GetReferenceValue(asset.VirtualCamera.exposedName, out bool idValid) == null)
+            base.DrawBackground(clip, region);
+
+            if (Application.isPlaying || !TargetPositionCache.UseCache 
+                || TargetPositionCache.CacheMode == TargetPositionCache.Mode.Disabled
+                || TimelineEditor.inspectedDirector == null)
             {
-                asset.VirtualCamera.exposedName = System.Guid.NewGuid().ToString();
-                d.SetReferenceValue(asset.VirtualCamera.exposedName, vcam);
+                return;
             }
-        }
-    }
 
-    GUIContent kUndamped = new GUIContent("UNCACHED");
+            // Draw the cache indicator over the cached region
+            var cacheRange = TargetPositionCache.CacheTimeRange;
+            if (!cacheRange.IsEmpty)
+            {
+                cacheRange.Start = (float)TimelineGlobalToLocalTime(cacheRange.Start);
+                cacheRange.End = (float)TimelineGlobalToLocalTime(cacheRange.End);
 
-    public override void DrawBackground(TimelineClip clip, ClipBackgroundRegion region)
-    {
-        base.DrawBackground(clip, region);
-
-        if (Application.isPlaying || !TargetPositionCache.UseCache 
-            || TargetPositionCache.CacheMode == TargetPositionCache.Mode.Disabled
-            || TimelineEditor.inspectedDirector == null)
-        {
-            return;
-        }
-
-        // Draw the cache indicator over the cached region
-        var cacheRange = TargetPositionCache.CacheTimeRange;
-        if (!cacheRange.IsEmpty)
-        {
-            cacheRange.Start = (float)TimelineGlobalToLocalTime(cacheRange.Start);
-            cacheRange.End = (float)TimelineGlobalToLocalTime(cacheRange.End);
-
-            // Clip cacheRange to rect
-            float start = (float)region.startTime;
-            float end = (float)region.endTime;
-            cacheRange.Start = Mathf.Max((float)clip.ToLocalTime(cacheRange.Start), start);
-            cacheRange.End = Mathf.Min((float)clip.ToLocalTime(cacheRange.End), end);
+                // Clip cacheRange to rect
+                float start = (float)region.startTime;
+                float end = (float)region.endTime;
+                cacheRange.Start = Mathf.Max((float)clip.ToLocalTime(cacheRange.Start), start);
+                cacheRange.End = Mathf.Min((float)clip.ToLocalTime(cacheRange.End), end);
                 
-            var r = region.position;
-            var a = r.x + r.width * (cacheRange.Start - start) / (end - start);
-            var b = r.x + r.width * (cacheRange.End - start) / (end - start);
-            r.x = a; r.width = b-a;
-            r.y += r.height; r.height *= 0.2f; r.y -= r.height;
-            EditorGUI.DrawRect(r, new Color(0.1f, 0.2f, 0.8f, 0.6f));
-        }
+                var r = region.position;
+                var a = r.x + r.width * (cacheRange.Start - start) / (end - start);
+                var b = r.x + r.width * (cacheRange.End - start) / (end - start);
+                r.x = a; r.width = b-a;
+                r.y += r.height; r.height *= 0.2f; r.y -= r.height;
+                EditorGUI.DrawRect(r, new Color(0.1f, 0.2f, 0.8f, 0.6f));
+            }
 
-        // Draw the "UNCACHED" indicator, if appropriate
-        if (!TargetPositionCache.IsRecording && !TargetPositionCache.CurrentPlaybackTimeValid)
-        {
-            var r = region.position;
-            var t = clip.ToLocalTime(TimelineGlobalToLocalTime(TimelineEditor.masterDirector.time));
-            var pos = r.x + r.width 
-                * (float)((t - region.startTime) / (region.endTime - region.startTime));
+            // Draw the "UNCACHED" indicator, if appropriate
+            if (!TargetPositionCache.IsRecording && !TargetPositionCache.CurrentPlaybackTimeValid)
+            {
+                var r = region.position;
+                var t = clip.ToLocalTime(TimelineGlobalToLocalTime(TimelineEditor.masterDirector.time));
+                var pos = r.x + r.width 
+                    * (float)((t - region.startTime) / (region.endTime - region.startTime));
     
-            var s = EditorStyles.miniLabel.CalcSize(kUndamped);
-            r.width = s.x; r.x = pos - r.width / 2;
-            var c = GUI.color;
-            GUI.color = Color.yellow;
-            EditorGUI.LabelField(r, kUndamped, EditorStyles.miniLabel);
-            GUI.color = c;
+                var s = EditorStyles.miniLabel.CalcSize(m_Uncached);
+                r.width = s.x; r.x = pos - r.width / 2;
+                var c = GUI.color;
+                GUI.color = Color.yellow;
+                EditorGUI.LabelField(r, m_Uncached, EditorStyles.miniLabel);
+                GUI.color = c;
+            }
         }
     }
 }
-
-
 #endif

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -1,19 +1,14 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
 #if CINEMACHINE_TIMELINE
 
 using UnityEditor;
 using UnityEngine;
-using Cinemachine.Editor;
 using System.Collections.Generic;
 using UnityEditor.Timeline;
-using Cinemachine;
 
-//namespace Cinemachine.Timeline
-//{
+namespace Cinemachine.Editor
+{
     [CustomEditor(typeof(CinemachineShot))]
-    internal sealed class CinemachineShotEditor : BaseEditor<CinemachineShot>
+    sealed class CinemachineShotEditor : BaseEditor<CinemachineShot>
     {
         static string kAutoCreateKey = "CM_Timeline_AutoCreateShotFromSceneView";
         public static bool AutoCreateShotFromSceneView
@@ -26,7 +21,6 @@ using Cinemachine;
             }
         }
 
-#if UNITY_2019_2_OR_NEWER
         static string kUseScrubbingCache = "CNMCN_Timeline_CachedScrubbing";
         public static bool UseScrubbingCache
         {
@@ -49,7 +43,6 @@ using Cinemachine;
                 TargetPositionCache.UseCache = UseScrubbingCache;
             }
         }
-#endif
 
         public static CinemachineVirtualCameraBase CreatePassiveVcamFromSceneView()
         {
@@ -67,21 +60,19 @@ using Cinemachine;
             return vcam;
         }
 
-        private static readonly GUIContent kVirtualCameraLabel
+        static readonly GUIContent kVirtualCameraLabel
             = new GUIContent("Virtual Camera", "The virtual camera to use for this shot");
-        private static readonly GUIContent kAutoCreateLabel = new GUIContent(
+        static readonly GUIContent kAutoCreateLabel = new GUIContent(
             "Auto-create new shots",  "When enabled, new clips will be "
                 + "automatically populated to match the scene view camera.  "
                 + "This is a global setting");
-#if UNITY_2019_2_OR_NEWER
-        private static readonly GUIContent kScrubbingCacheLabel = new GUIContent(
+        static readonly GUIContent kScrubbingCacheLabel = new GUIContent(
             "Cached Scrubbing",
             "For preview scrubbing, caches target positions and pre-simulates each frame to "
                 + "approximate damping and noise playback.  Target position cache is built when timeline is "
                 + "played forward, and used when timeline is scrubbed within the indicated zone. "
                 + "This is a global setting,.");
         GUIContent m_ClearText = new GUIContent("Clear", "Clear the target position scrubbing cache");
-#endif
 
         /// <summary>Get the property names to exclude in the inspector.</summary>
         /// <param name="excluded">Add the names to this list</param>
@@ -91,12 +82,12 @@ using Cinemachine;
             excluded.Add(FieldPath(x => x.VirtualCamera));
         }
 
-        private void OnDisable()
+        void OnDisable()
         {
             DestroyComponentEditors();
         }
 
-        private void OnDestroy()
+        void OnDestroy()
         {
             DestroyComponentEditors();
         }
@@ -111,7 +102,6 @@ using Cinemachine;
                 = EditorGUILayout.Toggle(kAutoCreateLabel, AutoCreateShotFromSceneView);
 
             Rect rect;
-#if UNITY_2019_2_OR_NEWER
             GUI.enabled = !Application.isPlaying;
             rect = EditorGUILayout.GetControlRect();
             var r = rect;
@@ -129,7 +119,6 @@ using Cinemachine;
             if (GUI.Button(r, m_ClearText))
                 TargetPositionCache.ClearCache();
             GUI.enabled = true;
-#endif
 
             EditorGUILayout.Space();
             CinemachineVirtualCameraBase vcam
@@ -199,7 +188,7 @@ using Cinemachine;
 
         CinemachineVirtualCameraBase m_cachedReferenceObject;
         UnityEditor.Editor[] m_editors = null;
-        static Dictionary<System.Type, bool> s_EditorExpanded = new Dictionary<System.Type, bool>();
+        static Dictionary<System.Type, bool> s_EditorExpanded = new();
 
         void UpdateComponentEditors(CinemachineVirtualCameraBase obj)
         {
@@ -237,5 +226,5 @@ using Cinemachine;
             }
         }
     }
-//}
+}
 #endif

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -523,7 +523,8 @@ namespace Cinemachine.Editor
 
             void Initialize(List<PlayableDirector> playableDirectors)
             {
-                m_CmShotsToUpdate = new Dictionary<PlayableDirector, List<CinemachineShot>>();
+                m_CmShotsToUpdate = new ();
+
                 // collect all cmShots that may require a reference update
                 foreach (var playableDirector in playableDirectors)
                 {

--- a/com.unity.cinemachine/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -49,12 +49,12 @@ namespace Cinemachine
         /// from state.ReferenceLookAt due to camera offset from player origin.</summary>
         public Vector3 AimTarget { get; private set; }
 
-        private void OnValidate()
+        void OnValidate()
         {
             AimDistance = Mathf.Max(1, AimDistance);
         }
 
-        private void Reset()
+        void Reset()
         {
             AimCollisionFilter = 1;
             IgnoreTag = string.Empty;
@@ -125,24 +125,31 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (stage == CinemachineCore.Stage.Body)
+            switch (stage)
             {
-                // Raycast to establish what we're actually aiming at
-                var player = vcam.Follow;
-                if (player != null)
+                case CinemachineCore.Stage.Body:
                 {
-                    state.ReferenceLookAt = ComputeLookAtPoint(state.CorrectedPosition, player);
-                    AimTarget = ComputeAimTarget(state.ReferenceLookAt, player);
+                    // Raycast to establish what we're actually aiming at
+                    var player = vcam.Follow;
+                    if (player != null)
+                    {
+                        state.ReferenceLookAt = ComputeLookAtPoint(state.CorrectedPosition, player);
+                        AimTarget = ComputeAimTarget(state.ReferenceLookAt, player);
+                    }
+
+                    break;
                 }
-            }
-            if (stage == CinemachineCore.Stage.Finalize)
-            {
-                // Stabilize the LookAt point in the center of the screen
-                var dir = state.ReferenceLookAt - state.FinalPosition;
-                if (dir.sqrMagnitude > 0.01f)
+                case CinemachineCore.Stage.Finalize:
                 {
-                    state.RawOrientation = Quaternion.LookRotation(dir, state.ReferenceUp);
-                    state.OrientationCorrection = Quaternion.identity;
+                    // Stabilize the LookAt point in the center of the screen
+                    var dir = state.ReferenceLookAt - state.FinalPosition;
+                    if (dir.sqrMagnitude > 0.01f)
+                    {
+                        state.RawOrientation = Quaternion.LookRotation(dir, state.ReferenceUp);
+                        state.OrientationCorrection = Quaternion.identity;
+                    }
+
+                    break;
                 }
             }
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -707,7 +707,7 @@ namespace Cinemachine
         }
 
         ICinemachineCamera mActiveCameraPreviousFrame;
-        GameObject mActiveCameraPreviousFrameGameObject;
+        CinemachineVirtualCameraBase mActiveCameraPreviousFrameGameObject;
 
         private void ProcessActiveCamera(float deltaTime)
         {
@@ -759,8 +759,7 @@ namespace Cinemachine
                 PushStateToUnityCamera(ref state);
             }
             mActiveCameraPreviousFrame = activeCamera;
-            mActiveCameraPreviousFrameGameObject 
-                = activeCamera == null ? null : activeCamera.VirtualCameraGameObject;
+            mActiveCameraPreviousFrameGameObject = activeCamera as CinemachineVirtualCameraBase;
         }
 
         private void UpdateFrame0(float deltaTime)

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
@@ -99,7 +99,7 @@ namespace Cinemachine
 
         /// <summary>Get the current "best" child virtual camera, that would be chosen
         /// if the ClearShot camera were active.</summary>
-        public ICinemachineCamera LiveChild { get; set; }
+        public CinemachineVirtualCameraBase LiveChild { get; set; }
 
         /// <summary>The CameraState of the currently live child</summary>
         public override CameraState State { get { return m_State; } }
@@ -275,7 +275,7 @@ namespace Cinemachine
 
         float mActivationTime = 0;
         float mPendingActivationTime = 0;
-        ICinemachineCamera mPendingCamera;
+        CinemachineVirtualCameraBase mPendingCamera;
         private CinemachineBlend mActiveBlend = null;
 
         void InvalidateListOfChildren()
@@ -315,7 +315,7 @@ namespace Cinemachine
         private bool mRandomizeNow = false;
         private  CinemachineVirtualCameraBase[] m_RandomizedChilden = null;
 
-        private ICinemachineCamera ChooseCurrentCamera(Vector3 worldUp)
+        private CinemachineVirtualCameraBase ChooseCurrentCamera(Vector3 worldUp)
         {
             if (m_ChildCameras == null || m_ChildCameras.Length == 0)
             {
@@ -333,9 +333,9 @@ namespace Cinemachine
                 childCameras = m_RandomizedChilden;
             }
 
-            if (LiveChild != null && !LiveChild.VirtualCameraGameObject.activeSelf)
+            if (LiveChild != null && !LiveChild.gameObject.activeSelf)
                 LiveChild = null;
-            ICinemachineCamera best = LiveChild;
+            var best = LiveChild;
             for (int i = 0; i < childCameras.Length; ++i)
             {
                 CinemachineVirtualCameraBase vcam = childCameras[i];
@@ -345,7 +345,7 @@ namespace Cinemachine
                     if (best == null
                         || vcam.State.ShotQuality > best.State.ShotQuality
                         || (vcam.State.ShotQuality == best.State.ShotQuality && vcam.Priority > best.Priority)
-                        || (m_RandomizeChoice && mRandomizeNow && (ICinemachineCamera)vcam != LiveChild
+                        || (m_RandomizeChoice && mRandomizeNow && vcam != LiveChild
                             && vcam.State.ShotQuality == best.State.ShotQuality
                             && vcam.Priority == best.Priority))
                     {

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -266,11 +266,9 @@ namespace Cinemachine
 
         public string Name { get; private set; }
         public string Description { get { return ""; }}
-        public int Priority { get; set; }
         public Transform LookAt { get; set; }
         public Transform Follow { get; set; }
         public CameraState State { get; private set; }
-        public GameObject VirtualCameraGameObject { get { return null; } }
         public bool IsValid { get { return true; } }
         public ICinemachineCamera ParentCamera { get { return null; } }
         public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) { return false; }
@@ -292,11 +290,9 @@ namespace Cinemachine
 
         public string Name { get { return "Mid-blend"; }}
         public string Description { get { return Blend == null ? "(null)" : Blend.Description; }}
-        public int Priority { get; set; }
         public Transform LookAt { get; set; }
         public Transform Follow { get; set; }
         public CameraState State { get; private set; }
-        public GameObject VirtualCameraGameObject { get { return null; } }
         public bool IsValid { get { return Blend != null && Blend.IsValid; } }
         public ICinemachineCamera ParentCamera { get { return null; } }
         public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false)

--- a/com.unity.cinemachine/Runtime/Core/ICinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Core/ICinemachineCamera.cs
@@ -19,13 +19,6 @@ namespace Cinemachine
         string Description { get; }
 
         /// <summary>
-        /// Gets the priority of this <c>ICinemachineCamera</c>. The virtual camera
-        /// will be inserted into the global priority stack based on this value.
-        /// </summary>
-        // GML TODO: Delete this
-        int Priority { get; set; }
-
-        /// <summary>
         /// The thing the camera wants to look at (aim).  May be null.
         /// </summary>
         Transform LookAt { get; set; }
@@ -39,12 +32,6 @@ namespace Cinemachine
         /// Camera state at the current time.
         /// </summary>
         CameraState State { get; }
-
-        /// <summary>
-        /// Gets the virtual camera game attached to this class.
-        /// </summary>
-        // GML TODO: Delete this
-        GameObject VirtualCameraGameObject { get; }
 
         /// <summary>
         /// Will return false if this references a deleted object

--- a/com.unity.cinemachine/Runtime/Core/TargetPositionCache.cs
+++ b/com.unity.cinemachine/Runtime/Core/TargetPositionCache.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using System.Collections.Generic;
-using System;
 
 namespace Cinemachine
 {

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.Serialization;
 #if CINEMACHINE_POST_PROCESSING_V2
 using System.Collections.Generic;
 using UnityEngine.Rendering.PostProcessing;
@@ -8,7 +9,6 @@ using UnityEngine.Rendering.PostProcessing;
 namespace Cinemachine.PostFX
 {
 #if !CINEMACHINE_POST_PROCESSING_V2
-    // Workaround for Unity scripting bug
     /// <summary>
     /// This behaviour is a liaison between Cinemachine with the Post-Processing v2 module.  You must
     /// have the Post-Processing V2 stack package installed in order to use this behaviour.
@@ -59,10 +59,6 @@ namespace Cinemachine.PostFX
         /// </summary>
         public static float s_VolumePriority = 1000f;
 
-        /// <summary>This is obsolete, please use m_FocusTracking</summary>
-        [HideInInspector]
-        public bool m_FocusTracksTarget;
-
         /// <summary>The reference object for focus tracking</summary>
         public enum FocusTrackingMode
         {
@@ -84,27 +80,35 @@ namespace Cinemachine.PostFX
         [Tooltip("If the profile has the appropriate overrides, will set the base focus "
             + "distance to be the distance from the selected target to the camera."
             + "The Focus Offset field will then modify that distance.")]
-        public FocusTrackingMode m_FocusTracking;
+         [FormerlySerializedAs("m_FocusTracking")]
+         public FocusTrackingMode FocusTracking;
 
         /// <summary>The target to use if Focus Tracks Target is set to Custom Target</summary>
         [Tooltip("The target to use if Focus Tracks Target is set to Custom Target")]
-        public Transform m_FocusTarget;
+        [FormerlySerializedAs("m_FocusTarget")]
+        public Transform FocusTarget;
 
         /// <summary>Offset from target distance, to be used with Focus Tracks Target.  
         /// Offsets the sharpest point away from the location of the focus target</summary>
         [Tooltip("Offset from target distance, to be used with Focus Tracks Target.  "
             + "Offsets the sharpest point away from the location of the focus target.")]
-        public float m_FocusOffset;
+        [FormerlySerializedAs("m_FocusOffset")]
+        public float FocusOffset;
 
         /// <summary>
         /// This Post-Processing profile will be applied whenever this virtual camera is live
         /// </summary>
         [Tooltip("This Post-Processing profile will be applied whenever this virtual camera is live")]
-        public PostProcessProfile m_Profile;
+        [FormerlySerializedAs("m_Profile")]
+        public PostProcessProfile Profile;
 
+        /// <summary>Legacy support for obsolete format</summary>
+        [HideInInspector, SerializeField, FormerlySerializedAs("m_FocusTracksTarget")]
+        bool m_LegacyFocusTracksTarget;
+       
         class VcamExtraState
         {
-            public PostProcessProfile mProfileCopy;
+            public PostProcessProfile ProfileCopy;
 
             public void CreateProfileCopy(PostProcessProfile source)
             {
@@ -118,19 +122,19 @@ namespace Cinemachine.PostFX
                         profile.settings.Add(itemCopy);
                     }
                 }
-                mProfileCopy = profile;
+                ProfileCopy = profile;
             }
 
             public void DestroyProfileCopy()
             {
-                if (mProfileCopy != null)
-                    RuntimeUtility.DestroyObject(mProfileCopy);
-                mProfileCopy = null;
+                if (ProfileCopy != null)
+                    RuntimeUtility.DestroyObject(ProfileCopy);
+                ProfileCopy = null;
             }
         }
 
         /// <summary>True if the profile is enabled and nontrivial</summary>
-        public bool IsValid { get { return m_Profile != null && m_Profile.settings.Count > 0; } }
+        public bool IsValid => Profile != null && Profile.settings.Count > 0;
 
         /// <summary>Called by the editor when the shared asset has been edited</summary>
         public void InvalidateCachedProfile()
@@ -145,12 +149,12 @@ namespace Cinemachine.PostFX
             base.OnEnable();
 
             // Map legacy m_FocusTracksTarget to focus mode
-            if (m_FocusTracksTarget)
+            if (m_LegacyFocusTracksTarget)
             {
-                m_FocusTracking = VirtualCamera.LookAt != null 
+                FocusTracking = VirtualCamera.LookAt != null 
                     ? FocusTrackingMode.LookAtTarget : FocusTrackingMode.Camera;
             }
-            m_FocusTracksTarget = false;
+            m_LegacyFocusTracksTarget = false;
         }
 
         protected override void OnDestroy()
@@ -176,30 +180,30 @@ namespace Cinemachine.PostFX
                     extra.DestroyProfileCopy();
                 else
                 {
-                    var profile = m_Profile;
+                    var profile = Profile;
 
                     // Handle Follow Focus
-                    if (m_FocusTracking == FocusTrackingMode.None)
+                    if (FocusTracking == FocusTrackingMode.None)
                         extra.DestroyProfileCopy();
                     else
                     {
-                        if (extra.mProfileCopy == null)
-                            extra.CreateProfileCopy(m_Profile);
-                        profile = extra.mProfileCopy;
+                        if (extra.ProfileCopy == null)
+                            extra.CreateProfileCopy(Profile);
+                        profile = extra.ProfileCopy;
                         DepthOfField dof;
                         if (profile.TryGetSettings(out dof))
                         {
-                            float focusDistance = m_FocusOffset;
-                            if (m_FocusTracking == FocusTrackingMode.LookAtTarget)
+                            float focusDistance = FocusOffset;
+                            if (FocusTracking == FocusTrackingMode.LookAtTarget)
                                 focusDistance += (state.FinalPosition - state.ReferenceLookAt).magnitude;
                             else
                             {
                                 Transform focusTarget = null;
-                                switch (m_FocusTracking)
+                                switch (FocusTracking)
                                 {
                                     default: break;
                                     case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
-                                    case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                    case FocusTrackingMode.CustomTarget: focusTarget = FocusTarget; break;
                                 }
                                 if (focusTarget != null)
                                     focusDistance += (state.FinalPosition - focusTarget.position).magnitude;

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -3,8 +3,9 @@
 #if CINEMACHINE_HDRP
     using System.Collections.Generic;
     using UnityEngine.Rendering;
-    #if CINEMACHINE_HDRP_7_3_1
-        using UnityEngine.Rendering.HighDefinition;
+using UnityEngine.Serialization;
+#if CINEMACHINE_HDRP_7_3_1
+using UnityEngine.Rendering.HighDefinition;
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
@@ -53,11 +54,7 @@ namespace Cinemachine.PostFX
         /// number in order to ensure that it overrides other volumes for the active vcam.
         /// You can change this value if necessary to work with other systems.
         /// </summary>
-        static public static float s_VolumePriority = 1000f;
-
-        /// <summary>This is obsolete, please use m_FocusTracking</summary>
-        [HideInInspector]
-        public bool m_FocusTracksTarget;
+        static public float s_VolumePriority = 1000f;
 
         /// <summary>The reference object for focus tracking</summary>
         public enum FocusTrackingMode
@@ -80,27 +77,35 @@ namespace Cinemachine.PostFX
         [Tooltip("If the profile has the appropriate overrides, will set the base focus "
             + "distance to be the distance from the selected target to the camera."
             + "The Focus Offset field will then modify that distance.")]
-        public FocusTrackingMode m_FocusTracking;
+        [FormerlySerializedAs("m_FocusTracking")]
+        public FocusTrackingMode FocusTracking;
 
         /// <summary>The target to use if Focus Tracks Target is set to Custom Target</summary>
         [Tooltip("The target to use if Focus Tracks Target is set to Custom Target")]
-        public Transform m_FocusTarget;
+        [FormerlySerializedAs("m_FocusTarget")]
+        public Transform FocusTarget;
 
         /// <summary>Offset from target distance, to be used with Focus Tracks Target.  
         /// Offsets the sharpest point away from the focus target</summary>
         [Tooltip("Offset from target distance, to be used with Focus Tracks Target.  "
             + "Offsets the sharpest point away from the focus target.")]
-        public float m_FocusOffset;
+        [FormerlySerializedAs("m_FocusOffset")]
+        public float FocusOffset;
 
         /// <summary>
         /// This profile will be applied whenever this virtual camera is live
         /// </summary>
         [Tooltip("This profile will be applied whenever this virtual camera is live")]
-        public VolumeProfile m_Profile;
+        [FormerlySerializedAs("m_Profile")]
+        public VolumeProfile Profile;
+
+        /// <summary>This is obsolete, please use m_FocusTracking</summary>
+        [HideInInspector, SerializeField, FormerlySerializedAs("m_FocusTracksTarget")]
+        bool m_LegacyFocusTracksTarget;
 
         class VcamExtraState
         {
-            public VolumeProfile mProfileCopy;
+            public VolumeProfile ProfileCopy;
 
             public void CreateProfileCopy(VolumeProfile source)
             {
@@ -115,19 +120,19 @@ namespace Cinemachine.PostFX
                         profile.isDirty = true;
                     }
                 }
-                mProfileCopy = profile;
+                ProfileCopy = profile;
             }
 
             public void DestroyProfileCopy()
             {
-                if (mProfileCopy != null)
-                    RuntimeUtility.DestroyObject(mProfileCopy);
-                mProfileCopy = null;
+                if (ProfileCopy != null)
+                    RuntimeUtility.DestroyObject(ProfileCopy);
+                ProfileCopy = null;
             }
         }
 
         /// <summary>True if the profile is enabled and nontrivial</summary>
-        public bool IsValid { get { return m_Profile != null && m_Profile.components.Count > 0; } }
+        public bool IsValid => Profile != null && Profile.components.Count > 0;
 
         /// <summary>Called by the editor when the shared asset has been edited</summary>
         public void InvalidateCachedProfile()
@@ -142,12 +147,12 @@ namespace Cinemachine.PostFX
             base.OnEnable();
 
             // Map legacy m_FocusTracksTarget to focus mode
-            if (m_FocusTracksTarget)
+            if (m_LegacyFocusTracksTarget)
             {
-                m_FocusTracking = VirtualCamera.LookAt != null 
+                FocusTracking = VirtualCamera.LookAt != null 
                     ? FocusTrackingMode.LookAtTarget : FocusTrackingMode.Camera;
             }
-            m_FocusTracksTarget = false;
+            m_LegacyFocusTracksTarget = false;
         }
 
         protected override void OnDestroy()
@@ -173,29 +178,29 @@ namespace Cinemachine.PostFX
                     extra.DestroyProfileCopy();
                 else
                 {
-                    var profile = m_Profile;
+                    var profile = Profile;
 
                     // Handle Follow Focus
-                    if (m_FocusTracking == FocusTrackingMode.None)
+                    if (FocusTracking == FocusTrackingMode.None)
                         extra.DestroyProfileCopy();
                     else
                     {
-                        if (extra.mProfileCopy == null)
-                            extra.CreateProfileCopy(m_Profile);
-                        profile = extra.mProfileCopy;
+                        if (extra.ProfileCopy == null)
+                            extra.CreateProfileCopy(Profile);
+                        profile = extra.ProfileCopy;
                         if (profile.TryGet(out DepthOfField dof))
                         {
-                            float focusDistance = m_FocusOffset;
-                            if (m_FocusTracking == FocusTrackingMode.LookAtTarget)
+                            float focusDistance = FocusOffset;
+                            if (FocusTracking == FocusTrackingMode.LookAtTarget)
                                 focusDistance += (state.FinalPosition - state.ReferenceLookAt).magnitude;
                             else
                             {
                                 Transform focusTarget = null;
-                                switch (m_FocusTracking)
+                                switch (FocusTracking)
                                 {
                                     default: break;
                                     case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
-                                    case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                    case FocusTrackingMode.CustomTarget: focusTarget = FocusTarget; break;
                                 }
                                 if (focusTarget != null)
                                     focusDistance += (state.FinalPosition - focusTarget.position).magnitude;

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -54,7 +54,7 @@ namespace Cinemachine.PostFX
         /// number in order to ensure that it overrides other volumes for the active vcam.
         /// You can change this value if necessary to work with other systems.
         /// </summary>
-        static public float s_VolumePriority = 1000f;
+        public static float s_VolumePriority = 1000f;
 
         /// <summary>The reference object for focus tracking</summary>
         public enum FocusTrackingMode
@@ -285,7 +285,7 @@ namespace Cinemachine.PostFX
         }
 
         static string sVolumeOwnerName = "__CMVolumes";
-        static  List<Volume> sVolumes = new List<Volume>();
+        static List<Volume> sVolumes = new List<Volume>();
         static List<Volume> GetDynamicBrainVolumes(CinemachineBrain brain, int minVolumes)
         {
             // Locate the camera's child object that holds our dynamic volumes
@@ -346,7 +346,7 @@ namespace Cinemachine.PostFX
         [RuntimeInitializeOnLoadMethod]
         static void InitializeModule()
         {
-            // Afetr the brain pushes the state to the camera, hook in to the PostFX
+            // After the brain pushes the state to the camera, hook in to the PostFX
             CinemachineCore.CameraUpdatedEvent.RemoveListener(ApplyPostFX);
             CinemachineCore.CameraUpdatedEvent.AddListener(ApplyPostFX);
             CinemachineCore.CameraCutEvent.RemoveListener(OnCameraCut);

--- a/com.unity.cinemachine/Runtime/Timeline/CinemachineMixer.cs
+++ b/com.unity.cinemachine/Runtime/Timeline/CinemachineMixer.cs
@@ -1,16 +1,11 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
 #if CINEMACHINE_TIMELINE
 
 using UnityEngine;
 using UnityEngine.Playables;
-using Cinemachine;
 using System.Collections.Generic;
 
-//namespace Cinemachine.Timeline
-//{
-
+namespace Cinemachine
+{
     internal sealed class CinemachineMixer : PlayableBehaviour
     {
         public delegate PlayableDirector MasterDirectorDelegate();
@@ -18,11 +13,11 @@ using System.Collections.Generic;
         public static MasterDirectorDelegate GetMasterPlayableDirector;
 
         // The brain that this track controls
-        private ICameraOverrideStack m_BrainOverrideStack;
-        private int m_BrainOverrideId = -1;
-        private bool m_PreviewPlay;
+        ICameraOverrideStack m_BrainOverrideStack;
+        int m_BrainOverrideId = -1;
+        bool m_PreviewPlay;
 
-#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+#if UNITY_EDITOR
         class ScrubbingCacheHelper
         {
             // Remember the active clips of the previous frame so we can track camera cuts
@@ -137,7 +132,7 @@ using System.Collections.Generic;
         ScrubbingCacheHelper m_ScrubbingCacheHelper;
 #endif
 
-#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+#if UNITY_EDITOR
         public override void OnGraphStart(Playable playable)
         {
             base.OnGraphStart(playable);
@@ -150,7 +145,7 @@ using System.Collections.Generic;
             if (m_BrainOverrideStack != null)
                 m_BrainOverrideStack.ReleaseCameraOverride(m_BrainOverrideId); // clean up
             m_BrainOverrideId = -1;
-#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+#if UNITY_EDITOR
             m_ScrubbingCacheHelper = null;
 #endif
         }
@@ -158,7 +153,7 @@ using System.Collections.Generic;
         public override void PrepareFrame(Playable playable, FrameData info)
         {
             m_PreviewPlay = false;
-#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+#if UNITY_EDITOR
             var cacheMode = TargetPositionCache.Mode.Disabled;
             if (!Application.isPlaying)
             {
@@ -257,7 +252,7 @@ using System.Collections.Generic;
             m_BrainOverrideId = m_BrainOverrideStack.SetCameraOverride(
                 m_BrainOverrideId, camA, camB, weightB, GetDeltaTime(info.deltaTime));
 
-#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+#if UNITY_EDITOR
             if (m_ScrubbingCacheHelper != null && TargetPositionCache.CacheMode != TargetPositionCache.Mode.Disabled)
             {
                 bool isNewB = (m_ScrubbingCacheHelper.ActivePlayableA != clipIndexB 
@@ -291,5 +286,5 @@ using System.Collections.Generic;
             return -1;
         }
     }
-//}
+}
 #endif

--- a/com.unity.cinemachine/Runtime/Timeline/CinemachineShot.cs
+++ b/com.unity.cinemachine/Runtime/Timeline/CinemachineShot.cs
@@ -1,24 +1,17 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
 #if CINEMACHINE_TIMELINE
 
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
-using Cinemachine;
 
-//namespace Cinemachine.Timeline
-//{
+namespace Cinemachine
+{
     /// <summary>
     /// Internal use only.  Not part of the public API.
     /// </summary>
     public sealed class CinemachineShot : PlayableAsset, IPropertyPreview
     {
         /// <summary>The name to display on the track</summary>
-#if !UNITY_2019_2_OR_NEWER
-        [HideInInspector]
-#endif
         public string DisplayName;
 
         /// <summary>The virtual camera to activate</summary>
@@ -53,5 +46,5 @@ using Cinemachine;
             driver.AddFromName<Camera>("far clip plane");
         }
     }
-//}
+}
 #endif

--- a/com.unity.cinemachine/Runtime/Timeline/CinemachineShotPlayable.cs
+++ b/com.unity.cinemachine/Runtime/Timeline/CinemachineShotPlayable.cs
@@ -1,17 +1,13 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
 #if CINEMACHINE_TIMELINE
 
 using UnityEngine.Playables;
-using Cinemachine;
 
-//namespace Cinemachine.Timeline
-//{
+namespace Cinemachine
+{
     internal sealed class CinemachineShotPlayable : PlayableBehaviour
     {
         public CinemachineVirtualCameraBase VirtualCamera;
-        public bool IsValid { get { return VirtualCamera != null; } }
+        public bool IsValid => VirtualCamera != null;
     }
-//}
+}
 #endif

--- a/com.unity.cinemachine/Runtime/Timeline/CinemachineTrack.cs
+++ b/com.unity.cinemachine/Runtime/Timeline/CinemachineTrack.cs
@@ -1,16 +1,12 @@
-#if !UNITY_2019_1_OR_NEWER
-#define CINEMACHINE_TIMELINE
-#endif
 #if CINEMACHINE_TIMELINE
 
 using System;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
-using Cinemachine;
 
-//namespace Cinemachine.Timeline
-//{
+namespace Cinemachine
+{
     /// <summary>
     /// Timeline track for Cinemachine virtual camera activation
     /// </summary>
@@ -30,20 +26,10 @@ using Cinemachine;
         public override Playable CreateTrackMixer(
             PlayableGraph graph, GameObject go, int inputCount)
         {
-#if !UNITY_2019_2_OR_NEWER
-            // Hack to set the display name of the clip to match the vcam
-            foreach (var c in GetClips())
-            {
-                CinemachineShot shot = (CinemachineShot)c.asset;
-                CinemachineVirtualCameraBase vcam = shot.VirtualCamera.Resolve(graph.GetResolver());
-                if (vcam != null)
-                    c.displayName = vcam.Name;
-            }
-#endif
             var mixer = ScriptPlayable<CinemachineMixer>.Create(graph);
             mixer.SetInputCount(inputCount);
             return mixer;
         }
     }
-//}
+}
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-1066: Cleanup more API
- Remove ICinemachineCamera.Priority accessor
- Remove ICinemachineCamera.VirtualCameraGameObject accessor
- CinemachinePostProcessing m_ fixup members
- CinemachineVolumeSettings m_ fixup members
- All CM Timeline code moved into Cinemachine and Cinemachine.Editor namespaces

This PR was also meant to include the 9611dc84 commit, which was accidentally pushed to master
