### PR TITLE
CMCL-0000: Physical camera fix

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -1012,14 +1012,14 @@ namespace Cinemachine
                 Camera cam = OutputCamera;
                 if (cam != null)
                 {
-                    cam.ResetProjectionMatrix();
+                    bool isPhysical = cam.usePhysicalProperties;
+                    if (!isPhysical)
+                        cam.ResetProjectionMatrix();
                     cam.nearClipPlane = state.Lens.NearClipPlane;
                     cam.farClipPlane = state.Lens.FarClipPlane;
                     cam.orthographicSize = state.Lens.OrthographicSize;
                     cam.fieldOfView = state.Lens.FieldOfView;
-
-                    bool isPhysical = cam.usePhysicalProperties;
-
+                    
                     if (LensModeOverride.Enabled)
                     {
                         if (state.Lens.ModeOverride != LensSettings.OverrideModes.None)

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -1013,8 +1013,8 @@ namespace Cinemachine
                 if (cam != null)
                 {
                     bool isPhysical = cam.usePhysicalProperties;
-                    if (!isPhysical)
-                        cam.ResetProjectionMatrix();
+                    cam.ResetProjectionMatrix();
+                    cam.usePhysicalProperties = isPhysical;
                     cam.nearClipPlane = state.Lens.NearClipPlane;
                     cam.farClipPlane = state.Lens.FarClipPlane;
                     cam.orthographicSize = state.Lens.OrthographicSize;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -1014,13 +1014,14 @@ namespace Cinemachine
                 {
                     bool isPhysical = cam.usePhysicalProperties;
                     cam.ResetProjectionMatrix();
-                    cam.usePhysicalProperties = isPhysical;
                     cam.nearClipPlane = state.Lens.NearClipPlane;
                     cam.farClipPlane = state.Lens.FarClipPlane;
                     cam.orthographicSize = state.Lens.OrthographicSize;
                     cam.fieldOfView = state.Lens.FieldOfView;
                     
-                    if (LensModeOverride.Enabled)
+                    if (!LensModeOverride.Enabled)
+                        cam.usePhysicalProperties = isPhysical; // because ResetProjectionMatrix resets it
+                    else
                     {
                         if (state.Lens.ModeOverride != LensSettings.OverrideModes.None)
                         {

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -273,7 +273,7 @@ namespace Cinemachine
             NearClipPlane = nearClip;
             FarClipPlane = farClip;
             Dutch = dutch;
-            m_SensorSize = new Vector2(1, 1);
+            m_SensorSize = Vector3.one;
             GateFit = Camera.GateFitMode.Horizontal;
 
 #if CINEMACHINE_HDRP

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -273,7 +273,7 @@ namespace Cinemachine
             NearClipPlane = nearClip;
             FarClipPlane = farClip;
             Dutch = dutch;
-            m_SensorSize = Vector3.one;
+            m_SensorSize = Vector2.one;
             GateFit = Camera.GateFitMode.Horizontal;
 
 #if CINEMACHINE_HDRP


### PR DESCRIPTION
### Purpose of this PR
We could not change to physical camera, because of ResetProjectionMatrix.

Guillaume noted in the bug dojo:
The physical sensor size is set to 1 mm by default. Should we have a 35 mm default instead?

What should we do about it?

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 