### PR TITLE
CMCL-1182: missing docs

### DIFF
--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
@@ -4,7 +4,7 @@
 namespace Cinemachine.PostFX.Editor
 {
     [CustomEditor(typeof(CinemachineAutoFocus))]
-    public sealed class CinemachineAutoFocusEditor : Cinemachine.Editor.BaseEditor<CinemachineAutoFocus>
+    sealed class CinemachineAutoFocusEditor : Cinemachine.Editor.BaseEditor<CinemachineAutoFocus>
     {
 #if !CINEMACHINE_HDRP
         public override void OnInspectorGUI()

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -13,7 +13,7 @@ namespace Cinemachine.Editor
     /// <summary>
     /// Collection of tools and helpers for drawing inspectors
     /// </summary>
-    public static class InspectorUtility
+    static class InspectorUtility
     {
         /// <summary>Put multiple properties on a single inspector line, with
         /// optional label overrides.  Passing null as a label (or sublabel) override will

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -122,6 +122,12 @@ namespace Cinemachine.Editor
             return ObjectNames.NicifyVariableName(name);
         }
         
+        /// <summary>
+        /// Remove the "Cinemachine" prefix, then call the standard Unity Nicify,
+        /// and add (Deprecated) to types with Obsolete attributes.
+        /// </summary>
+        /// <param name="type">The type to nicify as a string</param>
+        /// <returns>The nicified name</returns>
         public static string NicifyClassName(Type type)
         {
             var name = type.Name;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -41,11 +41,12 @@ namespace Cinemachine
             get => LookAtTarget;
             set => LookAtTarget = value;
         }
-
+        
         /// <summary>This vcam defines no targets</summary>
-        override public Transform Follow { get; set; }
+        public override Transform Follow { get; set; }
 
         /// <summary>Returns the TransitionParams settings</summary>
+        /// <returns>The TransitionParams settings</returns>
         public override TransitionParams GetTransitionParams() => default;
 
         /// <summary>Internal use only.  Do not call this method</summary>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -175,6 +175,7 @@ namespace Cinemachine
         }
 
         /// <summary>Rebuild the cached list of child cameras.</summary>
+        /// <returns>True, if rebuild was needed. False, otherwise.</returns>
         protected override bool UpdateCameraCache()
         {
             if (!base.UpdateCameraCache())

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -175,6 +175,7 @@ namespace Cinemachine
 
         void ISerializationCallbackReceiver.OnBeforeSerialize() {}
 
+        /// <summary>Obsolete Targets</summary>
         [Obsolete("m_Targets is obsolete.  Please use Targets instead")]
         public Target[] m_Targets
         {

--- a/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
@@ -102,6 +102,7 @@ namespace Cinemachine
         }
 
         /// <summary>Returns the TransitionParams settings</summary>
+        /// <returns>The TransitionParams settings</returns>
         public override TransitionParams GetTransitionParams() => Transitions;
 
         /// <summary>This is called to notify the CM camera that a target got warped,

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -131,7 +131,7 @@ namespace Cinemachine
         /// their weights blend along with the camera weights.  For efficiency, a fixed number of slots
         /// are provided, plus a (more expensive) overflow list.
         /// The base system manages but otherwise ignores this data - it is intended for 
-        /// extension modules.</summary>
+        /// extension modules.
         /// </summary>
         public struct CustomBlendableItems
         {
@@ -460,6 +460,9 @@ namespace Cinemachine
             }
         }
 
+        /// <summary>Returns the index of the custom blendable that is associated with the input.</summary>
+        /// <param name="custom">The object with which the returned custom blendable index is associated.</param>
+        /// <returns>The index of the custom blendable that is associated with the input.</returns>
         public static int FindCustomBlendable(this CameraState s, Object custom)
         {
             if (s.CustomBlendables.m_Item0.Custom == custom)

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -111,6 +111,7 @@ namespace Cinemachine
         }
 
         /// <summary>Returns the current live child's TransitionParams settings</summary>
+        /// <returns>The current live child's TransitionParams settings</returns>
         public override TransitionParams GetTransitionParams()
         {
             var child = LiveChild as CinemachineVirtualCameraBase;

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -468,6 +468,7 @@ namespace Cinemachine
         }
 
         /// <summary>Returns the camera's TransitionParams settings</summary>
+        /// <returns>The camera's TransitionParams settings</returns>
         public abstract TransitionParams GetTransitionParams();
 
         /// <summary>Check whether the vcam a live child of this camera.

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -272,6 +272,7 @@ namespace Cinemachine
         }
 
         /// <summary>Returns the TransitionParams settings</summary>
+        /// <returns>The TransitionParams settings</returns>
         public override TransitionParams GetTransitionParams() => m_Transitions;
 
         /// <summary>Check whether the vcam a live child of this camera.

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -321,7 +321,8 @@ namespace Cinemachine
             return pos;
         }
         
-        protected virtual void OnEnable() {} // to add enable toggle
+        /// <summary>Adds enable toggle to the inspector</summary>
+        protected virtual void OnEnable() {}
 
         private float[] m_DistanceToPos;
         private float[] m_PosToDistance;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -321,7 +321,7 @@ namespace Cinemachine
             return pos;
         }
         
-        void OnEnable() {} // to add enable toggle
+        protected virtual void OnEnable() {} // to add enable toggle
 
         private float[] m_DistanceToPos;
         private float[] m_PosToDistance;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -320,9 +320,8 @@ namespace Cinemachine
                 pos /= length;
             return pos;
         }
-
-        // to add enable toggle
-        public void OnEnable() {}
+        
+        void OnEnable() {} // to add enable toggle
 
         private float[] m_DistanceToPos;
         private float[] m_PosToDistance;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
@@ -94,7 +94,9 @@ namespace Cinemachine
             set { m_Follow = value; }
         }
 
+        
         /// <summary>Returns the TransitionParams settings</summary>
+        /// <returns>The TransitionParams settings</returns>
         public override TransitionParams GetTransitionParams() => m_Transitions;
 
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Impulse/CinemachineCollisionImpulseSource.cs
+++ b/com.unity.cinemachine/Runtime/Impulse/CinemachineCollisionImpulseSource.cs
@@ -4,7 +4,9 @@ using UnityEngine.Serialization;
 
 namespace Cinemachine
 {
+    
 #if !(CINEMACHINE_PHYSICS || CINEMACHINE_PHYSICS_2D)
+    /// <summary>If Physics or Physics 2D is part of the project, this would generate inpulse events.</summary>
     [AddComponentMenu("")] // Hide in menu
     public class CinemachineCollisionImpulseSource : CinemachineImpulseSource {}
 #else

--- a/com.unity.cinemachine/Runtime/Impulse/CinemachineCollisionImpulseSource.cs
+++ b/com.unity.cinemachine/Runtime/Impulse/CinemachineCollisionImpulseSource.cs
@@ -29,9 +29,9 @@ namespace Cinemachine
         [FormerlySerializedAs("m_LayerMask")]
         public LayerMask LayerMask = 1;
 
-        /// <summary>No Impulse evemts will be generated for collisions with objects having these tags</summary>
+        /// <summary>No Impulse events will be generated for collisions with objects having these tags</summary>
         [TagField]
-        [Tooltip("No Impulse evemts will be generated for collisions with objects having these tags")]
+        [Tooltip("No Impulse events will be generated for collisions with objects having these tags")]
         [FormerlySerializedAs("m_IgnoreTag")]
         public string IgnoreTag = string.Empty;
 


### PR DESCRIPTION
### Purpose of this PR
Added docs based on this report: https://yamato-artifactviewer.prd.cds.internal.unity3d.com/759bf7a1-6c2a-454c-a8a8-556226f16069%2Fpvp%2Fupm-ci~%2Fpvp/com.unity.cinemachine.json.

In some places, I changed the access modifier of the function/property that was missing docs. 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation