### PR TITLE
CMCL-1057: collider damping was not robust

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Bugfix: Collider damping is mre robust with extreme FreeLook configurations
+- Bugfix: Collider damping is more robust with extreme FreeLook configurations
 
 ## [2.9.0] - 2022-08-15
 - Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Bugfix: Collider damping is mre robust with extreme FreeLook configurations
+
 ## [2.9.0] - 2022-08-15
 - Bugfix: CinemachineConfiner was not confining correctly when Confine Screen Edges was enabled and the camera was rotated.
 - AimingRig sample is only optionally dependent on UnityEngine.UI.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
@@ -333,7 +333,7 @@ namespace Cinemachine
                     {
                         // To ease the transition between damped and undamped regions, we damp the damp time
                         dampTime = displacement.sqrMagnitude > extra.previousDisplacement.sqrMagnitude ? m_DampingWhenOccluded : m_Damping;
-                        if (displacement.sqrMagnitude < 0.01f)
+                        if (displacement.sqrMagnitude < Epsilon)
                             dampTime = extra.previousDampTime - Damper.Damp(extra.previousDampTime, dampTime, deltaTime);
 
                         var prevDisplacement = Quaternion.Inverse(dampingBypass) * (extra.previousCameraPosition - state.CorrectedPosition);
@@ -343,11 +343,11 @@ namespace Cinemachine
                     state.PositionCorrection += displacement;
 
                     // Adjust the damping bypass to account for the displacement
-                    if (state.HasLookAt)
+                    if (state.HasLookAt && VirtualCamera.PreviousStateIsValid)
                     {
                         var dir0 = extra.previousCameraPosition - state.ReferenceLookAt;
                         var dir1 = state.CorrectedPosition - state.ReferenceLookAt;
-                        if (dir0.sqrMagnitude > 0.01f && dir1.sqrMagnitude > 0.01f)
+                        if (dir0.sqrMagnitude > Epsilon && dir1.sqrMagnitude > Epsilon)
                             state.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
                                 dir0, dir1, state.ReferenceUp).eulerAngles;
                     }

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
@@ -65,6 +65,8 @@ namespace Cinemachine
         [Tooltip("Obsolete - no longer used")]
         public bool m_ApplyBeforeBody;
 
+        Quaternion m_PreviousCameraRotation;
+
         /// <summary>True if component is enabled and has a LookAt defined</summary>
         public override bool IsValid { get { return enabled; } }
 
@@ -140,6 +142,12 @@ namespace Cinemachine
             }
             rot = Quaternion.FromToRotation(curState.ReferenceUp, up) * rot;
             curState.RawOrientation = rot;
+
+            if (VirtualCamera.PreviousStateIsValid)
+                curState.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
+                    m_PreviousCameraRotation * Vector3.forward, 
+                    rot * Vector3.forward, curState.ReferenceUp).eulerAngles;
+            m_PreviousCameraRotation = rot;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1057 (has repro project)
When the FreeLook rigs were extreme the collider damping was not handled correctly, causing the camera to move incorrectly in depth, sometimes overshooting the character.

Solution was to redesign collider damping to use the previous camera position, and to set state.DampingBypass to account for its displacement, eliminating spurious rotation damping in the composer.

The new solution works with all collider strategies.

This fix should be backported to 2.6, 2.8, and 3.0

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

