### PR TITLE
CMCL-1174: Exempt some API doc missing errors

### DIFF
--- a/.yamato/package-validation.yml
+++ b/.yamato/package-validation.yml
@@ -21,8 +21,8 @@ api_doc_validation:
     - unity-downloader-cli --fast --wait -u {{ all_tests.first.editors.first }} -c editor
     # Run PVS in PVP mode.
     - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
-    # Require that PVP-20-1 (API docs validation) passed
-    - upm-pvp require PVP-20-1 --results "upm-ci~/pvp" --failures "upm-ci~/pvp/failures.json"
+    # Require that PVP-20-1 (API docs validation) passed, also exempt some known errors which are in pvp_api_doc_exemptions.json
+    - upm-pvp require ./pvp_api_doc_exemptions.json --results "upm-ci~/pvp" --failures "upm-ci~/pvp/failures.json"
   artifacts:
     pvp:
       paths:

--- a/pvp_api_doc_exemptions.json
+++ b/pvp_api_doc_exemptions.json
@@ -1,0 +1,29 @@
+{
+  "exempts": {
+    "PVP-20-1": {
+      "errors": [
+        "Missing Doc on System.String Cinemachine.Editor.CinemachineTool::GetIconPath()",
+        "Missing Doc on System.Void Cinemachine.CinemachineBlendListCamera::Reset()",
+        "Missing Doc on System.Void Cinemachine.CinemachineClearShot::Reset()",
+        "Missing Doc on System.Void Cinemachine.CinemachineMixingCamera::Reset()",
+        "Missing Doc on Cinemachine.CinemachineStoryboard",
+        "Missing Doc on System.Void Cinemachine.CinemachineTargetGroup::ISerializationCallbackReceiver.OnBeforeSerialize()",
+        "Missing Doc on System.Void Cinemachine.CinemachineSplineDolly::OnEnable()",
+        "Missing Doc on System.Void Cinemachine.CinemachineCameraManagerBase::Reset()",
+        "Invalid XML on: System.Single Cinemachine.SplineAutoDolly.ISplineAutoDolly::GetSplinePosition(MonoBehaviour, Transform, SplineContainer, System.Single, PathIndexUnit, System.Single). XML comment has badly formed XML -- \u0027An identifier was expected.\u0027",
+        "Missing Doc on System.Void Cinemachine.SplineAutoDolly.FixedSpeed::Cinemachine.SplineAutoDolly.ISplineAutoDolly.Validate()",
+        "Missing Doc on System.Single Cinemachine.SplineAutoDolly.FixedSpeed::Cinemachine.SplineAutoDolly.ISplineAutoDolly.GetSplinePosition(MonoBehaviour, Transform, SplineContainer, System.Single, PathIndexUnit, System.Single)",
+        "Missing Doc on System.Void Cinemachine.SplineAutoDolly.NearestPointToTarget::Cinemachine.SplineAutoDolly.ISplineAutoDolly.Validate()",
+        "Missing Doc on System.Single Cinemachine.SplineAutoDolly.NearestPointToTarget::Cinemachine.SplineAutoDolly.ISplineAutoDolly.GetSplinePosition(MonoBehaviour, Transform, SplineContainer, System.Single, PathIndexUnit, System.Single)",
+        "Missing Doc on System.Boolean Cinemachine.AxisState.IRequiresInput::RequiresInput()",
+        "Missing Doc on System.Boolean Cinemachine.CinemachineFreeLook::Cinemachine.AxisState.IRequiresInput.RequiresInput()",
+        "Missing Doc on System.Boolean Cinemachine.CinemachineOrbitalTransposer::Cinemachine.AxisState.IRequiresInput.RequiresInput()",
+        "Missing Doc on System.Boolean Cinemachine.CinemachinePOV::Cinemachine.AxisState.IRequiresInput.RequiresInput()",
+        "Missing \u003Creturns\u003E on non-void method System.Boolean Cinemachine.CinemachineVirtualCamera::Cinemachine.AxisState.IRequiresInput.RequiresInput()"
+      ]
+    }
+  },
+  "requires": [
+    "PVP-20-1"
+  ]
+}


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR
Exempt some API doc missing errors for Cinematic's API doc validation CI job. 
Some of the errors are false alarm, for example PVP complains private and protected methods miss doc, This is incorrect.
This PR is to filter out these noises.

[JIRA issue. Desc of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more.]
[CMCL-1174](https://jira.unity3d.com/browse/CMCL-1174) CI: Add API docs validation test to Cinemachine

