### PR TITLE
CMCL-1170: make ClipperLib internal

### DIFF
--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -3,10 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using Cinemachine.Utility;
 using UnityEngine;
-using Cinemachine.ClipperLib;
 
 namespace Cinemachine
 {
+    using IntPoint = ClipperLib.IntPoint;
+    using Clipper = ClipperLib.Clipper;
+    using ClipperOffset = ClipperLib.ClipperOffset;
+    using ClipperBase = ClipperLib.ClipperBase;
+    using IntRect = ClipperLib.IntRect;
+    using JoinType = ClipperLib.JoinType;
+    using EndType = ClipperLib.EndType;
+    using PolyType = ClipperLib.PolyType;
+    using PolyFillType = ClipperLib.PolyFillType;
+    using ClipType = ClipperLib.ClipType;
+
     /// <summary>
     /// Responsible for baking confiners via BakeConfiner function.
     /// </summary>

--- a/com.unity.cinemachine/Runtime/ThirdParty/clipper.cs
+++ b/com.unity.cinemachine/Runtime/ThirdParty/clipper.cs
@@ -55,18 +55,19 @@ using System.Collections.Generic;
 //using System.IO;            //debugging with streamReader & StreamWriter
 //using System.Windows.Forms; //debugging to clipboard
 
-namespace Cinemachine.ClipperLib
+namespace Cinemachine
 {
-
 #if use_int32
   using cInt = Int32;
 #else
   using cInt = Int64;
 #endif
 
-  using Path = List<IntPoint>;
-  using Paths = List<List<IntPoint>>;
+  using Path = List<ClipperLib.IntPoint>;
+  using Paths = List<List<ClipperLib.IntPoint>>;
 
+internal static class ClipperLib
+{
   public struct DoublePoint
   {
     public double X;
@@ -4910,4 +4911,5 @@ namespace Cinemachine.ClipperLib
   }
   //------------------------------------------------------------------------------
 
-} //end ClipperLib namespace
+} //end ClipperLib 
+} //end Cinemachine namespace


### PR DESCRIPTION
### Purpose of this PR

CMCL-1170 CLipperLib was accidentally added to the public API, enlarging the footprint.  Should be internal.  This is a release blocker.

** Needs to be backported to 2.6, 2.8, and 2.9 **

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

