### PR TITLE
CMCL-1174: Add api docs validation to Cinemachine

### DIFF
--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -7,15 +7,17 @@ api_doc_validation:
   name: API documentation validation
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/ubuntu:stable
     flavor: b1.medium
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
-    - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
-    # Download Unity.
-    - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0'; m['dependencies']['com.unity.modules.ui'] = '1.0.0'; json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
+    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    # Add dependencies on physics and HDRP packages in Cinemachine package to workaround script compilation errors.
+    # Since Cinemachine package's dependencies need to be changed by this job on the fly, we cannot use the package packed by the 'pack' job. So just pack the package inside this job and make it self sufficient.
+    - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0'; m['dependencies']['com.unity.render-pipelines.high-definition'] = '13.1.8'; json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path com.unity.cinemachine
+    # Download Unity.
     - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
     # Run PVS in PVP mode.
     - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -7,13 +7,16 @@ api_doc_validation:
   name: API documentation validation
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/ubuntu:stable
     flavor: b1.medium
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
-    - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+    - sudo apt-get update && sudo apt-get install -y upm-pvp
     # Download Unity.
-    - unity-downloader-cli --fast --wait -u 2021.3 -c editor
+    - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0';  json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
+    - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package pack --package-path com.unity.cinemachine
+    - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
     # Run PVS in PVP mode.
     - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
     # Require that PVP-20-1 (API docs validation) passed

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -13,7 +13,7 @@ api_doc_validation:
     # Needed for now, until we get a recent upm-pvp into the image.
     - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
     # Download Unity.
-    - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
+    - unity-downloader-cli --fast --wait -u 2021.3 -c editor
     # Run PVS in PVP mode.
     - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
     # Require that PVP-20-1 (API docs validation) passed

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -13,7 +13,7 @@ api_doc_validation:
     # Needed for now, until we get a recent upm-pvp into the image.
     - sudo apt-get update && sudo apt-get install -y upm-pvp
     # Download Unity.
-    - unity-downloader-cli --fast --wait -u {{ all_test_editors[0].version }} -c editor
+    - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
     # Run PVS in PVP mode.
     - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
     # Require that PVP-20-1 (API docs validation) passed

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -7,11 +7,11 @@ api_doc_validation:
   name: API documentation validation
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/win10:stable
     flavor: b1.medium
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
-    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
     # Download Unity.
     - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0';  json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -28,5 +28,3 @@ api_doc_validation:
     logs:
       paths:
         - upm-ci~/test-results/**
-  dependencies:
-    - .yamato/package-pack.yml#pack

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -1,0 +1,29 @@
+{% metadata_file .yamato/metadata.metafile %}
+---
+
+# The following job runs PVP API docs validation to validate all public APIs (classes and methods) have documentation.
+# For APIs which are exempted from API docs validartion, they are put in pvp_exemptions.json
+api_doc_validation:
+  name: API documentation validation
+  agent:
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.medium
+  commands:
+    # Needed for now, until we get a recent upm-pvp into the image.
+    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    # Download Unity.
+    - unity-downloader-cli --fast --wait -u {{ all_test_editors[0].version }} -c editor
+    # Run PVS in PVP mode.
+    - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
+    # Require that PVP-20-1 (API docs validation) passed
+    - upm-pvp require PVP-20-1 --results "upm-ci~/pvp" --failures "upm-ci~/pvp/failures.json"
+  artifacts:
+    pvp:
+      paths:
+        - upm-ci~/pvp/**
+    logs:
+      paths:
+        - upm-ci~/test-results/**
+  dependencies:
+    - .yamato/package-pack.yml#pack

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -13,7 +13,7 @@ api_doc_validation:
     # Needed for now, until we get a recent upm-pvp into the image.
     - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
     # Download Unity.
-    - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0';  json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
+    - python -c "import json, sys; m = json.load(open(sys.argv[1])); m['dependencies']['com.unity.modules.physics'] = '1.0.0'; m['dependencies']['com.unity.modules.ui'] = '1.0.0'; json.dump(m, open(sys.argv[1], 'w'))" com.unity.cinemachine/package.json
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path com.unity.cinemachine
     - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor

--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -7,11 +7,11 @@ api_doc_validation:
   name: API documentation validation
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/win10:stable
     flavor: b1.medium
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
-    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    - choco install upm-pvp -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
     # Download Unity.
     - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
     # Run PVS in PVP mode.


### PR DESCRIPTION
### Purpose of this PR
Add API docs validation test to Cinemachine CI.

[CMCL-1174](https://jira.unity3d.com/browse/CMCL-1174) CI: Add API docs validation test to Cinemachine

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [X] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Comments to reviewers
- The test job is [here](https://unity-ci.cds.internal.unity3d.com/job/16606034/logs) and this is [the test result](https://yamato-artifactviewer.prd.cds.internal.unity3d.com/759bf7a1-6c2a-454c-a8a8-556226f16069%2Fpvp%2Fupm-ci~%2Fpvp/com.unity.cinemachine.json) (see errors section).
- API docs validation test is similar to true isolation test. When I added the test, I met different script compilation errors. In order to workaround them, I need to add dependencies `com.unity.modules.physics` and `com.unity.render-pipelines.high-definition` in the Cinemachine package. Please see my comments in the jira ticket for details.

