### PR TITLE
CMCL-1140: spurious z rotation in blend

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: The FadeOut sample scene shader was culling some objects incorrectly.
 - Bugfix: Freelook had the wrong heading at the first frame, which could cause a slight jitter.
 - Bugfix: FramingTransposer and Composer had a slight rounding error in their Bias fields when the Screen X and Y fields were modified. 
-- Bugfix: Fixed spurious Z rotations during spherical blend.
+- Bugfix: Fixed spurious Z rotations during blend.
 - Regression fix: POV is relative to its parent transform.
 - Bugfix: Blending speed was not set correctly when blending back and forth between the same cameras.
 - Bugfix: AxisState.Recentering.RecenterNow() did not work reliably.

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -381,29 +381,25 @@ namespace Cinemachine
                 }
                 else
                 {
-                    var blendUp = (state.BlendHint & BlendHintValue.CylindricalPositionBlend) != 0 
-                        ? state.ReferenceUp // the pre-blended up vectors
-                        : Vector3.Slerp(stateA.RawOrientation * Vector3.up, stateB.RawOrientation * Vector3.up, t);
-
                     // Rotate while preserving our lookAt target
-                    if (Vector3.Cross(dirTarget, blendUp).AlmostZero())
+                    if (Vector3.Cross(dirTarget, state.ReferenceUp).AlmostZero())
                     {
                         // Looking up or down at the pole
                         newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                                stateA.RawOrientation, stateB.RawOrientation, t, blendUp);
+                                stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
                     }
                     else
                     {
                         // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, blendUp);
+                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
 
                         // Blend the desired offsets from center
                         Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, blendUp);
+                                stateA.ReferenceLookAt - stateA.CorrectedPosition, state.ReferenceUp);
                         Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, blendUp);
+                                stateB.ReferenceLookAt - stateB.CorrectedPosition, state.ReferenceUp);
                         newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), blendUp);
+                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
                     }
                 }
             }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1140: weird camera Z rotation when blending

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Tried to repro situations that prompted the initial code change that caused this regression. Could not repro issues. Attempts were based on these changelog entries:

- Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
- Bugfix: Blends between vcams, that are rotated so that their up vector is different from World up, are correct now.