### PR TITLE
CMCL-1120: NUnit dependency - testframework

### DIFF
--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -30,7 +30,8 @@
   ],
   "category": "cinematography",
   "dependencies": {
-    "com.unity.splines": "2.0.0-pre.2"
+    "com.unity.splines": "2.0.0-pre.2",
+    "com.unity.test-framework": "1.1.33"
   },
   "samples": [
     {


### PR DESCRIPTION
### Purpose of this PR
https://jira.unity3d.com/browse/CMCL-1120
- Forward-port from [2.9.0-prep](https://github.com/Unity-Technologies/com.unity.cinemachine/pull/511) branch. 
- This dependency is needed for isolation tests to not fail in editor versions 2022 and above, when promoting releases (just like https://github.com/Unity-Technologies/com.unity.cinemachine/pull/523).

### Testing status
- [ ] Added an automated test
- [x] Passed all automated tests
- [ ] Manually tested 

### Documentation status
- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Comments to reviewers
We could also make `com.unity.test-framework` an optional dependency  by adding #if CINEMACHINE_TESTFRAMEWORK to all our tests. Consequently disabling tests in isolation tests.