### PR TITLE
CMCL-0000: 's' before Blend Time is confusing [Experiment, CinemachineTestingDojo] 

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -122,7 +122,7 @@ namespace Cinemachine.Editor
                     EditorGUI.LabelField(rect, "Style");
 
                     rect.x += rect.width + hSpace; rect.width = floatFieldWidth;
-                    EditorGUI.LabelField(rect, "Time");
+                    EditorGUI.LabelField(rect, "Time (s)");
                 };
 
             m_BlendList.drawElementCallback

--- a/com.unity.cinemachine/Editor/PropertyDrawers/CinemachineBlendDefinitionPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CinemachineBlendDefinitionPropertyDrawer.cs
@@ -15,7 +15,7 @@ namespace Cinemachine.Editor
             float floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
 
             SerializedProperty timeProp = property.FindPropertyRelative(() => myClass.m_Time);
-            GUIContent timeText = new GUIContent(" s", timeProp.tooltip);
+            GUIContent timeText = new GUIContent(" ", timeProp.tooltip);
             var textDimensions = GUI.skin.label.CalcSize(timeText);
 
             rect = EditorGUI.PrefixLabel(rect, EditorGUI.BeginProperty(rect, label, property));
@@ -72,7 +72,7 @@ namespace Cinemachine.Editor
                 { style = { flexGrow = 0, flexBasis = floatFieldWidth }});
 
             var timeProp = property.FindPropertyRelative(() => myClass.m_Time);
-            var timeWidget = row.Right.AddChild(new InspectorUtility.CompactPropertyField(timeProp, "s")
+            var timeWidget = row.Right.AddChild(new InspectorUtility.CompactPropertyField(timeProp, " ")
                 { style = { flexGrow = 0, flexBasis = floatFieldWidth, marginLeft = 5 }});
 
             OnStyleChanged(styleProp);


### PR DESCRIPTION
### Purpose of this PR
Bug Dojo note: "Blend List Camera "s" before Hold layout is confusing a little bit "

Removed 's' from float field and added it in the Title row instead. Left a space for the float field to have a tooltip overlay space.

On the image, my mouse (invisible on screenshot) is hovering the part that you can touch to drag the float value (when the mouse has a little left and right arrow on top of it). This shows the tooltip.
<img width="383" alt="Screen Shot 2022-10-11 at 5 18 39 PM" src="https://user-images.githubusercontent.com/57672095/195200516-1c0fdfc3-d38c-476c-9539-953b70eb8f6f.png">

Could do same for Default Blend.
<img width="488" alt="Screen Shot 2022-10-11 at 5 22 43 PM" src="https://user-images.githubusercontent.com/57672095/195200990-c370fbb3-ef82-47cd-b64d-243a860868aa.png">

Could do same for Hold, and probably Blend In too.
<img width="499" alt="Screen Shot 2022-10-11 at 5 27 59 PM" src="https://user-images.githubusercontent.com/57672095/195201771-4431260f-104b-4328-9dae-8a5d9c96a303.png">

What do you think?

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
