### PR TITLE
CMCL-1059: Freelook and Collider don't work well together when transitioning between rigs

### DIFF
--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -328,7 +328,7 @@ namespace Cinemachine
 
                     var displacementSqrMagnitude = displacement.sqrMagnitude;
                     var prevDisplacementSqrMagnitude = extra.previousDisplacement.sqrMagnitude;
-                    if (displacementSqrMagnitude > Epsilon || prevDisplacementSqrMagnitude > Epsilon)
+                    if (displacementSqrMagnitude > Epsilon && prevDisplacementSqrMagnitude > Epsilon)
                     {
                         var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
                         var delta = undampedCameraPosition - extra.previousCorrectedPosition;
@@ -336,11 +336,21 @@ namespace Cinemachine
                         // Apply damping
                         if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
                         {
-                            var isBigger = displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude;
+                            var isBigger = displacementSqrMagnitude > prevDisplacementSqrMagnitude;
                             delta = Damper.Damp(delta, isBigger ? m_DampingWhenOccluded : m_Damping, deltaTime);
                         }
 
                         displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
+                    }
+                    else
+                    {
+                        if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
+                        {
+                            var isBigger = displacementSqrMagnitude > prevDisplacementSqrMagnitude;
+                            displacement = extra.previousDisplacement + 
+                                Damper.Damp(displacement - extra.previousDisplacement, 
+                                    isBigger ? m_DampingWhenOccluded : m_Damping, deltaTime);
+                        }
                     }
 
                     extra.previousDisplacement = displacement;

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -333,7 +333,7 @@ namespace Cinemachine
                         var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
                         var delta = undampedCameraPosition - extra.previousCorrectedPosition;
 
-                        // Apply damping
+                        // Apply damping when colliding
                         if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
                         {
                             var isBigger = displacementSqrMagnitude > prevDisplacementSqrMagnitude;
@@ -344,6 +344,7 @@ namespace Cinemachine
                     }
                     else
                     {
+                        // Apply damping when no longer colliding
                         if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
                         {
                             var isBigger = displacementSqrMagnitude > prevDisplacementSqrMagnitude;

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -324,23 +324,17 @@ namespace Cinemachine
 
                     // Apply additional correction due to camera radius
                     var cameraPos = state.CorrectedPosition + displacement;
-                    displacement += RespectCameraRadius(
-                        cameraPos, state.HasLookAt ? state.ReferenceLookAt : cameraPos);
+                    displacement += RespectCameraRadius(cameraPos, state.HasLookAt ? state.ReferenceLookAt : cameraPos);
                     
                     var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
                     var delta = undampedCameraPosition - extra.previousCorrectedPosition;
-                    Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.red);
+                    // Apply damping
                     if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
                     {
-                        delta = Damper.Damp(
-                            delta,
-                            displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude ? m_DampingWhenOccluded : m_Damping,
-                            deltaTime);
-                        Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.blue);
+                        var isBigger = displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude;
+                        delta = Damper.Damp(delta, isBigger ? m_DampingWhenOccluded : m_Damping, deltaTime);
                     }
-
                     displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
-                    Debug.DrawLine(state.RawPosition, state.RawPosition + displacement, Color.green);
 
                     extra.previousDisplacement = displacement;
                     state.PositionCorrection += displacement;

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -325,16 +325,23 @@ namespace Cinemachine
                     // Apply additional correction due to camera radius
                     var cameraPos = state.CorrectedPosition + displacement;
                     displacement += RespectCameraRadius(cameraPos, state.HasLookAt ? state.ReferenceLookAt : cameraPos);
-                    
-                    var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
-                    var delta = undampedCameraPosition - extra.previousCorrectedPosition;
-                    // Apply damping
-                    if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
+
+                    var displacementSqrMagnitude = displacement.sqrMagnitude;
+                    var prevDisplacementSqrMagnitude = extra.previousDisplacement.sqrMagnitude;
+                    if (displacementSqrMagnitude > Epsilon || prevDisplacementSqrMagnitude > Epsilon)
                     {
-                        var isBigger = displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude;
-                        delta = Damper.Damp(delta, isBigger ? m_DampingWhenOccluded : m_Damping, deltaTime);
+                        var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
+                        var delta = undampedCameraPosition - extra.previousCorrectedPosition;
+
+                        // Apply damping
+                        if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
+                        {
+                            var isBigger = displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude;
+                            delta = Damper.Damp(delta, isBigger ? m_DampingWhenOccluded : m_Damping, deltaTime);
+                        }
+
+                        displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
                     }
-                    displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
 
                     extra.previousDisplacement = displacement;
                     state.PositionCorrection += displacement;

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -326,34 +326,21 @@ namespace Cinemachine
                     var cameraPos = state.CorrectedPosition + displacement;
                     displacement += RespectCameraRadius(
                         cameraPos, state.HasLookAt ? state.ReferenceLookAt : cameraPos);
-
-                    if (m_Strategy != ResolutionStrategy.PullCameraForward)
-                    {
-                        if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
-                        {
-                            displacement = extra.previousDisplacement + Damper.Damp(
-                                displacement - extra.previousDisplacement, 
-                                displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude ? m_DampingWhenOccluded : m_Damping,
-                                deltaTime);
-                        }
-                    }
-                    else
-                    {
-                        var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
-                        var delta = undampedCameraPosition - extra.previousCorrectedPosition;
-                        Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.red);
-                        if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
-                        {
-                            delta = Damper.Damp(
-                                delta, 
-                                displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude ? m_DampingWhenOccluded : m_Damping,
-                                deltaTime);
-                            Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.blue);
-                        }
                     
-                        displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
-                        Debug.DrawLine(state.RawPosition, state.RawPosition + displacement, Color.green);
+                    var undampedCameraPosition = state.RawPosition + state.PositionCorrection + displacement;
+                    var delta = undampedCameraPosition - extra.previousCorrectedPosition;
+                    Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.red);
+                    if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
+                    {
+                        delta = Damper.Damp(
+                            delta,
+                            displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude ? m_DampingWhenOccluded : m_Damping,
+                            deltaTime);
+                        Debug.DrawLine(extra.previousCorrectedPosition, extra.previousCorrectedPosition + delta, Color.blue);
                     }
+
+                    displacement = (extra.previousCorrectedPosition + delta) - state.CorrectedPosition;
+                    Debug.DrawLine(state.RawPosition, state.RawPosition + displacement, Color.green);
 
                     extra.previousDisplacement = displacement;
                     state.PositionCorrection += displacement;


### PR DESCRIPTION
### Purpose of this PR
Parent issue: CMCL-1057 - has repro project.

The issue was that we were damping the displacement, but when colliding with a wall, this caused a strong overshot towards or away from the target.
I think, we should damp the delta between the `previous corrected camera position` and the `current corrected position` instead. 

<br>
<img width="372" alt="figure" src="https://user-images.githubusercontent.com/57672095/184420835-56e19449-1364-4587-b08f-e4ed004dbcc7.png">
- The red camera indicates where the camera is **without** a collider. 
- The yellow camera indicates where the camera is **with** a collider. 
<br>

TODO: have not tested with normal vcams!
TODO: I noticed that there is a bump when hitting the collider in this implementation that was not there in the original implementation. This is not good!

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested with repro project and in freelook collider scene

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version
This fix will need to be ported to 2.6, 2.9, 3.0.