### PR TITLE
CMCL-1131: release prep for 2.6.17

### DIFF
--- a/.yamato/metadata.metafile
+++ b/.yamato/metadata.metafile
@@ -14,11 +14,11 @@ all_platforms:
 
 all_configurations:
   - name: integration_tests
-    editors: [2018.4, 2019.4, 2020.3, 2021.2, trunk]
+    editors: [2019.4, 2020.3, 2021.2, trunk]
     platforms: [windows, macOS, ubuntu]
     args: --type package-tests
   - name: isolation_tests
-    editors: [2018.4, 2019.4, 2020.3, 2021.2, trunk]
+    editors: [2019.4, 2020.3, 2021.2, trunk]
     platforms: [windows, macOS, ubuntu]
     args: --type package-tests --enable-load-and-test-isolation
   - name: coverage
@@ -26,7 +26,7 @@ all_configurations:
     platforms: [windows]
     args: --type package-tests --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Cinemachine,+com.unity.cinemachine.editor'
   - name: promotion_tests
-    editors: [2018.4, 2019.4, 2020.3, 2021.2, trunk]
+    editors: [2019.4, 2020.3, 2021.2, trunk]
     platforms: [windows, macOS, ubuntu]
     args: --type vetting-tests --platform editmode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.6.17] - 2022-08-15
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: CinemachineInputProvider stops providing input when the CinemachineInputProvider component is disabled
-- Bugfix: Fixed spurious Z rotations during speherical blend.
+- Bugfix: Fixed spurious Z rotations during blend.
 - Bugfix: Blending speed was not set correctly, when blending back and forth between the same cameras.
 - Bugfix: AxisState.Recentering.RecenterNow() did not work reliably.
 - Bugfix: SensorSize is not saved when not using physical camera.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.6.16] - 2022-07-22
+## [2.6.17] - 2022-07-22
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: CinemachineInputProvider stops providing input when the CinemachineInputProvider component is disabled
 - Bugfix: Fixed spurious Z rotations during speherical blend.
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: No redundant RepaintAllViews calls.
 - Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.
 - Bugfix: SaveDuringPlay works with ILists now.
+- AimingRig sample is only optionally dependent on UnityEngine.UI.
+- Dependency on com.unity.test-framework added.
 
 
 ## [2.6.15] - 2022-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.6.17] - 2022-07-22
+## [2.6.17] - 2022-08-15
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: CinemachineInputProvider stops providing input when the CinemachineInputProvider component is disabled
 - Bugfix: Fixed spurious Z rotations during speherical blend.

--- a/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -1,3 +1,4 @@
+#if CINEMACHINE_UNITY_ANIMATION
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -452,3 +453,4 @@ namespace Cinemachine.Editor
         }
     }
 }
+#endif

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -80,6 +80,7 @@ namespace Cinemachine.Editor
             vcam.m_Instructions[1].m_Blend.m_Time = 2f;
         }
 
+#if CINEMACHINE_UNITY_ANIMATION
         [MenuItem("Cinemachine/Create State-Driven Camera", false, 1)]
         private static void CreateStateDivenCamera()
         {
@@ -95,7 +96,8 @@ namespace Cinemachine.Editor
             // Give it a child
             Undo.SetTransformParent(CreateDefaultVirtualCamera().transform, go.transform, "create state driven camera");
         }
-
+#endif
+        
 #if CINEMACHINE_PHYSICS
         [MenuItem("Cinemachine/Create ClearShot Camera", false, 1)]
         private static void CreateClearShotVirtualCamera()

--- a/Editor/com.unity.cinemachine.Editor.asmdef
+++ b/Editor/com.unity.cinemachine.Editor.asmdef
@@ -63,6 +63,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "7.0.0",
             "define": "CINEMACHINE_LWRP_7_0_0"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
         }
     ]
 }

--- a/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -1,3 +1,4 @@
+#if CINEMACHINE_UNITY_ANIMATION
 using Cinemachine.Utility;
 using System;
 using System.Collections.Generic;
@@ -557,3 +558,4 @@ namespace Cinemachine
         }
     }
 }
+#endif

--- a/Runtime/Components/CinemachineSameAsFollowTarget.cs
+++ b/Runtime/Components/CinemachineSameAsFollowTarget.cs
@@ -52,6 +52,7 @@ namespace Cinemachine
             }
             m_PreviousReferenceOrientation = dampedOrientation;
             curState.RawOrientation = dampedOrientation;
+            curState.ReferenceUp = dampedOrientation * Vector3.up;
         }
     }
 }

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -376,31 +376,27 @@ namespace Cinemachine
                     || ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.IgnoreLookAtTarget) != 0)
                 {
                     // Don't know what we're looking at - can only slerp
-                    newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                            stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
+                    newOrient = Quaternion.Slerp(stateA.RawOrientation, stateB.RawOrientation, t);
                 }
                 else
                 {
                     // Rotate while preserving our lookAt target
-                    if (Vector3.Cross(dirTarget, state.ReferenceUp).AlmostZero())
+                    var up = state.ReferenceUp;
+                    dirTarget.Normalize();
+                    if (Vector3.Cross(dirTarget, up).AlmostZero())
                     {
                         // Looking up or down at the pole
-                        newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                                stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
+                        newOrient = Quaternion.Slerp(stateA.RawOrientation, stateB.RawOrientation, t);
+                        up = newOrient * Vector3.up;
                     }
-                    else
-                    {
-                        // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
 
-                        // Blend the desired offsets from center
-                        Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, state.ReferenceUp);
-                        Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, state.ReferenceUp);
-                        newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
-                    }
+                    // Blend the desired offsets from center
+                    newOrient = Quaternion.LookRotation(dirTarget, up);
+                    var deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
+                            stateA.ReferenceLookAt - stateA.CorrectedPosition, up);
+                    var deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
+                            stateB.ReferenceLookAt - stateB.CorrectedPosition, up);
+                    newOrient = newOrient.ApplyCameraRotation(Vector2.Lerp(deltaA, deltaB, adjustedT), up);
                 }
             }
             state.RawOrientation = ApplyRotBlendHint(

--- a/Runtime/Core/CameraState.cs
+++ b/Runtime/Core/CameraState.cs
@@ -381,29 +381,25 @@ namespace Cinemachine
                 }
                 else
                 {
-                    var blendUp = (state.BlendHint & BlendHintValue.CylindricalPositionBlend) != 0 
-                        ? state.ReferenceUp // the pre-blended up vectors
-                        : Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
-
                     // Rotate while preserving our lookAt target
-                    if (Vector3.Cross(dirTarget, blendUp).AlmostZero())
+                    if (Vector3.Cross(dirTarget, state.ReferenceUp).AlmostZero())
                     {
                         // Looking up or down at the pole
                         newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                                stateA.RawOrientation, stateB.RawOrientation, t, blendUp);
+                                stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
                     }
                     else
                     {
                         // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, blendUp);
+                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
 
                         // Blend the desired offsets from center
                         Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, blendUp);
+                                stateA.ReferenceLookAt - stateA.CorrectedPosition, state.ReferenceUp);
                         Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, blendUp);
+                                stateB.ReferenceLookAt - stateB.CorrectedPosition, state.ReferenceUp);
                         newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), blendUp);
+                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
                     }
                 }
             }

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -23,7 +23,7 @@ namespace Cinemachine
         public static readonly int kStreamingVersion = 20170927;
 
         /// <summary>Human-readable Cinemachine Version</summary>
-        public static readonly string kVersionString = "2.6.16";
+        public static readonly string kVersionString = "2.6.17";
 
         /// <summary>
         /// Stages in the Cinemachine Component pipeline, used for

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Cinemachine",
+    "rootNamespace": "",
     "references": [
         "Unity.Timeline",
         "Unity.Postprocessing.Runtime",
@@ -77,6 +78,11 @@
             "name": "com.unity.inputsystem",
             "expression": "1.0.0-preview",
             "define": "CINEMACHINE_UNITY_INPUTSYSTEM"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
         }
     ],
     "noEngineReferences": false

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimReticle.cs
@@ -1,3 +1,4 @@
+#if CINEMACHINE_UGUI
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -55,3 +56,4 @@ public class AimReticle : MonoBehaviour
         Bottom.rectTransform.position = screenCenterPoint + (Vector2.down * m_CurrentRadius);
     }
 }
+#endif

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.asmdef
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "AimingRig",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.ugui",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UGUI"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.asmdef.meta
+++ b/Samples~/Cinemachine Example Scenes/Scenes/AimingRig/AimingRig.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4f3124b5596b549b9a983c141448dd11
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],
     "category": "cinematography",
     "dependencies": {
+        "com.unity.test-framework": "1.1.33"
     },
     "samples": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.6.16",
+    "version": "2.6.17",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nIMPORTANT NOTE: If you are upgrading from the Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR
- [x] CMCL-1123 backport of [CMCL-1119](https://jira.unity3d.com/browse/CMCL-1119) - NUnit dependency
- [x] [CMCL-1118](https://jira.unity3d.com/browse/CMCL-1118) Optional UI dependency in AimingRig
- [x] https://github.com/Unity-Technologies/com.unity.cinemachine/pull/529 - https://github.com/Unity-Technologies/com.unity.cinemachine/pull/529 - verified with the attached repro projects.

The rest of the issues in the changelog where verified in the [2.6.16 PR](https://github.com/Unity-Technologies/com.unity.cinemachine/pull/477).

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests (2021.3.6f1)
- [x] Manually tested 
- [x] Package validation (yellow)

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version

- [x] Updated package version -> 2.6.17
