### PR TITLE
CMCL-0000: GroupFraming is different in old and new  [CinemachineTestingDojo]

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -160,7 +160,7 @@ namespace Cinemachine
                 return;
 
             var group = vcam.FollowTargetAsGroup;
-            if (group == null || group.Sphere.radius < k_MinimumGroupSize)
+            if (group == null)
                 return;
 
             var extra = GetExtraState<VcamExtraState>(vcam);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -128,12 +128,14 @@ namespace Cinemachine
             public Vector3 PosAdjustment;
             public Vector2 RotAdjustment;
             public float FovAdjustment;
+            public bool PreviousStateIsValid;
 
             public void Reset()
             {
                 PosAdjustment = Vector3.zero;
                 RotAdjustment = Vector2.zero;
                 FovAdjustment = 0;
+                PreviousStateIsValid = false;
             }
         };
 
@@ -159,14 +161,15 @@ namespace Cinemachine
             if (stage != CinemachineCore.Stage.Noise)
                 return;
 
-            var group = vcam.FollowTargetAsGroup;
-            if (group == null)
-                return;
-
             var extra = GetExtraState<VcamExtraState>(vcam);
             if (!vcam.PreviousStateIsValid)
                 extra.Reset();
-            
+
+            var group = vcam.FollowTargetAsGroup;
+            if (group == null || extra.PreviousStateIsValid && group.Sphere.radius < k_MinimumGroupSize)
+                return;
+            extra.PreviousStateIsValid = true;
+
             if (state.Lens.Orthographic)
                 OrthoFraming(vcam, group, extra, ref state, deltaTime);
             else

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -158,14 +158,14 @@ namespace Cinemachine
             // We ignore the noise effect anyway, so it doesn't hurt.
             if (stage != CinemachineCore.Stage.Noise)
                 return;
+            
+            var group = vcam.FollowTargetAsGroup;
+            if (group == null)
+                return;
 
             var extra = GetExtraState<VcamExtraState>(vcam);
             if (!vcam.PreviousStateIsValid)
                 extra.Reset();
-
-            var group = vcam.FollowTargetAsGroup;
-            if (group == null)
-                return;
 
             if (state.Lens.Orthographic)
                 OrthoFraming(vcam, group, extra, ref state, deltaTime);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -128,14 +128,12 @@ namespace Cinemachine
             public Vector3 PosAdjustment;
             public Vector2 RotAdjustment;
             public float FovAdjustment;
-            public bool PreviousStateIsValid;
 
             public void Reset()
             {
                 PosAdjustment = Vector3.zero;
                 RotAdjustment = Vector2.zero;
                 FovAdjustment = 0;
-                PreviousStateIsValid = false;
             }
         };
 
@@ -166,9 +164,8 @@ namespace Cinemachine
                 extra.Reset();
 
             var group = vcam.FollowTargetAsGroup;
-            if (group == null || extra.PreviousStateIsValid && group.Sphere.radius < k_MinimumGroupSize)
+            if (group == null)
                 return;
-            extra.PreviousStateIsValid = true;
 
             if (state.Lens.Orthographic)
                 OrthoFraming(vcam, group, extra, ref state, deltaTime);

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -692,7 +692,7 @@ namespace Cinemachine
         {
             c.FramingMode = (CinemachineGroupFraming.FramingModes)m_GroupFramingMode; // values are the same
             c.FramingSize = m_GroupFramingSize;
-            c.Damping = 0;
+            c.Damping = m_ZDamping;
             c.SizeAdjustment = (CinemachineGroupFraming.SizeAdjustmentModes)m_AdjustmentMode; // values are the same
             c.LateralAdjustment = CinemachineGroupFraming.LateralAdjustmentModes.ChangePosition;
             c.DollyRange = new Vector2(-m_MaxDollyIn, m_MaxDollyOut);

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -692,7 +692,7 @@ namespace Cinemachine
         {
             c.FramingMode = (CinemachineGroupFraming.FramingModes)m_GroupFramingMode; // values are the same
             c.FramingSize = m_GroupFramingSize;
-            c.Damping = m_ZDamping;
+            c.Damping = 0;
             c.SizeAdjustment = (CinemachineGroupFraming.SizeAdjustmentModes)m_AdjustmentMode; // values are the same
             c.LateralAdjustment = CinemachineGroupFraming.LateralAdjustmentModes.ChangePosition;
             c.DollyRange = new Vector2(-m_MaxDollyIn, m_MaxDollyOut);


### PR DESCRIPTION
### Purpose of this PR
- [x] Initial state was different between old and new, because new did not run when previous frame was invalid.
- [x] Behaviour is still not the same when damping is enabled.  Both look ok. Old one seems to be buggy. We keep new good behaviour. Will fix old later.

Old FramingTransposer has a bug probably. It is not tracking the TargetGroup. It also modifies the Camera's Z value by -1. New one is tracking the TargetGroup position correctly. So I think the new one is correct, the old one has a bug.

What do you think? I send you a project where you can test it easily to see.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 