### PR TITLE
Dev/2.9 freelook forceposition

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -451,8 +451,7 @@ namespace Cinemachine
             const int maxIteration = 10;
             const float epsilon = 0.00005f;
             var x = (min + max) / 2f; // initial guess - mid point
-            int i;
-            for (i = 0; i < maxIteration; ++i)
+            for (var i = 0; i < maxIteration; ++i)
             {
                 var angle = AngleFunction(x);
                 var slope = SlopeOfAngleFunction(x);
@@ -472,10 +471,8 @@ namespace Cinemachine
             // approximating derivative using symmetric difference quotient (finite diff)
             float SlopeOfAngleFunction(float input)
             {
-                var fxBehind = GetLocalPositionForCameraFromInput(input - epsilon);
-                var angleBehind = Vector3.SignedAngle(desiredDirection, fxBehind, Vector3.right);
-                var fxAfter = GetLocalPositionForCameraFromInput(input + epsilon);
-                var angleAfter = Vector3.SignedAngle(desiredDirection, fxAfter, Vector3.right);
+                var angleBehind = AngleFunction(input - epsilon);
+                var angleAfter = AngleFunction(input + epsilon);
                 return (angleAfter - angleBehind) / (2f * epsilon);
             }
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -445,24 +445,21 @@ namespace Cinemachine
             return m_YAxis.Value; // stay conservative
         }
 
-        const float k_Epsilon = 0.00005f;
-        HashSet<float> m_Xs = new HashSet<float> {10,20,30,40,50}; // alloc 5 places, in my tests that was max - might not need, we could also add an iteration count max instead of this check
+        
         float SteepestDescent(float min, float max, Vector3 desiredDirection)
         {
-            m_Xs.Clear();
-            var x = (min + max) / 2f; // midpoint as guess
-            float angle, slope;
-            while (Mathf.Abs(AngleFunction(x)) >= k_Epsilon)
+            const int maxIteration = 10;
+            const float epsilon = 0.00005f;
+            var x = (min + max) / 2f; // initial guess - mid point
+            int i;
+            for (i = 0; i < maxIteration; ++i)
             {
-                angle = AngleFunction(x);
-                slope = SlopeOfAngleFunction(x);
-                if (slope == 0 || m_Xs.Contains(x))
+                var angle = AngleFunction(x);
+                var slope = SlopeOfAngleFunction(x);
+                if (slope == 0 || Mathf.Abs(angle) < epsilon)
                     break; // found best
-
-                m_Xs.Add(x);
                 x = Mathf.Clamp(x - (angle / slope), min, max); // clamping so we don't overshoot
             }
-            Debug.Log(m_Xs.Count);
             return x;
 
             // localFunctions
@@ -475,11 +472,11 @@ namespace Cinemachine
             // approximating derivative using symmetric difference quotient (finite diff)
             float SlopeOfAngleFunction(float input)
             {
-                var fxBehind = GetLocalPositionForCameraFromInput(input - k_Epsilon);
+                var fxBehind = GetLocalPositionForCameraFromInput(input - epsilon);
                 var angleBehind = Vector3.SignedAngle(desiredDirection, fxBehind, Vector3.right);
-                var fxAfter = GetLocalPositionForCameraFromInput(input + k_Epsilon);
+                var fxAfter = GetLocalPositionForCameraFromInput(input + epsilon);
                 var angleAfter = Vector3.SignedAngle(desiredDirection, fxAfter, Vector3.right);
-                return (angleAfter - angleBehind) / (2f * k_Epsilon);
+                return (angleAfter - angleBehind) / (2f * epsilon);
             }
         }
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -444,23 +444,25 @@ namespace Cinemachine
             }
             return m_YAxis.Value; // stay conservative
         }
-        
+
         const float k_Epsilon = 0.00005f;
+        HashSet<float> m_Xs = new HashSet<float> {10,20,30,40,50}; // alloc 5 places, in my tests that was max - might not need, we could also add an iteration count max instead of this check
         float SteepestDescent(float min, float max, Vector3 desiredDirection)
         {
-            var xs = new HashSet<float>();
+            m_Xs.Clear();
             var x = (min + max) / 2f; // midpoint as guess
             float angle, slope;
             while (Mathf.Abs(AngleFunction(x)) >= k_Epsilon)
             {
                 angle = AngleFunction(x);
                 slope = SlopeOfAngleFunction(x);
-                if (slope == 0 || xs.Count != 0 && xs.Contains(x))
+                if (slope == 0 || m_Xs.Contains(x))
                     break; // found best
 
-                xs.Add(x);
+                m_Xs.Add(x);
                 x = Mathf.Clamp(x - (angle / slope), min, max); // clamping so we don't overshoot
             }
+            Debug.Log(m_Xs.Count);
             return x;
 
             // localFunctions

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -444,7 +444,6 @@ namespace Cinemachine
             }
             return m_YAxis.Value; // stay conservative
         }
-
         
         float SteepestDescent(float min, float max, Vector3 desiredDirection)
         {
@@ -457,7 +456,7 @@ namespace Cinemachine
                 var slope = SlopeOfAngleFunction(x);
                 if (slope == 0 || Mathf.Abs(angle) < epsilon)
                     break; // found best
-                x = Mathf.Clamp(x - (angle / slope), min, max); // clamping so we don't overshoot
+                x = Mathf.Clamp(x - (angle / slope), min, max); // clamping is needed so we don't overshoot
             }
             return x;
 
@@ -467,7 +466,6 @@ namespace Cinemachine
                 var point = GetLocalPositionForCameraFromInput(input);
                 return Vector3.SignedAngle(desiredDirection, point, Vector3.right);
             }
-
             // approximating derivative using symmetric difference quotient (finite diff)
             float SlopeOfAngleFunction(float input)
             {


### PR DESCRIPTION
### Purpose of this PR
Replace freelook position search with Steepest Descent.

Binary search does not work, because the angles along the spline are not sorted. Instead, the angle function is parabolic, so finding the minimum of the parabola gives us the interpolation **t** we are looking for.

The results are more precise.

I measured performance:
Old method was 0.6 ms.
New (Steepest Descent) is 0.5-0.8 ms.

In my experience the max iteration count could be set to 5, but I wanted to be generous with 10. In my experience every point was found within 5 steps with good precision. The only time we go to 10, is when the steepest descent jumps around the solutions (e.g. x values: 0.3099999 -> 0.31.00001 -> 0.3099999 -> 0.31.00001 ...). So probably we could set it lower.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version