### PR TITLE
CMCL-1146: re-implement blending fixes for CMCL-315 and CMCL-406

### DIFF
--- a/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
@@ -52,6 +52,7 @@ namespace Cinemachine
             }
             m_PreviousReferenceOrientation = dampedOrientation;
             curState.RawOrientation = dampedOrientation;
+            curState.ReferenceUp = dampedOrientation * Vector3.up;
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -376,31 +376,27 @@ namespace Cinemachine
                     || ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.IgnoreLookAtTarget) != 0)
                 {
                     // Don't know what we're looking at - can only slerp
-                    newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                            stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
+                    newOrient = Quaternion.Slerp(stateA.RawOrientation, stateB.RawOrientation, t);
                 }
                 else
                 {
                     // Rotate while preserving our lookAt target
-                    if (Vector3.Cross(dirTarget, state.ReferenceUp).AlmostZero())
+                    var up = state.ReferenceUp;
+                    dirTarget.Normalize();
+                    if (Vector3.Cross(dirTarget, up).AlmostZero())
                     {
                         // Looking up or down at the pole
-                        newOrient = UnityQuaternionExtensions.SlerpWithReferenceUp(
-                                stateA.RawOrientation, stateB.RawOrientation, t, state.ReferenceUp);
+                        newOrient = Quaternion.Slerp(stateA.RawOrientation, stateB.RawOrientation, t);
+                        up = newOrient * Vector3.up;
                     }
-                    else
-                    {
-                        // Put the target in the center
-                        newOrient = Quaternion.LookRotation(dirTarget, state.ReferenceUp);
 
-                        // Blend the desired offsets from center
-                        Vector2 deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
-                                stateA.ReferenceLookAt - stateA.CorrectedPosition, state.ReferenceUp);
-                        Vector2 deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
-                                stateB.ReferenceLookAt - stateB.CorrectedPosition, state.ReferenceUp);
-                        newOrient = newOrient.ApplyCameraRotation(
-                                Vector2.Lerp(deltaA, deltaB, adjustedT), state.ReferenceUp);
-                    }
+                    // Blend the desired offsets from center
+                    newOrient = Quaternion.LookRotation(dirTarget, up);
+                    var deltaA = -stateA.RawOrientation.GetCameraRotationToTarget(
+                            stateA.ReferenceLookAt - stateA.CorrectedPosition, up);
+                    var deltaB = -stateB.RawOrientation.GetCameraRotationToTarget(
+                            stateB.ReferenceLookAt - stateB.CorrectedPosition, up);
+                    newOrient = newOrient.ApplyCameraRotation(Vector2.Lerp(deltaA, deltaB, adjustedT), up);
                 }
             }
             state.RawOrientation = ApplyRotBlendHint(


### PR DESCRIPTION
### Purpose of this PR

CMCL-1146: Revisit cases CMCL-315 and CMCL-406.  
Original fixes introduced a regression and were reverted.
Please see the 4 repro cases in the jira ticket.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

