### PR TITLE
CMCL-936: reset projection matrix

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Collider damping is more robust with extreme FreeLook configurations
 - Add support for HDRP 14 (Unity 2022.2)
 - Bugfix: InputValueGain mode of axis input was not framerate-independent
+- Bugfix: When recording with an accumulation buffer, camera lens was not always set correctly
 
 
 ## [2.9.1] - 2022-08-24

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -971,6 +971,7 @@ namespace Cinemachine
                 Camera cam = OutputCamera;
                 if (cam != null)
                 {
+                    cam.ResetProjectionMatrix();
                     cam.nearClipPlane = state.Lens.NearClipPlane;
                     cam.farClipPlane = state.Lens.FarClipPlane;
                     cam.orthographicSize = state.Lens.OrthographicSize;


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

CMCL-936 Only affects recorder.  When recording with accumulation buffer, camera matrix gets overridden.  Fix is to reset the camera matrix before setting the camera's lens.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

