### PR TITLE
CMCL-1080: Update timeline references

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -91,7 +91,7 @@ namespace Cinemachine.Editor
             for (var s = 0; s < m_SceneManager.SceneCount; ++s)
             {
                 var scene = OpenScene(s);
-                var directors = TimelineManager.GetPlayableDirector(scene);
+                var directors = TimelineManager.GetPlayableDirectors(scene);
                 foreach (var director in directors)
                 {
                     var rename = new TimelineRename
@@ -111,7 +111,7 @@ namespace Cinemachine.Editor
             for (var s = 0; s < m_SceneManager.SceneCount; ++s)
             {
                 var scene = OpenScene(s);
-                var directors = TimelineManager.GetPlayableDirector(scene);
+                var directors = TimelineManager.GetPlayableDirectors(scene);
                 foreach (var director in directors)
                 {
                     for (var i = 0; i < renames.Count; ++i)
@@ -567,10 +567,10 @@ namespace Cinemachine.Editor
 
             public TimelineManager(Scene scene)
             {
-                Initialize(GetPlayableDirector(scene));
+                Initialize(GetPlayableDirectors(scene));
             }
             
-            public static List<PlayableDirector> GetPlayableDirector(Scene scene)
+            public static List<PlayableDirector> GetPlayableDirectors(Scene scene)
             {
                 var playableDirectors = new List<PlayableDirector>();
 

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgrader.cs
@@ -85,28 +85,26 @@ namespace Cinemachine.Editor
         /// We need to be able to tell timelines apart, and their name may not be unique. So we make them
         /// unique here, and restore their original name when we are done with RestoreTimelineNames().
         /// </summary>
-        void MakeTimelineNamesUnique(out List<TimelineRename> renames)
+        /// <param name="renames">Dictionary, Key = GUID name generated, Value = original name</param>
+        void MakeTimelineNamesUnique(out Dictionary<string, string> renames)
         {
-            renames = new List<TimelineRename>();
+            renames = new Dictionary<string, string>();
             for (var s = 0; s < m_SceneManager.SceneCount; ++s)
             {
                 var scene = OpenScene(s);
                 var directors = TimelineManager.GetPlayableDirectors(scene);
                 foreach (var director in directors)
                 {
-                    var rename = new TimelineRename
-                    {
-                        original = director.name,
-                        guid = director.name = GUID.Generate().ToString()
-                    };
-                    renames.Add(rename);
+                    var originalName = director.name;
+                    director.name = GUID.Generate().ToString();
+                    renames.Add(director.name, originalName); // key = guid, value = originalName
                 }
                 EditorSceneManager.SaveScene(scene);
             }
         }
         
         
-        void RestoreTimelineNames(List<TimelineRename> renames)
+        void RestoreTimelineNames(Dictionary<string, string> renames)
         {
             for (var s = 0; s < m_SceneManager.SceneCount; ++s)
             {
@@ -114,14 +112,9 @@ namespace Cinemachine.Editor
                 var directors = TimelineManager.GetPlayableDirectors(scene);
                 foreach (var director in directors)
                 {
-                    for (var i = 0; i < renames.Count; ++i)
+                    if (renames.ContainsKey(director.name)) // search based on guid name
                     {
-                        if (director.name == renames[i].guid)
-                        {
-                            director.name = renames[i].original;
-                            renames.RemoveAt(i);
-                            break;
-                        }
+                        director.name = renames[director.name]; // restore director name
                     }
                 }
                 EditorSceneManager.SaveScene(scene);


### PR DESCRIPTION
### Purpose of this PR
CMCL-1080

Timeline references were not updated correctly, because ExposedReferences values could be the same for different PlayableDirectors. ExposedReferences are only unique when paired with their PlayableDirector. 

I am thinking about using the strategy used here for ConversionLink:
`manager.MakeTimelineNamesUnique(out var renames);  ` 
--> Make all vcams, prefabs, prefabInstances unique at start -> then we can just use their name -> Then restore names at the end.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status
### Technical risk
### Comments to reviewers
### Package version
- [ ] Updated package version
