### PR TITLE
CMCL-837: input speed is affected by FPS

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Transposer with LockToTarget binding sometimes had gimbal lock.
 - Bugfix: Collider damping is more robust with extreme FreeLook configurations
 - Add support for HDRP 14 (Unity 2022.2)
+- Bugfix: InputValueGain mode of axis input was not framerate-independent
 
 
 ## [2.9.1] - 2022-08-24

--- a/com.unity.cinemachine/Runtime/Core/AxisState.cs
+++ b/com.unity.cinemachine/Runtime/Core/AxisState.cs
@@ -232,29 +232,27 @@ namespace Cinemachine
                 return MaxSpeedUpdate(input, deltaTime); // legacy mode
 
             // Direct mode update: maxSpeed interpreted as multiplier
-            input *= m_MaxSpeed;
+            input *= m_MaxSpeed; // apply gain
             if (deltaTime < Epsilon)
                 m_CurrentSpeed = 0;
             else
             {
-                float speed = input / deltaTime;
-                float dampTime = Mathf.Abs(speed) < Mathf.Abs(m_CurrentSpeed) ? m_DecelTime : m_AccelTime;
-                speed = m_CurrentSpeed + Damper.Damp(speed - m_CurrentSpeed, dampTime, deltaTime);
-                m_CurrentSpeed = speed;
+                float dampTime = Mathf.Abs(input) < Mathf.Abs(m_CurrentSpeed) ? m_DecelTime : m_AccelTime;
+                m_CurrentSpeed += Damper.Damp(input - m_CurrentSpeed, dampTime * 0.5f, deltaTime);
 
                 // Decelerate to the end points of the range if not wrapping
                 float range = m_MaxValue - m_MinValue;
                 if (!m_Wrap && m_DecelTime > Epsilon && range > Epsilon)
                 {
                     float v0 = ClampValue(Value);
-                    float v = ClampValue(v0 + speed * deltaTime);
-                    float d = (speed > 0) ? m_MaxValue - v : v - m_MinValue;
-                    if (d < (0.1f * range) && Mathf.Abs(speed) > Epsilon)
-                        speed = Damper.Damp(v - v0, m_DecelTime, deltaTime) / deltaTime;
+                    float v = ClampValue(v0 + m_CurrentSpeed * deltaTime);
+                    float d = (m_CurrentSpeed > 0) ? m_MaxValue - v : v - m_MinValue;
+                    if (d < (0.1f * range) && Mathf.Abs(m_CurrentSpeed) > Epsilon)
+                        m_CurrentSpeed = Damper.Damp(v - v0, m_DecelTime, deltaTime);
                 }
-                input = speed * deltaTime;
+                input = m_CurrentSpeed;
             }
-            Value = ClampValue(Value + input);
+            Value = ClampValue(Value + input * deltaTime);
             return Mathf.Abs(input) > Epsilon;
         }
 

--- a/com.unity.cinemachine/Runtime/Core/AxisState.cs
+++ b/com.unity.cinemachine/Runtime/Core/AxisState.cs
@@ -233,12 +233,12 @@ namespace Cinemachine
 
             // Direct mode update: maxSpeed interpreted as multiplier
             input *= m_MaxSpeed; // apply gain
-            if (deltaTime < Epsilon)
+            if (deltaTime < 0)
                 m_CurrentSpeed = 0;
             else
             {
                 float dampTime = Mathf.Abs(input) < Mathf.Abs(m_CurrentSpeed) ? m_DecelTime : m_AccelTime;
-                m_CurrentSpeed += Damper.Damp(input - m_CurrentSpeed, dampTime * 0.5f, deltaTime);
+                m_CurrentSpeed += Damper.Damp(input - m_CurrentSpeed, dampTime, deltaTime);
 
                 // Decelerate to the end points of the range if not wrapping
                 float range = m_MaxValue - m_MinValue;
@@ -248,11 +248,11 @@ namespace Cinemachine
                     float v = ClampValue(v0 + m_CurrentSpeed * deltaTime);
                     float d = (m_CurrentSpeed > 0) ? m_MaxValue - v : v - m_MinValue;
                     if (d < (0.1f * range) && Mathf.Abs(m_CurrentSpeed) > Epsilon)
-                        m_CurrentSpeed = Damper.Damp(v - v0, m_DecelTime, deltaTime);
+                        m_CurrentSpeed = Damper.Damp(v - v0, m_DecelTime, deltaTime) / deltaTime;
                 }
-                input = m_CurrentSpeed;
+                input = m_CurrentSpeed * deltaTime;
             }
-            Value = ClampValue(Value + input * deltaTime);
+            Value = ClampValue(Value + m_CurrentSpeed);
             return Mathf.Abs(input) > Epsilon;
         }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-837: AxisState needs to apply deltaTime for all input.  When using mouse delta input, client is responsible for scaling the input value by 1/deltaTime.  In new input system, this can be done with a binding processor.  In legacy input, this can be done with a custom delegate for CinemachineCore.GetInputAxis.  There is no way to just make this work out of the box for all input devices.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
