### PR TITLE
CMCL-582: Add IShotQualityEvaluator

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added customizable Auto Dolly to cameras and Spline Cart.
 - Bugfix: No redundant RepaintAllViews calls.
 - Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.
+- Added IShotQualityEvaluator to enable customization of shot quality evaluation for ClearShot
 
 
 ## UNRELEASED

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using UnityEditor;
-using Cinemachine.Utility;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
@@ -124,7 +124,7 @@ namespace Cinemachine.Editor
 
         EvaluatorState GetEvaluatorState()
         {
-            var numEvaluatorChildren = 0;
+            int numEvaluatorChildren = 0;
             bool colliderOnParent = ObjectHasEvaluator(Target);
 
             var children = Target.ChildCameras;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
@@ -3,13 +3,12 @@ using UnityEngine;
 
 namespace Cinemachine.Editor
 {
-#if CINEMACHINE_PHYSICS
     [CustomEditor(typeof(CinemachineClearShot))]
     [CanEditMultipleObjects]
     class CinemachineClearShotEditor : CinemachineVirtualCameraBaseEditor<CinemachineClearShot>
     {
         EmbeddeAssetEditor<CinemachineBlenderSettings> m_BlendsEditor;
-        ColliderState m_ColliderState;
+        EvaluatorState m_EvaluatorState;
 
         private UnityEditorInternal.ReorderableList m_ChildList;
 
@@ -36,34 +35,47 @@ namespace Cinemachine.Editor
                 m_BlendsEditor.OnDisable();
         }
 
+
+        static string GetAvailableQualityEvaluatorNames()
+        {
+            var names = InspectorUtility.GetAssignableBehaviourNames(typeof(IShotQualityEvaluator));
+            if (names == InspectorUtility.s_NoneString)
+                return "Not Shot Quality Evaluator extensions are available.  This might be because the "
+                    + "physics module is disabled and all Shot Quality Evaluator implementations "
+                    + "depend on physics raycasts";
+            return "Available Shot Quality Evaluators are: " + names;
+        }
+
         public override void OnInspectorGUI()
         {
             BeginInspector();
             if (m_ChildList == null)
                 SetupChildList();
 
-            m_ColliderState = GetColliderState();
-            switch (m_ColliderState)
+            m_EvaluatorState = GetEvaluatorState();
+            switch (m_EvaluatorState)
             {
-                case ColliderState.ColliderOnParent:
-                case ColliderState.ColliderOnAllChildren:
+                case EvaluatorState.EvaluatorOnParent:
+                case EvaluatorState.EvaluatorOnAllChildren:
                     break;
-                case ColliderState.NoCollider:
+                case EvaluatorState.NoEvaluator:
                     EditorGUILayout.HelpBox(
-                        "ClearShot requires a Collider extension to rank the shots.  "
-                            + "Either add one to the ClearShot itself, or to each of the child cameras.",
+                        "ClearShot requires a Shot Quality Evaluator extension to rank the shots.  "
+                            + "Either add one to the ClearShot itself, or to each of the child cameras.  "
+                            + GetAvailableQualityEvaluatorNames(),
                         MessageType.Warning);
                     break;
-                case ColliderState.ColliderOnSomeChildren:
+                case EvaluatorState.EvaluatorOnSomeChildren:
                     EditorGUILayout.HelpBox(
-                        "Some child cameras do not have a Collider extension.  ClearShot requires a "
-                            + "Collider on all the child cameras, or alternatively on the ClearShot iself.",
+                        "Some child cameras do not have a Shot Quality Evaluator extension.  ClearShot requires a "
+                            + "Shot Quality Evaluator on all the child cameras, or alternatively on the ClearShot iself.  "
+                            + GetAvailableQualityEvaluatorNames(),
                         MessageType.Warning);
                     break;
-                case ColliderState.ColliderOnChildrenAndParent:
+                case EvaluatorState.EvaluatorOnChildrenAndParent:
                     EditorGUILayout.HelpBox(
-                        "There is a Collider extension on the ClearShot camera, and also on some "
-                            + "of its child cameras.  You can't have both.",
+                        "There is a Shot Quality Evaluator extension on the ClearShot camera, and also on some "
+                            + "of its child cameras.  You can't have both.  " + GetAvailableQualityEvaluatorNames(),
                         MessageType.Error);
                     break;
             }
@@ -101,39 +113,39 @@ namespace Cinemachine.Editor
             DrawExtensionsWidgetInInspector();
         }
 
-        enum ColliderState
+        enum EvaluatorState
         {
-            NoCollider,
-            ColliderOnAllChildren,
-            ColliderOnSomeChildren,
-            ColliderOnParent,
-            ColliderOnChildrenAndParent
+            NoEvaluator,
+            EvaluatorOnAllChildren,
+            EvaluatorOnSomeChildren,
+            EvaluatorOnParent,
+            EvaluatorOnChildrenAndParent
         }
 
-        ColliderState GetColliderState()
+        EvaluatorState GetEvaluatorState()
         {
-            int numColliderChildren = 0;
-            bool colliderOnParent = ObjectHasCollider(Target);
+            int numEvaluatorChildren = 0;
+            bool colliderOnParent = ObjectHasEvaluator(Target);
 
             var children = Target.ChildCameras;
             var numChildren = children == null ? 0 : children.Count;
             for (int i = 0; i < numChildren; ++i)
-                if (ObjectHasCollider(children[i]))
-                    ++numColliderChildren;
+                if (ObjectHasEvaluator(children[i]))
+                    ++numEvaluatorChildren;
             if (colliderOnParent)
-                return (numColliderChildren > 0)
-                    ? ColliderState.ColliderOnChildrenAndParent : ColliderState.ColliderOnParent;
-            if (numColliderChildren > 0)
-                return (numColliderChildren == numChildren)
-                    ? ColliderState.ColliderOnAllChildren : ColliderState.ColliderOnSomeChildren;
-            return ColliderState.NoCollider;
+                return (numEvaluatorChildren > 0)
+                    ? EvaluatorState.EvaluatorOnChildrenAndParent : EvaluatorState.EvaluatorOnParent;
+            if (numEvaluatorChildren > 0)
+                return (numEvaluatorChildren == numChildren)
+                    ? EvaluatorState.EvaluatorOnAllChildren : EvaluatorState.EvaluatorOnSomeChildren;
+            return EvaluatorState.NoEvaluator;
         }
 
-        bool ObjectHasCollider(object obj)
+        bool ObjectHasEvaluator(object obj)
         {
             CinemachineVirtualCameraBase vcam = obj as CinemachineVirtualCameraBase;
-            var collider = (vcam == null) ? null : vcam.GetComponent<CinemachineCollider>();
-            return (collider != null && collider.enabled);
+            var evaluatoe = (vcam == null) ? null : vcam.GetComponent<IShotQualityEvaluator>() as MonoBehaviour;
+            return (evaluatoe != null && evaluatoe.enabled);
         }
 
         void SetupChildList()
@@ -161,12 +173,12 @@ namespace Cinemachine.Editor
                     rect.width -= floatFieldWidth + hSpace;
                     rect.height = EditorGUIUtility.singleLineHeight;
                     SerializedProperty element = m_ChildList.serializedProperty.GetArrayElementAtIndex(index);
-                    if (m_ColliderState == ColliderState.ColliderOnSomeChildren
-                        || m_ColliderState == ColliderState.ColliderOnChildrenAndParent)
+                    if (m_EvaluatorState == EvaluatorState.EvaluatorOnSomeChildren
+                        || m_EvaluatorState == EvaluatorState.EvaluatorOnChildrenAndParent)
                     {
-                        bool hasCollider = ObjectHasCollider(element.objectReferenceValue);
-                        if ((m_ColliderState == ColliderState.ColliderOnSomeChildren && !hasCollider)
-                            || (m_ColliderState == ColliderState.ColliderOnChildrenAndParent && hasCollider))
+                        bool hasEvaluator = ObjectHasEvaluator(element.objectReferenceValue);
+                        if ((m_EvaluatorState == EvaluatorState.EvaluatorOnSomeChildren && !hasEvaluator)
+                            || (m_EvaluatorState == EvaluatorState.EvaluatorOnChildrenAndParent && hasEvaluator))
                         {
                             float width = rect.width;
                             rect.width = rect.height;
@@ -204,9 +216,6 @@ namespace Cinemachine.Editor
                 {
                     var index = l.serializedProperty.arraySize;
                     var vcam = CinemachineMenu.CreateDefaultVirtualCamera(parentObject: Target.gameObject);
-                    var collider = Undo.AddComponent<CinemachineCollider>(vcam.gameObject);
-                    collider.AvoidObstacles = false;
-                    Undo.RecordObject(collider, "create ClearShot child");
                     vcam.transform.SetSiblingIndex(index);
                 };
             m_ChildList.onRemoveCallback = (UnityEditorInternal.ReorderableList l) =>
@@ -220,5 +229,4 @@ namespace Cinemachine.Editor
                 };
         }
     }
-#endif
 }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
@@ -40,7 +40,7 @@ namespace Cinemachine.Editor
         {
             var names = InspectorUtility.GetAssignableBehaviourNames(typeof(IShotQualityEvaluator));
             if (names == InspectorUtility.s_NoneString)
-                return "Not Shot Quality Evaluator extensions are available.  This might be because the "
+                return "No Shot Quality Evaluator extensions are available.  This might be because the "
                     + "physics module is disabled and all Shot Quality Evaluator implementations "
                     + "depend on physics raycasts";
             return "Available Shot Quality Evaluators are: " + names;
@@ -124,28 +124,28 @@ namespace Cinemachine.Editor
 
         EvaluatorState GetEvaluatorState()
         {
-            int numEvaluatorChildren = 0;
+            var numEvaluatorChildren = 0;
             bool colliderOnParent = ObjectHasEvaluator(Target);
 
             var children = Target.ChildCameras;
             var numChildren = children == null ? 0 : children.Count;
-            for (int i = 0; i < numChildren; ++i)
+            for (var i = 0; i < numChildren; ++i)
                 if (ObjectHasEvaluator(children[i]))
                     ++numEvaluatorChildren;
             if (colliderOnParent)
-                return (numEvaluatorChildren > 0)
+                return numEvaluatorChildren > 0
                     ? EvaluatorState.EvaluatorOnChildrenAndParent : EvaluatorState.EvaluatorOnParent;
             if (numEvaluatorChildren > 0)
-                return (numEvaluatorChildren == numChildren)
+                return numEvaluatorChildren == numChildren
                     ? EvaluatorState.EvaluatorOnAllChildren : EvaluatorState.EvaluatorOnSomeChildren;
             return EvaluatorState.NoEvaluator;
         }
 
         bool ObjectHasEvaluator(object obj)
         {
-            CinemachineVirtualCameraBase vcam = obj as CinemachineVirtualCameraBase;
-            var evaluatoe = (vcam == null) ? null : vcam.GetComponent<IShotQualityEvaluator>() as MonoBehaviour;
-            return (evaluatoe != null && evaluatoe.enabled);
+            var vcam = obj as CinemachineVirtualCameraBase;
+            var evaluator = vcam == null ? null : vcam.GetComponent<IShotQualityEvaluator>() as MonoBehaviour;
+            return evaluator != null && evaluator.enabled;
         }
 
         void SetupChildList()

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -327,6 +327,7 @@ namespace Cinemachine.Editor
         }
 
         static Dictionary<Type, string> s_AssignableTypes = new Dictionary<Type, string>();
+        internal static string s_NoneString = "(none)";
         internal static string GetAssignableBehaviourNames(Type inputType)
         {
             if (!s_AssignableTypes.ContainsKey(inputType))
@@ -341,7 +342,7 @@ namespace Cinemachine.Editor
                     s += sep + t.Name;
                 }
                 if (s.Length == 0)
-                    s = "(none)";
+                    s = s_NoneString;
                 s_AssignableTypes[inputType] = s;
             }
             return s_AssignableTypes[inputType];

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -327,7 +327,8 @@ namespace Cinemachine.Editor
         }
 
         static Dictionary<Type, string> s_AssignableTypes = new Dictionary<Type, string>();
-        internal static string s_NoneString = "(none)";
+        internal const string s_NoneString = "(none)";
+
         internal static string GetAssignableBehaviourNames(Type inputType)
         {
             if (!s_AssignableTypes.ContainsKey(inputType))

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
@@ -4,7 +4,6 @@ using UnityEngine.Serialization;
 
 namespace Cinemachine
 {
-#if CINEMACHINE_PHYSICS
     /// <summary>
     /// Cinemachine ClearShot is a "manager camera" that owns and manages a set of
     /// Virtual Camera gameObject children.  When Live, the ClearShot will check the
@@ -335,5 +334,4 @@ namespace Cinemachine
             return blend;
         }
     }
-#endif
 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
@@ -23,7 +23,7 @@ namespace Cinemachine
     [ExecuteAlways]
     [DisallowMultipleComponent]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineCollider.html")]
-    public class CinemachineCollider : CinemachineExtension
+    public class CinemachineCollider : CinemachineExtension, IShotQualityEvaluator
     {
         /// <summary>Objects on these layers will be detected.</summary>
         [Header("Obstacle Detection")]

--- a/com.unity.cinemachine/Runtime/Core/IShotQualityEvaluator.cs
+++ b/com.unity.cinemachine/Runtime/Core/IShotQualityEvaluator.cs
@@ -1,0 +1,9 @@
+namespace Cinemachine
+{
+    /// <summary>
+    /// An abstract representation of a component that evaluates shot quality.
+    /// Component (usually a CinemachineExtension) is expected to set state.ShotQuality
+    /// late in the camera pipeline (after Aim).
+    /// </summary>
+    public interface IShotQualityEvaluator {}
+}

--- a/com.unity.cinemachine/Runtime/Core/IShotQualityEvaluator.cs.meta
+++ b/com.unity.cinemachine/Runtime/Core/IShotQualityEvaluator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ca693ed6c42a60448aa5e8970c46a736
+timeCreated: 1484407000
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

CMCL-582: Add IShotQualityEvaluator.
- Implemented by CinemachineCollider
- ClearShot no longer depends on UNITY_PHYSICS
- Possibility for alternate shot quality evaluation oimplementations (make a custom extension that implements IShotQualityEvaluator)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
