### PR TITLE
CMCL-1114: spline min version bump

### DIFF
--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -30,7 +30,7 @@
   ],
   "category": "cinematography",
   "dependencies": {
-    "com.unity.splines": "2.0.0-pre.2",
+    "com.unity.splines": "2.0.0-pre.3",
     "com.unity.test-framework": "1.1.33"
   },
   "samples": [


### PR DESCRIPTION
### Purpose of this PR
Bumped min version of splines to avoid test problems on ci.

### Testing status
Yamato 🔴 looks like spline - pre 3 is not available on trunk editor or earlier! -> Checking with spline team ⏳ 