### PR TITLE
CMCL-651: state driven camera transition glitch 

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Clipper library dependency is no longer conflicting with users.
 - AimingRig sample is only optionally dependent on UnityEngine.UI.
 - Bugfix: Transposer with LockToTarget binding sometimes had gibmal lock
+- Bugfix: StateDrivenCamera/Clearshot: Transition glitch when backing out of a transition in progress
 
 
 ## [2.9.0-pre.7] - 2022-03-29

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -155,10 +155,8 @@ namespace Cinemachine
                     if (previousCam != null)
                     {
                         // Create a blend (will be null if a cut)
-                        m_ActiveBlend = CreateBlend(
-                                previousCam, LiveChild,
-                                Instructions[m_CurrentInstruction].Blend,
-                                m_ActiveBlend);
+                        m_ActiveBlend = CreateActiveBlend(
+                            previousCam, LiveChild, Instructions[m_CurrentInstruction].Blend);
 
                         // If cutting, generate a camera cut event if live
                         if (m_ActiveBlend == null || !m_ActiveBlend.Uses(previousCam))

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
@@ -162,9 +162,7 @@ namespace Cinemachine
                 if (previousCam != null)
                 {
                     // Create a blend (will be null if a cut)
-                    m_ActiveBlend = CreateBlend(
-                            previousCam, LiveChild,
-                            LookupBlend(previousCam, LiveChild), m_ActiveBlend);
+                    m_ActiveBlend = CreateActiveBlend(previousCam, LiveChild, LookupBlend(previousCam, LiveChild));
 
                     // If cutting, generate a camera cut event if live
                     if (m_ActiveBlend == null || !m_ActiveBlend.Uses(previousCam))

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -45,6 +45,9 @@ namespace Cinemachine
         /// <summary>This vcam defines no targets</summary>
         override public Transform Follow { get; set; }
 
+        /// <summary>Returns the TransitionParams settings</summary>
+        public override TransitionParams GetTransitionParams() => default;
+
         /// <summary>Internal use only.  Do not call this method</summary>
         /// <param name="worldUp">Effective world up</param>
         /// <param name="deltaTime">Effective deltaTime</param>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -205,9 +205,7 @@ namespace Cinemachine
                 if (previousCam != null)
                 {
                     // Create a blend (will be null if a cut)
-                    m_ActiveBlend = CreateBlend(
-                            previousCam, LiveChild,
-                            LookupBlend(previousCam, LiveChild), m_ActiveBlend);
+                    m_ActiveBlend = CreateActiveBlend(previousCam, LiveChild, LookupBlend(previousCam, LiveChild));
 
                     // If cutting, generate a camera cut event if live
                     if (m_ActiveBlend == null || !m_ActiveBlend.Uses(previousCam))

--- a/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
@@ -101,6 +101,9 @@ namespace Cinemachine
             set { Target.TrackingTarget = value; }
         }
 
+        /// <summary>Returns the TransitionParams settings</summary>
+        public override TransitionParams GetTransitionParams() => Transitions;
+
         /// <summary>This is called to notify the CM camera that a target got warped,
         /// so that the CM camera can update its internal state to make the camera
         /// also warp seamlessly.</summary>

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -465,6 +465,9 @@ namespace Cinemachine
             }
         }
 
+        /// <summary>Returns the camera's TransitionParams settings</summary>
+        public abstract TransitionParams GetTransitionParams();
+
         /// <summary>Check whether the vcam a live child of this camera.
         /// This base class implementation always returns false.</summary>
         /// <param name="vcam">The Virtual Camera to check</param>
@@ -720,39 +723,6 @@ namespace Cinemachine
                 for (int i = 0; i < Extensions.Count; ++i)
                     Extensions[i].ForceCameraPosition(pos, rot);
             }
-        }
-        
-        /// <summary>Create a blend between 2 virtual cameras, taking into account
-        /// any existing active blend, with special case handling if the new blend is 
-        /// effectively an undo of the current blend</summary>
-        /// <param name="camA">Outgoing virtual camera</param>
-        /// <param name="camB">Incoming virtual camera</param>
-        /// <param name="blendDef">Definition of the blend to create</param>
-        /// <param name="activeBlend">The current active blend</param>
-        /// <returns>The new blend</returns>
-        protected CinemachineBlend CreateBlend(
-            ICinemachineCamera camA, ICinemachineCamera camB,
-            CinemachineBlendDefinition blendDef,
-            CinemachineBlend activeBlend)
-        {
-            if (blendDef.BlendCurve == null || blendDef.BlendTime <= 0 || (camA == null && camB == null))
-                return null;
-            if (activeBlend != null)
-            {
-                // Special case: if backing out of a blend-in-progress
-                // with the same blend in reverse, adjust the belnd time
-                if (activeBlend.CamA == camB
-                    && activeBlend.CamB == camA
-                    && activeBlend.Duration <= blendDef.BlendTime)
-                {
-                    blendDef.m_Time = activeBlend.TimeInBlend;
-                }
-                camA = new BlendSourceVirtualCamera(activeBlend);
-            }
-            else if (camA == null)
-                camA = new StaticPointVirtualCamera(State, "(none)");
-            return new CinemachineBlend(
-                camA, camB, blendDef.BlendCurve, blendDef.BlendTime, 0);
         }
 
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -271,6 +271,9 @@ namespace Cinemachine
             set { m_Follow = value; }
         }
 
+        /// <summary>Returns the TransitionParams settings</summary>
+        public override TransitionParams GetTransitionParams() => m_Transitions;
+
         /// <summary>Check whether the vcam a live child of this camera.
         /// Returns true if the child is currently contributing actively to the camera state.</summary>
         /// <param name="vcam">The Virtual Camera to check</param>

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
@@ -94,6 +94,9 @@ namespace Cinemachine
             set { m_Follow = value; }
         }
 
+        /// <summary>Returns the TransitionParams settings</summary>
+        public override TransitionParams GetTransitionParams() => m_Transitions;
+
         /// <summary>
         /// Query components and extensions for the maximum damping time.
         /// </summary>


### PR DESCRIPTION
CMCL-651: backport to CM3, remove hack

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

