### PR TITLE
CMCL-0000: Stale text based reference in AnimationController [CinemachineTestingDojo]

### DIFF
--- a/com.unity.cinemachine/Samples~/Sample Scenes/Shared/Cameron/Model/CameronSimpleController.controller
+++ b/com.unity.cinemachine/Samples~/Sample Scenes/Shared/Cameron/Model/CameronSimpleController.controller
@@ -3,9 +3,6 @@
 --- !u!206 &-3149639009288007864
 BlendTree:
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: Blend Tree
   m_Childs:
   - serializedVersion: 2
@@ -71,37 +68,9 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 2
---- !u!1101 &-1003416643247770379
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Jump
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 6938611319206377421}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.12697601
-  m_TransitionOffset: 0.03187641
-  m_ExitTime: 0.8275654
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: CameronSimpleController
   serializedVersion: 5
   m_AnimatorParameters:
@@ -151,7 +120,6 @@ AnimatorController:
   - serializedVersion: 5
     m_Name: Base Layer
     m_StateMachine: {fileID: 5252751724755048829}
-    m_Mask: {fileID: 0}
     m_Motions: []
     m_Behaviours: []
     m_BlendingMode: 0
@@ -163,15 +131,11 @@ AnimatorController:
 --- !u!1101 &775935384185778692
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Land
     m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 5351786783861475141}
   m_Solo: 0
   m_Mute: 0
@@ -189,9 +153,6 @@ AnimatorStateTransition:
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: Jump
   m_Speed: 1
   m_CycleOffset: 0
@@ -216,9 +177,6 @@ AnimatorState:
 AnimatorStateMachine:
   serializedVersion: 6
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: Base Layer
   m_ChildStates:
   - serializedVersion: 1
@@ -241,9 +199,6 @@ AnimatorStateMachine:
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: Movement
   m_Speed: 1
   m_CycleOffset: 0
@@ -267,15 +222,11 @@ AnimatorState:
 --- !u!1101 &5406036619693422872
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Jump
     m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3847384438597556834}
   m_Solo: 0
   m_Mute: 0


### PR DESCRIPTION
### Purpose of this PR
Fix stale text references in AnimationControlller.
![New samples import (1)](https://user-images.githubusercontent.com/57672095/195421631-9c2870dd-bd88-4a8f-88cf-61df80ebdf84.png)

There is still a Removing null node error when enterring playmode. I have asked devs-editor why this could happen, because the error is thrown there. This happens on master branch.

### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 