### PR TITLE
CMCL-679: pov centers at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: AxisState Recentering wait time not work reliably in FixedUpdate.
 - Add support for HDRP 14 (Unity 2022.2)
 - Bugfix: InputValueGain mode of axis input was not framerate-independent
+- Bugfix: POV starts up in its centered position, if recentering is enabled
 
 
 ## [2.8.9] - 2022-08-24

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -119,17 +119,18 @@ namespace Cinemachine
                 return;
 
             // Only read joystick when game is playing
-            if (deltaTime >= 0 && CinemachineCore.Instance.IsLive(VirtualCamera))
+            if (deltaTime >= 0 && (!VirtualCamera.PreviousStateIsValid || !CinemachineCore.Instance.IsLive(VirtualCamera)))
+                deltaTime = -1;
+            if (deltaTime >= 0)
             {
                 if (m_HorizontalAxis.Update(deltaTime))
                     m_HorizontalRecentering.CancelRecentering();
                 if (m_VerticalAxis.Update(deltaTime))
                     m_VerticalRecentering.CancelRecentering();
-
-                var recenterTarget = GetRecenterTarget();
-                m_HorizontalRecentering.DoRecentering(ref m_HorizontalAxis, deltaTime, recenterTarget.x);
-                m_VerticalRecentering.DoRecentering(ref m_VerticalAxis, deltaTime, recenterTarget.y);
             }
+            var recenterTarget = GetRecenterTarget();
+            m_HorizontalRecentering.DoRecentering(ref m_HorizontalAxis, deltaTime, recenterTarget.x);
+            m_VerticalRecentering.DoRecentering(ref m_VerticalAxis, deltaTime, recenterTarget.y);
 
             // If we have a transform parent, then apply POV in the local space of the parent
             Quaternion rot = Quaternion.Euler(m_VerticalAxis.Value, m_HorizontalAxis.Value, 0);


### PR DESCRIPTION
### Purpose of this PR

CMCL-679: when a vcam with POV becomes live, it should start up in its centered state, if recentering is enabled.  It was starting always at 0 then recentering.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [m] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
