### PR TITLE
CMCL-653: Freelook ForcePosition is not precise enough (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: InputValueGain mode of axis input was not framerate-independent
 - Bugfix: POV starts up in its centered position, if recentering is enabled
 - Bugfix: When recording with an accumulation buffer, camera lens was not always set correctly
+- Freelook ForcePosition is more precise now.
 
 
 ## [2.8.9] - 2022-08-24

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -442,44 +442,60 @@ namespace Cinemachine
                 Vector3 flatDir = dir; flatDir.y = 0;
                 if (!flatDir.AlmostZero())
                 {
-                    float angle = Vector3.SignedAngle(flatDir, Vector3.back, Vector3.up);
+                    float angle = UnityVectorExtensions.SignedAngle(flatDir, Vector3.back, Vector3.up);
                     dir = Quaternion.AngleAxis(angle, Vector3.up) * dir;
                 }
                 dir.x = 0;
 
-                // Sample the spline in a few places, find the 2 closest, and lerp
-                int i0 = 0, i1 = 0;
-                float a0 = 0, a1 = 0;
-                const int NumSamples = 13;
-                float step = 1f / (NumSamples-1);
-                for (int i = 0; i < NumSamples; ++i)
-                {
-                    float a = Vector3.SignedAngle(
-                        dir, GetLocalPositionForCameraFromInput(i * step), Vector3.right);
-                    if (i == 0)
-                        a0 = a1 = a;
-                    else
-                    {
-                        if (Mathf.Abs(a) < Mathf.Abs(a0))
-                        {
-                            a1 = a0;
-                            i1 = i0;
-                            a0 = a;
-                            i0 = i;
-                        }
-                        else if (Mathf.Abs(a) < Mathf.Abs(a1))
-                        {
-                            a1 = a;
-                            i1 = i;
-                        }
-                    }
-                }
-                if (Mathf.Sign(a0) == Mathf.Sign(a1))
-                    return i0 * step;
-                float t = Mathf.Abs(a0) / (Mathf.Abs(a0) + Mathf.Abs(a1));
-                return Mathf.Lerp(i0 * step, i1 * step, t);
+                // We need to find the minimum of the angle of function using steepest descent
+                return SteepestDescent(dir.normalized * (cameraPos - Follow.position).magnitude);
             }
             return m_YAxis.Value; // stay conservative
+        }
+
+        float SteepestDescent(Vector3 cameraOffset)
+        {
+            const int maxIteration = 10;
+            const float epsilon = 0.00005f;
+            var x = InitialGuess(cameraOffset);
+            for (var i = 0; i < maxIteration; ++i)
+            {
+                var angle = AngleFunction(x);
+                var slope = SlopeOfAngleFunction(x);
+                if (Mathf.Abs(slope) < epsilon || Mathf.Abs(angle) < epsilon)
+                    break; // found best
+                x = Mathf.Clamp01(x - (angle / slope)); // clamping is needed so we don't overshoot
+            }
+            return x;
+
+            // localFunctions
+            float AngleFunction(float input)
+            {
+                var point = GetLocalPositionForCameraFromInput(input);
+                return Mathf.Abs(UnityVectorExtensions.SignedAngle(cameraOffset, point, Vector3.right));
+            }
+            // approximating derivative using symmetric difference quotient (finite diff)
+            float SlopeOfAngleFunction(float input)
+            {
+                var angleBehind = AngleFunction(input - epsilon);
+                var angleAfter = AngleFunction(input + epsilon);
+                return (angleAfter - angleBehind) / (2f * epsilon);
+            }
+            // initial guess based on closest line (approximating spline) to point 
+            float InitialGuess(Vector3 cameraPosInRigSpace)
+            {
+                UpdateCachedSpline();
+                var pb = m_CachedKnots[1]; // point at the bottom of spline
+                var pm = m_CachedKnots[2]; // point in the middle of spline
+                var pt = m_CachedKnots[3]; // point at the top of spline
+                var t1 = cameraPosInRigSpace.ClosestPointOnSegment(pb, pm);
+                var d1 = Vector3.SqrMagnitude(Vector3.Lerp(pb, pm, t1) - cameraPosInRigSpace);
+                var t2 = cameraPosInRigSpace.ClosestPointOnSegment(pm, pt);
+                var d2 = Vector3.SqrMagnitude(Vector3.Lerp(pm, pt, t2) - cameraPosInRigSpace);
+
+                // [0,0.5] represent bottom to mid, and [0.5,1] represents mid to top
+                return d1 < d2 ? Mathf.Lerp(0f, 0.5f, t1) : Mathf.Lerp(0.5f, 1f, t2);
+            }
         }
 
         CameraState m_State = CameraState.Default;          // Current state this frame

--- a/Tests/Runtime/FreelookForcePositionTests.cs
+++ b/Tests/Runtime/FreelookForcePositionTests.cs
@@ -1,0 +1,90 @@
+using System.Collections;
+using Cinemachine;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.TestTools.Utils;
+
+namespace Tests.Runtime
+{
+    public class FreelookForcePositionTests : CinemachineFixtureBase
+    {
+        CinemachineFreeLook m_Freelook;
+        Vector3 m_OriginalPosition;
+        Quaternion m_OriginalOrientation;
+        
+        [SetUp]
+        public override void SetUp()
+        {
+            CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain)).GetComponent<Camera>();
+            var vcamHolder = CreateGameObject("CM Freelook", typeof(CinemachineFreeLook));
+            m_Freelook = vcamHolder.GetComponent<CinemachineFreeLook>();
+            m_Freelook.Priority = 100;
+
+            base.SetUp();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+
+        static IEnumerable RigSetups
+        {
+            get
+            {
+                yield return new TestCaseData(new[]
+                {
+                    new CinemachineFreeLook.Orbit { m_Height = 0, m_Radius = 1 },
+                    new CinemachineFreeLook.Orbit { m_Height = 1, m_Radius = 2 },
+                    new CinemachineFreeLook.Orbit { m_Height = 2, m_Radius = 3 }
+                }).SetName("Rig1").Returns(null);
+
+                yield return new TestCaseData(new[]
+                {
+                    new CinemachineFreeLook.Orbit { m_Height = 5, m_Radius = 3 },
+                    new CinemachineFreeLook.Orbit { m_Height = 3, m_Radius = 1 },
+                    new CinemachineFreeLook.Orbit { m_Height = 1, m_Radius = 2 }
+                }).SetName("Rig2").Returns(null);
+
+                yield return new TestCaseData(new[]
+                {
+                    new CinemachineFreeLook.Orbit { m_Height = -1, m_Radius = 3 },
+                    new CinemachineFreeLook.Orbit { m_Height = -3, m_Radius = 8 },
+                    new CinemachineFreeLook.Orbit { m_Height = -5, m_Radius = 5 }
+                }).SetName("Rig3").Returns(null);
+            }
+        }
+
+        [UnityTest, TestCaseSource(nameof(RigSetups))]
+        public IEnumerator Test_Freelook_ForcePosition_Precision(CinemachineFreeLook.Orbit[] rigSetup)
+        {
+            for (var i = 0; i < m_Freelook.m_Orbits.Length; ++i) 
+                m_Freelook.m_Orbits[i] = rigSetup[i];
+
+            const float steps = 20f;
+            for (var i = 0f; i <= steps; ++i)
+            {
+                var axisValue = i / steps;
+                m_Freelook.m_XAxis.Value = 180f * axisValue; // x axis range [0, 180]
+                m_Freelook.m_YAxis.Value = axisValue; // y axis range [0, 1]
+        
+                yield return null;
+        
+                // save camera current position and rotation
+                m_OriginalPosition = m_Freelook.State.CorrectedPosition;
+                m_OriginalOrientation = m_Freelook.State.CorrectedOrientation;
+        
+                yield return null;
+        
+                m_Freelook.ForceCameraPosition(m_OriginalPosition, m_OriginalOrientation);
+        
+                yield return null;
+        
+                Assert.That(m_Freelook.State.CorrectedPosition, Is.EqualTo(m_OriginalPosition).Using(new Vector3EqualityComparer(0.01f)));
+                Assert.That(m_Freelook.State.CorrectedOrientation, Is.EqualTo(m_OriginalOrientation).Using(new QuaternionEqualityComparer(0.001f)));
+            }
+        }
+    }
+}

--- a/Tests/Runtime/FreelookForcePositionTests.cs.meta
+++ b/Tests/Runtime/FreelookForcePositionTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 91618bd9ae854bccb009be5799b14b49
+timeCreated: 1664223159


### PR DESCRIPTION
### Purpose of this PR

[CMCL-653](https://jira.unity3d.com/browse/CMCL-653)
Backport of https://github.com/Unity-Technologies/com.unity.cinemachine/pull/574

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation