### PR TITLE
CMCL-1083: ReplaceComponent only replaces exact type matches

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectForCm3.cs
@@ -150,7 +150,7 @@ namespace Cinemachine.Editor
             where TOld : MonoBehaviour
             where TNew : MonoBehaviour
         {
-            if (go.TryGetComponent<TOld>(out var cOld))
+            if (go.TryGetComponent<TOld>(out var cOld) && cOld.GetType() == typeof(TOld))
             {
                 Undo.RecordObject(cOld, "Upgrader: disable obsolete");
                 cOld.enabled = false;


### PR DESCRIPTION
### Purpose of this PR
CMCL-1083 - ReplaceComponent only replaces exact type matches

### Testing status
- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested