### PR TITLE
CMCL-0000: UGUI #if was at the wrong place

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -1,5 +1,5 @@
-﻿#if CINEMACHINE_UGUI
-using UnityEngine;
+﻿using UnityEngine;
+#if CINEMACHINE_UGUI
 using System.Collections.Generic;
 using UnityEngine.Serialization;
 


### PR DESCRIPTION
### Purpose of this PR
Fixed #if for UGUI, because UnityEngine is needed for AddComponent and MonoBehaviour at the bottom.