### PR TITLE
CMCL-1175: support hdrp 14 (unity 2022.2)

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Occasional 1-frame glitch when transitioning between some freelooks
 - Bugfix: Transposer with LockToTarget binding sometimes had gimbal lock.
 - Bugfix: Collider damping is more robust with extreme FreeLook configurations
+- Add support for HDRP 14 (Unity 2022.2)
 
 
 ## [2.9.1] - 2022-08-24

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -986,6 +986,16 @@ namespace Cinemachine
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
 #if CINEMACHINE_HDRP
+    #if CINEMACHINE_HDRP_14
+                        //cam.focusDistance = state.Lens.FocusDistance; // implemented in CM 3.0
+                        cam.iso = state.Lens.Iso;
+                        cam.shutterSpeed = state.Lens.ShutterSpeed;
+                        cam.aperture = state.Lens.Aperture;
+                        cam.bladeCount = state.Lens.BladeCount;
+                        cam.curvature = state.Lens.Curvature;
+                        cam.barrelClipping = state.Lens.BarrelClipping;
+                        cam.anamorphism = state.Lens.Anamorphism;
+    #else
                         cam.TryGetComponent<HDAdditionalCameraData>(out var hda);
                         if (hda != null)
                         {
@@ -997,6 +1007,7 @@ namespace Cinemachine
                             hda.physicalParameters.barrelClipping = state.Lens.BarrelClipping;
                             hda.physicalParameters.anamorphism = state.Lens.Anamorphism;
                         }
+    #endif
 #endif
                     }
                 }

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -155,9 +155,15 @@ namespace Cinemachine
 #if CINEMACHINE_HDRP
         public int Iso;
         public float ShutterSpeed;
+#if CINEMACHINE_HDRP_14
+        [Range(Camera.kMinAperture, Camera.kMaxAperture)]
+        public float Aperture;
+        [Range(Camera.kMinBladeCount, Camera.kMaxBladeCount)]
+#else
         [Range(HDPhysicalCamera.kMinAperture, HDPhysicalCamera.kMaxAperture)]
         public float Aperture;
         [Range(HDPhysicalCamera.kMinBladeCount, HDPhysicalCamera.kMaxBladeCount)]
+#endif
         public int BladeCount;
         public Vector2 Curvature;
         [Range(0, 1)]
@@ -189,6 +195,15 @@ namespace Cinemachine
 #if CINEMACHINE_HDRP
                 if (lens.IsPhysicalCamera)
                 {
+#if CINEMACHINE_HDRP_14
+                    lens.Iso = fromCamera.iso;
+                    lens.ShutterSpeed = fromCamera.shutterSpeed;
+                    lens.Aperture = fromCamera.aperture;
+                    lens.BladeCount = fromCamera.bladeCount;
+                    lens.Curvature = fromCamera.curvature;
+                    lens.BarrelClipping = fromCamera.barrelClipping;
+                    lens.Anamorphism = fromCamera.anamorphism;
+#else
                     var pc = new HDPhysicalCamera();
     #if UNITY_2019_2_OR_NEWER
                     fromCamera.TryGetComponent<HDAdditionalCameraData>(out var hda);
@@ -204,6 +219,7 @@ namespace Cinemachine
                     lens.Curvature = pc.curvature;
                     lens.BarrelClipping = pc.barrelClipping;
                     lens.Anamorphism = pc.anamorphism;
+#endif
                 }
 #endif
             }
@@ -329,6 +345,15 @@ namespace Cinemachine
             m_SensorSize.x = Mathf.Max(m_SensorSize.x, 0.1f);
             m_SensorSize.y = Mathf.Max(m_SensorSize.y, 0.1f);
 #if CINEMACHINE_HDRP
+    #if CINEMACHINE_HDRP_14
+            ShutterSpeed = Mathf.Max(0, ShutterSpeed);
+            Aperture = Mathf.Clamp(Aperture, Camera.kMinAperture, Camera.kMaxAperture);
+            BladeCount = Mathf.Clamp(BladeCount, Camera.kMinBladeCount, Camera.kMaxBladeCount);
+            BarrelClipping = Mathf.Clamp01(BarrelClipping);
+            Curvature.x = Mathf.Clamp(Curvature.x, Camera.kMinAperture, Camera.kMaxAperture);
+            Curvature.y = Mathf.Clamp(Curvature.y, Curvature.x, Camera.kMaxAperture);
+            Anamorphism = Mathf.Clamp(Anamorphism, -1, 1);
+    #else
             ShutterSpeed = Mathf.Max(0, ShutterSpeed);
             Aperture = Mathf.Clamp(Aperture, HDPhysicalCamera.kMinAperture, HDPhysicalCamera.kMaxAperture);
             BladeCount = Mathf.Clamp(BladeCount, HDPhysicalCamera.kMinBladeCount, HDPhysicalCamera.kMaxBladeCount);
@@ -336,6 +361,7 @@ namespace Cinemachine
             Curvature.x = Mathf.Clamp(Curvature.x, HDPhysicalCamera.kMinAperture, HDPhysicalCamera.kMaxAperture);
             Curvature.y = Mathf.Clamp(Curvature.y, Curvature.x, HDPhysicalCamera.kMaxAperture);
             Anamorphism = Mathf.Clamp(Anamorphism, -1, 1);
+    #endif
 #endif
         }
     }

--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Cinemachine",
+    "rootNamespace": "",
     "references": [
         "Unity.Timeline",
         "Unity.Postprocessing.Runtime",
@@ -78,6 +79,11 @@
             "name": "com.unity.modules.imgui",
             "expression": "1.0.0",
             "define": "CINEMACHINE_UNITY_IMGUI"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "14.0.0",
+            "define": "CINEMACHINE_HDRP_14"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
### Purpose of this PR

CMCL-1175: In HDRP 14, physical settings were moved from HDAdditionalCameraData to Camera class.

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

L:ow
