### PR TITLE
CMCL-1131: Publish 2.6 release without running isolation tests

### DIFF
--- a/.yamato/metadata.metafile
+++ b/.yamato/metadata.metafile
@@ -18,7 +18,7 @@ all_configurations:
     platforms: [windows, macOS, ubuntu]
     args: --type package-tests
   - name: isolation_tests
-    editors: [2018.4, 2019.4, 2020.3, 2021.2]
+    editors: [2019.4, 2020.3, 2021.2]
     platforms: [windows, macOS, ubuntu]
     args: --type package-tests --enable-load-and-test-isolation
   - name: coverage

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -8,10 +8,11 @@ publish:
     image: package-ci/win10:stable
     flavor: b1.large
   variables:
+    IS_DRY_RUN: 0
     UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package publish
+    - IF %IS_DRY_RUN% == 1 (upm-ci package publish --dry-run) ELSE (upm-ci package publish)
   triggers:
     tags:
       only:
@@ -21,19 +22,5 @@ publish:
       paths:
         - "upm-ci~/packages/*.tgz"
   dependencies:
-    - .yamato/package-pack.yml#pack
-    {% for config_name in publish_configurations %}
-    {% for config in all_configurations %}
-    {% if config.name == config_name %}
-    {% for platform_name in publish_platforms %}
-    {% for platform in all_platforms %}
-    {% if platform.name == platform_name %}
-    {% for editor in config.editors %}
-    - .yamato/package-test.yml#test_{{config.name}}_{{platform.name}}_{{editor}}
-    {% endfor %}
-    {% endif %}
-    {% endfor %}
-    {% endfor %}
-    {% endif %}
-    {% endfor %}
-    {% endfor %}
+    - .yamato/package-pack.yml#pack   
+    - .yamato/package-test.yml#test_promotion_tests_windows_2018.4


### PR DESCRIPTION
### Purpose of this PR

Unity 2018.4 doesn't support soft dependencies, therefore isolation tests cannot pass and block the package's publishing. This runs only the vetting tests, which are sufficient to publish the package. This also adds an handy dry-run variable. 

### Testing status

I tried a publishing dry-run on my branch and it works. 

### Technical risk

0

### Comments to reviewers

This is not the cleanest way of doing things, but support of 2.6 will soon end. 

