### PR TITLE
CMCL-0000: [TestingDojo] Remove capsule from FreeLook on Spherical Surface scene

### DIFF
--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -90,8 +90,10 @@ namespace Cinemachine.Editor
             if (m_NavelGazeMessage != null)
             {
                 CameraState state = Target.State;
-                bool isNavelGazing = Target.PreviousStateIsValid 
-                    && state.HasLookAt() && (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero();
+                bool isNavelGazing = Target.PreviousStateIsValid && state.HasLookAt() &&
+                    (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero() &&
+                    (Target.GetCinemachineComponent(CinemachineCore.Stage.Body) != null ||
+                        Target.GetCinemachineComponent(CinemachineCore.Stage.Aim) != null);
                 m_NavelGazeMessage.style.display = isNavelGazing ? DisplayStyle.Flex : DisplayStyle.None;
             }
 


### PR DESCRIPTION
Warning camera is trying to look at itself not always accurate. For example, move cmCamera to its target, and set the Position and Rotation control to null. The warning message is still there without this fix.