### PR TITLE
CMCL-0000: Prefab instance modification fixes

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -117,7 +117,11 @@ namespace Cinemachine.Editor
         void UpgradeObjectReferences(GameObject[] rootObjects)
         {
             var map = m_ObjectUpgrader.ClassUpgradeMap;
-            foreach (var go in rootObjects)
+            foreach (var go in rootObjects) 
+            {
+                if (go == null)
+                    continue; // ignore deleted objects (prefab instance copies)
+                
                 ReflectionHelpers.RecursiveUpdateBehaviourReferences(go, (expectedType, oldValue) =>
                 {
                     var oldType = oldValue.GetType();
@@ -129,6 +133,7 @@ namespace Cinemachine.Editor
                     }
                     return oldValue;
                 });
+            }
         }
         
         void UpgradeNonPrefabReferencables()

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -133,14 +133,6 @@ namespace Cinemachine.Editor
                     }
                     return oldValue;
                 });
-                
-                // manager cameras need to be recorded to keep references after saving scenes if they are part of a prefab
-                if (PrefabUtility.IsPartOfAnyPrefab(go))
-                {
-                    var managers = go.GetComponents<CinemachineCameraManagerBase>();
-                    foreach (var manager in managers) 
-                        PrefabUtility.RecordPrefabInstancePropertyModifications(manager);
-                }
             }
         }
         

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -385,6 +385,8 @@ namespace Cinemachine.Editor
                 var prefabInstance = Find(conversionLink.originalGUIDName, allGameObjectsInScene);
                 var convertedCopy = Find(conversionLink.convertedGUIDName, allGameObjectsInScene);
 
+                UpgradeObjectComponents(prefabInstance, null); // prefab instance modification that added an old vcam needs to be upgraded
+
                 // GML todo: do we need to do this recursively for child GameObjects?
                 SynchronizeComponents(prefabInstance, convertedCopy, m_ObjectUpgrader.ObsoleteComponentTypesToDelete);
 #if CINEMACHINE_TIMELINE

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -385,7 +385,9 @@ namespace Cinemachine.Editor
                 var prefabInstance = Find(conversionLink.originalGUIDName, allGameObjectsInScene);
                 var convertedCopy = Find(conversionLink.convertedGUIDName, allGameObjectsInScene);
 
-                UpgradeObjectComponents(prefabInstance, null); // prefab instance modification that added an old vcam needs to be upgraded
+                // Prefab instance modification that added an old vcam needs to be upgraded,
+                // all other prefab instances were indirectly upgraded when the Prefab Asset was upgraded
+                UpgradeObjectComponents(prefabInstance, null); 
 
                 // GML todo: do we need to do this recursively for child GameObjects?
                 SynchronizeComponents(prefabInstance, convertedCopy, m_ObjectUpgrader.ObsoleteComponentTypesToDelete);

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -133,6 +133,16 @@ namespace Cinemachine.Editor
                     }
                     return oldValue;
                 });
+                
+                // manager cameras need to be recorded to keep references after saving scenes if they are part of a prefab
+                if (PrefabUtility.IsPartOfAnyPrefab(go))
+                {
+                    var managers = go.GetComponents<CinemachineCameraManagerBase>();
+                    foreach (var manager in managers)
+                    {
+                        PrefabUtility.RecordPrefabInstancePropertyModifications(manager);
+                    }
+                }
             }
         }
         

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -138,10 +138,8 @@ namespace Cinemachine.Editor
                 if (PrefabUtility.IsPartOfAnyPrefab(go))
                 {
                     var managers = go.GetComponents<CinemachineCameraManagerBase>();
-                    foreach (var manager in managers)
-                    {
+                    foreach (var manager in managers) 
                         PrefabUtility.RecordPrefabInstancePropertyModifications(manager);
-                    }
                 }
             }
         }

--- a/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
+++ b/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
@@ -268,7 +268,11 @@ namespace Cinemachine.Utility
             {
                 var obj = c as object;
                 if (ScanFields(ref obj, updater))
+                {
                     doneSomething = true;
+                    if (UnityEditor.PrefabUtility.IsPartOfAnyPrefab(go)) 
+                        UnityEditor.PrefabUtility.RecordPrefabInstancePropertyModifications(c);
+                }
             }
             return doneSomething;
 


### PR DESCRIPTION
### Purpose of this PR

- Prefab instance modification for manager cameras need to be recorded (otherwise the instructions for StateDriveCamera are lost).
- When an old vcam is added to a Prefab instance, it was not upgraded.
- rootObjects may contain nulls, because converted copies are now deleted.

TODO: Statedrivecamera loses references if they are changed in prefab instance.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested on 2022.2.0a16