### PR TITLE
CMCL-0000: add targeted cameras menu group

### DIFF
--- a/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
+++ b/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
@@ -85,6 +85,24 @@ namespace Cinemachine.Editor
             Undo.AddComponent<InputAxisController>(vcam.gameObject);
             Undo.AddComponent<CinemachineFreeLookModifier>(vcam.gameObject).enabled = false;
         }
+        
+        [MenuItem(m_CinemachineGameObjectRootMenu + "Targeted Cameras/Third Person Aim Camera", false, m_GameObjectMenuPriority)]
+        static void CreateThirdPersonAimCamera(MenuCommand command)
+        {
+            CinemachineEditorAnalytics.SendCreateEvent("Third Person Aim Camera");
+            var targetObject = command.context as GameObject;
+            var parent = targetObject == null || targetObject.transform.parent == null 
+                ? null : targetObject.transform.parent.gameObject;
+            var vcam = CreatePassiveVirtualCamera("Third Person Aim Camera", parent, true);
+            if (targetObject != null)
+                vcam.Follow = targetObject.transform;
+            var thirdPersonFollow = Undo.AddComponent<Cinemachine3rdPersonFollow>(vcam.gameObject);
+            thirdPersonFollow.ShoulderOffset = new Vector3(0.8f, -0.4f, 0f);
+            thirdPersonFollow.CameraSide = 1;
+            thirdPersonFollow.VerticalArmLength = 1.2f;
+            thirdPersonFollow.CameraDistance = 4f;
+            Undo.AddComponent<Cinemachine3rdPersonAim>(vcam.gameObject);
+        }
 
         [MenuItem(m_CinemachineGameObjectRootMenu + "Targeted Cameras/Target Group Camera", false, m_GameObjectMenuPriority)]
         static void CreateTargetGroupCamera(MenuCommand command)

--- a/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
@@ -42,7 +42,7 @@ namespace Cinemachine.Editor
             if (GUI.Button(rect, EditorGUIUtility.IconContent("_Popup"), GUI.skin.label))
             {
                 GenericMenu menu = new GenericMenu();
-                menu.AddItem(new GUIContent("Convert to TargetGroup"), false, () =>
+                menu.AddItem(new GUIContent("Convert to Target Group"), false, () =>
                 {
                     if (target != null && target.GetComponent<CinemachineTargetGroup>() == null)
                     {
@@ -50,7 +50,7 @@ namespace Cinemachine.Editor
                         var group = go.GetComponent<CinemachineTargetGroup>();
                    
                         group.RotationMode = CinemachineTargetGroup.RotationModes.GroupAverage;
-                        group.AddMember(target, 1, 1);
+                        group.AddMember(target, 1, 0.5f);
                         property.objectReferenceValue = group.Transform;
                         property.serializedObject.ApplyModifiedProperties();
                     }


### PR DESCRIPTION
### Purpose of this PR

Experiment: add Targeted Cameras menu group.

When you right-click on a GameObject and select one of the Targeted Camera options, it will create the camera as a sibling of the clicked-on thing and then automatically populate the Tracking Target with that thing.  So, right-click on Player, then select FreeLook camera and you have a FreeLook tracking the player, ready to go.

![image](https://user-images.githubusercontent.com/6424658/192885061-b4b6f61d-c53d-438e-aca5-ca985d78f3a6.png)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

