### PR TITLE
CMCL-0000: Dev/screen composition ux refactor

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added "Place Objects At World Origin" preference option support.
 - Added Channel setting, to use for multiple CM Brains, instead of piggybacking on the layer system.
 - CinemachineConfiner renamed to CinemachineDeoccluder
+- New inspector and API for composition guides.
+- Game View Guides now indicate when they are hot and can be dragged.
 
 
 ## [3.0.0-pre.1] - 2022-06-01

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -67,7 +67,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnGUI()
         {
-            // Draw the camera guides
             if (Target == null || !CinemachineCorePrefs.ShowInGameGuides.Value || !Target.isActiveAndEnabled)
                 return;
 
@@ -75,9 +74,8 @@ namespace Cinemachine.Editor
             if (brain == null || (brain.OutputCamera.activeTexture != null && CinemachineCore.Instance.BrainCount > 1))
                 return;
 
-            bool isLive = targets.Length <= 1 && brain.IsLive(Target.VirtualCamera, true);
-
             // Screen guides
+            bool isLive = targets.Length <= 1 && brain.IsLive(Target.VirtualCamera, true);
             m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens);
 
             // Draw an on-screen gizmo for the target

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -20,10 +20,8 @@ namespace Cinemachine.Editor
         {
             m_PipelineUtility = new (this);
             m_ScreenGuideEditor = new CinemachineScreenComposerGuides();
-            m_ScreenGuideEditor.GetHardGuide = () => Target.HardGuideRect;
-            m_ScreenGuideEditor.GetSoftGuide = () => Target.SoftGuideRect;
-            m_ScreenGuideEditor.SetHardGuide = (Rect r) => { Target.HardGuideRect = r; };
-            m_ScreenGuideEditor.SetSoftGuide = (Rect r) => { Target.SoftGuideRect = r; };
+            m_ScreenGuideEditor.GetComposition = () => Target.Composition;
+            m_ScreenGuideEditor.SetComposition = (ScreenComposerSettings s) => Target.Composition = s;
             m_ScreenGuideEditor.Target = () => serializedObject;
 
             m_GameViewEventCatcher = new GameViewEventCatcher();
@@ -56,13 +54,12 @@ namespace Cinemachine.Editor
 
             m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackedObjectOffset)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDistance)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.DeadZoneDepth)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.UnlimitedSoftZone)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CenterOnActivate)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
 
             m_PipelineUtility.UpdateState();
             return ux;
@@ -81,7 +78,7 @@ namespace Cinemachine.Editor
             bool isLive = targets.Length <= 1 && brain.IsLive(Target.VirtualCamera, true);
 
             // Screen guides
-            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens, !Target.UnlimitedSoftZone);
+            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens);
 
             // Draw an on-screen gizmo for the target
             if (Target.FollowTarget != null && isLive)

--- a/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
@@ -20,10 +20,8 @@ namespace Cinemachine.Editor
         {
             m_PipelineUtility = new (this);
             m_ScreenGuideEditor = new CinemachineScreenComposerGuides();
-            m_ScreenGuideEditor.GetHardGuide = () => { return Target.HardGuideRect; };
-            m_ScreenGuideEditor.GetSoftGuide = () => { return Target.SoftGuideRect; };
-            m_ScreenGuideEditor.SetHardGuide = (Rect r) => { Target.HardGuideRect = r; };
-            m_ScreenGuideEditor.SetSoftGuide = (Rect r) => { Target.SoftGuideRect = r; };
+            m_ScreenGuideEditor.GetComposition = () => Target.Composition;
+            m_ScreenGuideEditor.SetComposition = (ScreenComposerSettings s) => Target.Composition = s;
             m_ScreenGuideEditor.Target = () => { return serializedObject; };
 
             m_GameViewEventCatcher = new GameViewEventCatcher();
@@ -54,10 +52,10 @@ namespace Cinemachine.Editor
 
             m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackedObjectOffset)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CenterOnActivate)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
             m_PipelineUtility.UpdateState();
             return ux;
         }
@@ -76,7 +74,7 @@ namespace Cinemachine.Editor
 
             // Screen guides
             bool isLive = targets.Length <= 1 && brain.IsLive(vcam, true);
-            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens, true);
+            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens);
 
             // Draw an on-screen gizmo for the target
             if (Target.LookAtTarget != null && isLive)

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineComposerEditor.cs
@@ -9,21 +9,8 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachineComposerEditor : BaseEditor<CinemachineComposer>
     {
-        CinemachineScreenComposerGuides m_ScreenGuideEditor;
-        GameViewEventCatcher m_GameViewEventCatcher;
-
         protected virtual void OnEnable()
         {
-            m_ScreenGuideEditor = new CinemachineScreenComposerGuides();
-            m_ScreenGuideEditor.GetHardGuide = () => { return Target.HardGuideRect; };
-            m_ScreenGuideEditor.GetSoftGuide = () => { return Target.SoftGuideRect; };
-            m_ScreenGuideEditor.SetHardGuide = (Rect r) => { Target.HardGuideRect = r; };
-            m_ScreenGuideEditor.SetSoftGuide = (Rect r) => { Target.SoftGuideRect = r; };
-            m_ScreenGuideEditor.Target = () => { return serializedObject; };
-
-            m_GameViewEventCatcher = new GameViewEventCatcher();
-            m_GameViewEventCatcher.OnEnable();
-
             CinemachineDebug.OnGUIHandlers -= OnGUI;
             CinemachineDebug.OnGUIHandlers += OnGUI;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
@@ -34,7 +21,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnDisable()
         {
-            m_GameViewEventCatcher.OnDisable();
             CinemachineDebug.OnGUIHandlers -= OnGUI;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
                 InspectorUtility.RepaintGameView();
@@ -59,7 +45,6 @@ namespace Cinemachine.Editor
 
             // Draw the properties
             DrawRemainingPropertiesInInspector();
-            m_ScreenGuideEditor.SetNewBounds(oldHard, oldSoft, Target.HardGuideRect, Target.SoftGuideRect);
         }
 
         protected virtual void OnGUI()
@@ -78,11 +63,8 @@ namespace Cinemachine.Editor
             if (brain == null || (brain.OutputCamera.activeTexture != null && CinemachineCore.Instance.BrainCount > 1))
                 return;
 
-            // Screen guides
-            bool isLive = targets.Length <= 1 && brain.IsLive(vcam, true);
-            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens, true);
-
             // Draw an on-screen gizmo for the target
+            bool isLive = targets.Length <= 1 && brain.IsLive(vcam, true);
             if (Target.LookAtTarget != null && isLive)
             {
                 Vector3 targetScreenPosition = brain.OutputCamera.WorldToScreenPoint(Target.TrackedPoint);

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineFramingTransposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineFramingTransposerEditor.cs
@@ -10,9 +10,6 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachineFramingTransposerEditor : BaseEditor<CinemachineFramingTransposer>
     {
-        CinemachineScreenComposerGuides m_ScreenGuideEditor;
-        GameViewEventCatcher m_GameViewEventCatcher;
-
         /// <summary>Get the property names to exclude in the inspector.</summary>
         /// <param name="excluded">Add the names to this list</param>
         protected override void GetExcludedPropertiesInInspector(List<string> excluded)
@@ -80,16 +77,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnEnable()
         {
-            m_ScreenGuideEditor = new CinemachineScreenComposerGuides();
-            m_ScreenGuideEditor.GetHardGuide = () => { return Target.HardGuideRect; };
-            m_ScreenGuideEditor.GetSoftGuide = () => { return Target.SoftGuideRect; };
-            m_ScreenGuideEditor.SetHardGuide = (Rect r) => { Target.HardGuideRect = r; };
-            m_ScreenGuideEditor.SetSoftGuide = (Rect r) => { Target.SoftGuideRect = r; };
-            m_ScreenGuideEditor.Target = () => { return serializedObject; };
-
-            m_GameViewEventCatcher = new GameViewEventCatcher();
-            m_GameViewEventCatcher.OnEnable();
-
             CinemachineDebug.OnGUIHandlers -= OnGUI;
             CinemachineDebug.OnGUIHandlers += OnGUI;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
@@ -101,7 +88,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnDisable()
         {
-            m_GameViewEventCatcher.OnDisable();
             CinemachineDebug.OnGUIHandlers -= OnGUI;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
                 InspectorUtility.RepaintGameView();
@@ -128,7 +114,6 @@ namespace Cinemachine.Editor
 
             // Draw the properties
             DrawRemainingPropertiesInInspector();
-            m_ScreenGuideEditor.SetNewBounds(oldHard, oldSoft, Target.HardGuideRect, Target.SoftGuideRect);
         }
         
         protected virtual void OnGUI()
@@ -145,12 +130,8 @@ namespace Cinemachine.Editor
             if (brain == null || (brain.OutputCamera.activeTexture != null && CinemachineCore.Instance.BrainCount > 1))
                 return;
 
-            bool isLive = targets.Length <= 1 && brain.IsLive(Target.VirtualCamera, true);
-
-            // Screen guides
-            m_ScreenGuideEditor.OnGUI_DrawGuides(isLive, brain.OutputCamera, Target.VcamState.Lens, !Target.m_UnlimitedSoftZone);
-
             // Draw an on-screen gizmo for the target
+            bool isLive = targets.Length <= 1 && brain.IsLive(Target.VirtualCamera, true);
             if (Target.FollowTarget != null && isLive)
             {
                 Vector3 targetScreenPosition = brain.OutputCamera.WorldToScreenPoint(Target.TrackedPoint);

--- a/com.unity.cinemachine/Editor/Utility/CinemachineScreenComposerGuides.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineScreenComposerGuides.cs
@@ -290,9 +290,9 @@ namespace Cinemachine.Editor
             if (Event.current.type == EventType.MouseUp)
                 m_IsDragging = m_IsHot = DragBar.NONE;
             if (Event.current.type == EventType.MouseDown)
-                m_IsDragging = GeDragBarUnderPoint(Event.current.mousePosition);
+                m_IsDragging = GetDragBarUnderPoint(Event.current.mousePosition);
             if (Event.current.type == EventType.Repaint)
-                m_IsHot = GeDragBarUnderPoint(Event.current.mousePosition);
+                m_IsHot = m_IsDragging != DragBar.NONE ? m_IsDragging : GetDragBarUnderPoint(Event.current.mousePosition);
 
             // Handle an actual drag event
             if (m_IsDragging != DragBar.NONE && Event.current.type == EventType.MouseDrag)
@@ -322,7 +322,7 @@ namespace Cinemachine.Editor
             }
         }
 
-        DragBar GeDragBarUnderPoint(Vector2 point)
+        DragBar GetDragBarUnderPoint(Vector2 point)
         {
             var bar = DragBar.NONE;
             for (DragBar i = DragBar.Center; i < DragBar.NONE && bar == DragBar.NONE; ++i)

--- a/com.unity.cinemachine/Editor/Utility/CinemachineScreenComposerGuides.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineScreenComposerGuides.cs
@@ -215,7 +215,7 @@ namespace Cinemachine.Editor
             hardBarsColour.a *= overlayOpacity;
             softBarsColour.a *= overlayOpacity;
 
-            Rect r = GetComposition().HardLimits.Enabled ? GetComposition().HardLimitsRect : new Rect(-2, -2, 4, 4);
+            Rect r = GetComposition().HardLimitsRect;
             float hardEdgeLeft = r.xMin * screenWidth;
             float hardEdgeTop = r.yMin * screenHeight;
             float hardEdgeRight = r.xMax * screenWidth;

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -407,8 +407,10 @@ namespace Cinemachine.Editor
             UpdateVisibility(interactiveLabel, interactiveToggle);
             static void UpdateVisibility(Label label, Toggle toggle)
             {
+                toggle.value = CinemachineCorePrefs.DraggableComposerGuides.Value;
                 toggle.SetVisible(CinemachineCorePrefs.ShowInGameGuides.Value);
                 label.style.opacity = CinemachineCorePrefs.DraggableComposerGuides.Value ? 1 : 0.5f;
+                //label.text = CinemachineCorePrefs.DraggableComposerGuides.Value ? "Draggable" : "Not draggable";
                 label.SetVisible(CinemachineCorePrefs.ShowInGameGuides.Value);
             }
 

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -344,27 +344,22 @@ namespace Cinemachine.Editor
         /// </summary>
         public void AddSaveDuringPlayToggle(VisualElement ux)
         {
-            var helpBox = new HelpBox("CmCamera settings changes made during Play Mode will be "
-                    + "propagated back to the scene when Play Mode is exited.", 
-                HelpBoxMessageType.Info);
-            helpBox.style.display = (SaveDuringPlay.SaveDuringPlay.Enabled && Application.isPlaying) 
-                ? DisplayStyle.Flex : DisplayStyle.None;
-
-            var toggle = new Toggle("Save During Play") { style = { height = InspectorUtility.SingleLineHeight }};
-
+            var toggle = ux.AddChild(new Toggle("Save During Play") { style = { height = InspectorUtility.SingleLineHeight }});
             toggle.AddToClassList(InspectorUtility.kAlignFieldClass);
-
             toggle.tooltip = "If checked, CmCamera settings changes made during Play Mode "
                 + "will be propagated back to the scene when Play Mode is exited.";
             toggle.value = SaveDuringPlay.SaveDuringPlay.Enabled;
+
+            var helpBox = ux.AddChild(new HelpBox("CmCamera settings changes made during Play Mode will be "
+                    + "propagated back to the scene when Play Mode is exited.", 
+                HelpBoxMessageType.Info));
+            helpBox.SetVisible(SaveDuringPlay.SaveDuringPlay.Enabled && Application.isPlaying);
+
             toggle.RegisterValueChangedCallback((evt) => 
             {
                 SaveDuringPlay.SaveDuringPlay.Enabled = evt.newValue;
-                helpBox.style.display = (evt.newValue && Application.isPlaying) 
-                    ? DisplayStyle.Flex : DisplayStyle.None;
+                helpBox.SetVisible(evt.newValue && Application.isPlaying);
             });
-            ux.Add(toggle);
-            ux.Add(helpBox);
         }
 
         /// <summary>
@@ -372,13 +367,52 @@ namespace Cinemachine.Editor
         /// </summary>
         public void AddGameViewGuidesToggle(VisualElement ux)
         {
-            var toggle = new Toggle("Game View Guides") { style = { height = InspectorUtility.SingleLineHeight }};
-            toggle.AddToClassList(InspectorUtility.kAlignFieldClass);
-            toggle.tooltip = "Enable the display of overlays in the Game window.  "
-                + "You can adjust colours and opacity in Cinemachine Preferences.";
+            var row = new InspectorUtility.LeftRightContainer();
+
+            const string tooltip = "Enable the display of overlays in the Game window.  "
+                    + "You can adjust colours and opacity in Cinemachine Preferences.";
+            var label = row.Left.AddChild(new Label("Game View Guides") 
+            { 
+                tooltip = tooltip, 
+                style = { alignSelf = Align.Center, flexGrow = 1, marginBottom = 1 }
+            });
+            var toggle = row.Right.AddChild(new Toggle("") { tooltip = tooltip, style = { height = InspectorUtility.SingleLineHeight }});
             toggle.value = CinemachineCorePrefs.ShowInGameGuides.Value;
-            toggle.RegisterValueChangedCallback((evt) => CinemachineCorePrefs.ShowInGameGuides.Value = evt.newValue);
-            ux.Add(toggle);
+
+            const string interactiveTooltip = "Enable this to make the gave view giudes draggable with the mouse.";
+            var interactiveToggle = row.Right.AddChild(new Toggle("") 
+            { 
+                tooltip = interactiveTooltip, 
+                style = { height = InspectorUtility.SingleLineHeight, marginLeft = 8, marginRight = 4 }
+            });
+
+            var interactiveLabel = row.Right.AddChild(new Label("Draggable")
+            {
+                tooltip = interactiveTooltip, 
+                style = { alignSelf = Align.Center, flexGrow = 1, marginBottom = 1 }
+            });
+
+            interactiveToggle.RegisterValueChangedCallback((evt) => 
+            {
+                CinemachineCorePrefs.DraggableComposerGuides.Value = evt.newValue;
+                UpdateVisibility(interactiveLabel, interactiveToggle);
+            });
+
+            toggle.RegisterValueChangedCallback((evt) => 
+            {
+                CinemachineCorePrefs.ShowInGameGuides.Value = evt.newValue;
+                UpdateVisibility(interactiveLabel, interactiveToggle);
+            });
+
+            UpdateVisibility(interactiveLabel, interactiveToggle);
+            static void UpdateVisibility(Label label, Toggle toggle)
+            {
+                toggle.SetVisible(CinemachineCorePrefs.ShowInGameGuides.Value);
+                label.style.opacity = CinemachineCorePrefs.DraggableComposerGuides.Value ? 1 : 0.5f;
+                label.SetVisible(CinemachineCorePrefs.ShowInGameGuides.Value);
+            }
+
+            ux.Add(row);
         }
 
         static List<MonoBehaviour> s_componentCache = new List<MonoBehaviour>();

--- a/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
@@ -10,36 +10,125 @@ namespace Cinemachine
         /// <summary>Screen position for target. The camera will adjust to position the 
         /// tracked object here.  0 is screen center, and 1 is screen edge</summary>
         [Tooltip("Screen position for target. The camera will adjust to position the "
-        + "tracked object here.  0 is screen center, and 1 is screen edge")]
+        + "tracked object here.  0 is screen center, and +1 or -1 is screen edge")]
         public Vector2 ScreenPosition;
 
+        [Serializable]
+        public struct DeadZoneSettings
+        {
+            /// <summary>Enables the Dead Zone settings</summary>
+            public bool Enabled;
+            /// <summary>The camera will not adjust if the target is within this range of the screen position.  
+            /// 0 is screen center, and +1 or -1 is screen edge</summary>
+            [Tooltip("The camera will not adjust if the target is within this range of the screen position.  "
+                + "0 is screen center, and +1 or -1 is screen edge")]
+            public Vector2 Size;
+        }
         /// <summary>The camera will not adjust if the target is within this range of the screen position</summary>
         [Tooltip("The camera will not adjust if the target is within this range of the screen position")]
-        public Vector2 DeadZoneSize;
+        [FoldoutWithEnabledButton]
+        public DeadZoneSettings DeadZone;
 
-        /// <summary>When the target is within this region, the camera will gradually adjust to re-align
+        /// <summary>The target will not be allowed to be outside this region.
+        /// When the target is within this region, the camera will gradually adjust to re-align
         /// towards the desired position, depending on the damping speed</summary>
-        [Tooltip("When the target is within this region, the camera will gradually adjust to re-align "
+        [Serializable]
+        public struct HardLimitSettings
+        {
+            /// <summary>Enables the Hard Limit settings</summary>
+            public bool Enabled;
+            /// <summary>The target will not be allowed to be outside this region.
+            /// When the target is within this region, the camera will gradually adjust to re-align
+            /// towards the desired position, depending on the damping speed.  
+            /// 0 is screen center, and +1 or -1 is screen edge</summary>
+            [Tooltip("The target will not be allowed to be outside this region. "
+                + "When the target is within this region, the camera will gradually adjust to re-align "
+                + "towards the desired position, depending on the damping speed.  "
+                + "0 is screen center, and +1 or -1 is screen edge")]
+            public Vector2 Size;
+            /// <summary>A zero Bias means that the hard limits will be centered around the target screen position.  
+            /// A nonzero bias will uncenter the target screen position within the hard limits.
+            /// </summary>
+            [Tooltip("A zero Bias means that the hard limits will be centered around the target screen position.  "
+                + "A nonzero bias will uncenter the target screen position within the hard limits.")]
+            public Vector2 Bias;
+        }
+        /// <summary>The target will not be allowed to be outside this region.
+        /// When the target is within this region, the camera will gradually adjust to re-align
+        /// towards the desired position, depending on the damping speed</summary>
+        [Tooltip("The target will not be allowed to be outside this region. "
+            + "When the target is within this region, the camera will gradually adjust to re-align "
             + "towards the desired position, depending on the damping speed")]
-        public Vector2 SoftZoneSize;
-        
-        /// <summary>A non-zero Bias will move the target position away from the center of the soft zone</summary>
-        [Tooltip("A non-zero Bias will move the target position away from the center of the soft zone")]
-        public Vector2 Bias;
+        [FoldoutWithEnabledButton]
+        public HardLimitSettings HardLimits;
 
         /// <summary>Clamps values to the expected ranges</summary>
         public void Validate()
         {
             ScreenPosition.x = Mathf.Clamp(ScreenPosition.x, -1.5f, 1.5f);
             ScreenPosition.y = Mathf.Clamp(ScreenPosition.y, -1.5f, 1.5f);
-            DeadZoneSize.x = Mathf.Clamp(DeadZoneSize.x, 0f, 2f);
-            DeadZoneSize.y = Mathf.Clamp(DeadZoneSize.y, 0f, 2f);
-            SoftZoneSize.x = Mathf.Clamp(SoftZoneSize.x, 0f, 2f);
-            SoftZoneSize.y = Mathf.Clamp(SoftZoneSize.y, 0f, 2f);
-            Bias.x = Mathf.Clamp(Bias.x, -1f, 1f);
-            Bias.y = Mathf.Clamp(Bias.y, -1f, 1f);
+            DeadZone.Size.x = Mathf.Clamp(DeadZone.Size.x, 0f, 2f);
+            DeadZone.Size.y = Mathf.Clamp(DeadZone.Size.y, 0f, 2f);
+            HardLimits.Size.x = Mathf.Clamp(HardLimits.Size.x, 0f, 2f);
+            HardLimits.Size.y = Mathf.Clamp(HardLimits.Size.y, 0f, 2f);
+            HardLimits.Bias.x = Mathf.Clamp(HardLimits.Bias.x, -1f, 1f);
+            HardLimits.Bias.y = Mathf.Clamp(HardLimits.Bias.y, -1f, 1f);
         }
 
+        /// <summary>Get the effictive dead zone size, taking enabled state into account</summary>
+        public Vector2 EffectiveDeadZoneSize => DeadZone.Enabled ? DeadZone.Size : Vector2.zero;
+
+        /// <summary>Get the effictive hard limits size, taking enabled state into account</summary>
+        public Vector2 EffectiveHardLimitSize => HardLimits.Enabled ? HardLimits.Size : new Vector2(4, 8);
+
+        /// <summary>Get/set the screenspace rect for the dead zone region.  This also defines screen position</summary>
+        public Rect DeadZoneRect
+        {
+            get
+            {
+                var deadZoneSize = EffectiveDeadZoneSize;
+                return new Rect(ScreenPosition - deadZoneSize / 2 + new Vector2(0.5f, 0.5f), deadZoneSize);
+            }
+            set
+            {
+                var deadZoneSize = EffectiveDeadZoneSize;
+                if (DeadZone.Enabled)
+                {
+                    deadZoneSize = new Vector2(Mathf.Clamp(value.width, 0, 2), Mathf.Clamp(value.height, 0, 2));
+                    DeadZone.Size = deadZoneSize;
+                }
+                ScreenPosition = new Vector2(
+                    Mathf.Clamp(value.x - 0.5f + deadZoneSize.x / 2, -1.5f,  1.5f), 
+                    Mathf.Clamp(value.y - 0.5f + deadZoneSize.y / 2, -1.5f,  1.5f));
+                HardLimits.Size = new Vector2(
+                    Mathf.Max(HardLimits.Size.x, deadZoneSize.x),
+                    Mathf.Max(HardLimits.Size.y, deadZoneSize.y));
+            }
+        }
+
+        /// <summary>Get/set the screenspace rect for the hard limits.</summary>
+        public Rect HardLimitsRect
+        {
+            get
+            {
+                var deadZoneSize = EffectiveDeadZoneSize;
+                var r = new Rect(
+                    ScreenPosition - HardLimits.Size / 2 + new Vector2(0.5f, 0.5f),
+                    HardLimits.Size);
+                r.position += new Vector2(
+                    HardLimits.Bias.x * (HardLimits.Size.x - deadZoneSize.x),
+                    HardLimits.Bias.y * (HardLimits.Size.y - deadZoneSize.y));
+                return r;
+            }
+            set
+            {
+                HardLimits.Size.x = Mathf.Clamp(value.width, 0, 2f);
+                HardLimits.Size.y = Mathf.Clamp(value.height, 0, 2f);
+                DeadZone.Size.x = Mathf.Min(DeadZone.Size.x, HardLimits.Size.x);
+                DeadZone.Size.y = Mathf.Min(DeadZone.Size.y, HardLimits.Size.y);
+            }
+        }
+        
         /// <summary>
         /// Linear interpolation between 2 settings objects.
         /// </summary>
@@ -52,9 +141,17 @@ namespace Cinemachine
             return new ScreenComposerSettings
             {
                 ScreenPosition = Vector2.Lerp(a.ScreenPosition, b.ScreenPosition, t),
-                DeadZoneSize = Vector2.Lerp(a.DeadZoneSize, b.DeadZoneSize, t),
-                SoftZoneSize = Vector2.Lerp(a.SoftZoneSize, b.SoftZoneSize, t),
-                Bias = Vector2.Lerp(a.Bias, b.Bias, t),
+                DeadZone = new () 
+                { 
+                    Enabled = a.DeadZone.Enabled || b.DeadZone.Enabled,
+                    Size = Vector2.Lerp(a.EffectiveDeadZoneSize, b.EffectiveDeadZoneSize, t) 
+                },
+                HardLimits = new ()
+                { 
+                    Enabled = a.HardLimits.Enabled || b.HardLimits.Enabled, 
+                    Size = Vector2.Lerp(a.EffectiveHardLimitSize, b.EffectiveHardLimitSize, t),
+                    Bias = Vector2.Lerp(a.HardLimits.Bias, b.HardLimits.Bias, t)
+                }
             };
         }
 
@@ -68,12 +165,19 @@ namespace Cinemachine
         {
             return Mathf.Approximately(a.ScreenPosition.x, b.ScreenPosition.x)
                 && Mathf.Approximately(a.ScreenPosition.y, b.ScreenPosition.y)
-                && Mathf.Approximately(a.DeadZoneSize.x, b.DeadZoneSize.x)
-                && Mathf.Approximately(a.DeadZoneSize.y, b.DeadZoneSize.y)
-                && Mathf.Approximately(a.SoftZoneSize.x, b.SoftZoneSize.x)
-                && Mathf.Approximately(a.SoftZoneSize.y, b.SoftZoneSize.y)
-                && Mathf.Approximately(a.Bias.x, b.Bias.x)
-                && Mathf.Approximately(a.Bias.y, b.Bias.y);
+                && Mathf.Approximately(a.EffectiveDeadZoneSize.x, b.EffectiveDeadZoneSize.x)
+                && Mathf.Approximately(a.EffectiveDeadZoneSize.y, b.EffectiveDeadZoneSize.y)
+                && Mathf.Approximately(a.EffectiveHardLimitSize.x, b.EffectiveHardLimitSize.x)
+                && Mathf.Approximately(a.EffectiveHardLimitSize.y, b.EffectiveHardLimitSize.y)
+                && Mathf.Approximately(a.HardLimits.Bias.x, b.HardLimits.Bias.x)
+                && Mathf.Approximately(a.HardLimits.Bias.y, b.HardLimits.Bias.y);
         }
+
+        /// <summary>The default screen composition</summary>
+        public static ScreenComposerSettings Default => new () 
+        { 
+            DeadZone = new () { Enabled = false, Size = new Vector2(0.2f, 0.2f) },
+            HardLimits = new () { Enabled = false, Size = new Vector2(0.8f, 0.8f) }
+        };
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
@@ -69,8 +69,8 @@ namespace Cinemachine
             ScreenPosition.y = Mathf.Clamp(ScreenPosition.y, -1.5f, 1.5f);
             DeadZone.Size.x = Mathf.Clamp(DeadZone.Size.x, 0f, 2f);
             DeadZone.Size.y = Mathf.Clamp(DeadZone.Size.y, 0f, 2f);
-            HardLimits.Size.x = Mathf.Clamp(HardLimits.Size.x, 0f, 2f);
-            HardLimits.Size.y = Mathf.Clamp(HardLimits.Size.y, 0f, 2f);
+            HardLimits.Size.x = Mathf.Clamp(HardLimits.Size.x, 0f, 6f);
+            HardLimits.Size.y = Mathf.Clamp(HardLimits.Size.y, 0f, 6f);
             HardLimits.Bias.x = Mathf.Clamp(HardLimits.Bias.x, -1f, 1f);
             HardLimits.Bias.y = Mathf.Clamp(HardLimits.Bias.y, -1f, 1f);
         }
@@ -79,7 +79,7 @@ namespace Cinemachine
         public Vector2 EffectiveDeadZoneSize => DeadZone.Enabled ? DeadZone.Size : Vector2.zero;
 
         /// <summary>Get the effictive hard limits size, taking enabled state into account</summary>
-        public Vector2 EffectiveHardLimitSize => HardLimits.Enabled ? HardLimits.Size : new Vector2(4, 8);
+        public Vector2 EffectiveHardLimitSize => HardLimits.Enabled ? HardLimits.Size : new Vector2(6, 6);
 
         /// <summary>Get/set the screenspace rect for the dead zone region.  This also defines screen position</summary>
         public Rect DeadZoneRect
@@ -111,10 +111,10 @@ namespace Cinemachine
         {
             get
             {
+                if (!HardLimits.Enabled)
+                    return new Rect(Vector2.zero, EffectiveHardLimitSize);
+                var r = new Rect(ScreenPosition - HardLimits.Size / 2 + new Vector2(0.5f, 0.5f), HardLimits.Size);
                 var deadZoneSize = EffectiveDeadZoneSize;
-                var r = new Rect(
-                    ScreenPosition - HardLimits.Size / 2 + new Vector2(0.5f, 0.5f),
-                    HardLimits.Size);
                 r.position += new Vector2(
                     HardLimits.Bias.x * (HardLimits.Size.x - deadZoneSize.x),
                     HardLimits.Bias.y * (HardLimits.Size.y - deadZoneSize.y));
@@ -122,8 +122,8 @@ namespace Cinemachine
             }
             set
             {
-                HardLimits.Size.x = Mathf.Clamp(value.width, 0, 2f);
-                HardLimits.Size.y = Mathf.Clamp(value.height, 0, 2f);
+                HardLimits.Size.x = Mathf.Clamp(value.width, 0, 6f);
+                HardLimits.Size.y = Mathf.Clamp(value.height, 0, 6f);
                 DeadZone.Size.x = Mathf.Min(DeadZone.Size.x, HardLimits.Size.x);
                 DeadZone.Size.y = Mathf.Min(DeadZone.Size.y, HardLimits.Size.y);
             }

--- a/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
@@ -116,8 +116,8 @@ namespace Cinemachine
                 var r = new Rect(ScreenPosition - HardLimits.Size / 2 + new Vector2(0.5f, 0.5f), HardLimits.Size);
                 var deadZoneSize = EffectiveDeadZoneSize;
                 r.position += new Vector2(
-                    HardLimits.Bias.x * (HardLimits.Size.x - deadZoneSize.x),
-                    HardLimits.Bias.y * (HardLimits.Size.y - deadZoneSize.y));
+                    HardLimits.Bias.x * 0.5f * (HardLimits.Size.x - deadZoneSize.x),
+                    HardLimits.Bias.y * 0.5f * (HardLimits.Size.y - deadZoneSize.y));
                 return r;
             }
             set
@@ -126,6 +126,7 @@ namespace Cinemachine
                 HardLimits.Size.y = Mathf.Clamp(value.height, 0, 6f);
                 DeadZone.Size.x = Mathf.Min(DeadZone.Size.x, HardLimits.Size.x);
                 DeadZone.Size.y = Mathf.Min(DeadZone.Size.y, HardLimits.Size.y);
+                // GML todo: set bias
             }
         }
         

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
@@ -531,7 +531,7 @@ namespace Cinemachine
             {
                 Enabled = true,
                 Size = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
-                Bias = new Vector2(m_BiasX, m_BiasY)
+                Bias = new Vector2(m_BiasX, m_BiasY) * 2
             }
         };
     }

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
@@ -526,9 +526,13 @@ namespace Cinemachine
         internal ScreenComposerSettings GetScreenComposerSettings() => new ()
         {
             ScreenPosition = new Vector2(m_ScreenX, m_ScreenY) - new Vector2(0.5f, 0.5f),
-            DeadZoneSize = new Vector2(m_DeadZoneWidth, m_DeadZoneHeight),
-            SoftZoneSize = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
-            Bias = new Vector2(m_BiasX, m_BiasY)
+            DeadZone = new () { Enabled = true, Size = new Vector2(m_DeadZoneWidth, m_DeadZoneHeight) },
+            HardLimits = new () 
+            {
+                Enabled = true,
+                Size = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
+                Bias = new Vector2(m_BiasX, m_BiasY)
+            }
         };
     }
 }

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -678,11 +678,14 @@ namespace Cinemachine
             c.Composition = new ScreenComposerSettings
             {
                 ScreenPosition = new Vector2(m_ScreenX, m_ScreenY) - new Vector2(0.5f, 0.5f),
-                DeadZoneSize = new Vector2(m_DeadZoneWidth, m_DeadZoneHeight),
-                SoftZoneSize = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
-                Bias = new Vector2(m_BiasX, m_BiasY)
+                DeadZone = new () { Enabled = true, Size = new Vector2(m_DeadZoneWidth, m_DeadZoneHeight) },
+                HardLimits = new ()
+                {
+                    Enabled = !m_UnlimitedSoftZone,
+                    Size = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
+                    Bias = new Vector2(m_BiasX, m_BiasY)
+                }
             };
-            c.UnlimitedSoftZone = m_UnlimitedSoftZone;
             c.CenterOnActivate = m_CenterOnActivate;
         }
 

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -683,7 +683,7 @@ namespace Cinemachine
                 {
                     Enabled = !m_UnlimitedSoftZone,
                     Size = new Vector2(m_SoftZoneWidth, m_SoftZoneHeight),
-                    Bias = new Vector2(m_BiasX, m_BiasY)
+                    Bias = new Vector2(m_BiasX, m_BiasY) * 2
                 }
             };
             c.CenterOnActivate = m_CenterOnActivate;


### PR DESCRIPTION
### Purpose of this PR

Make the Game View Guides UX (inspector and on-screen) clearer.

New inspector:
![image](https://user-images.githubusercontent.com/6424658/195891993-3c1af550-ad71-45d7-9bf1-04221011f286.png)

This adds the functionality of having no hard limits, which used to be implemented separately in Position Composer, now it works natively for both.

Added "Draggable" toggle for game view guides to turn off interactivity (option already existed in preferences):
![image](https://user-images.githubusercontent.com/6424658/195892323-67339340-b6ae-43e7-84ed-de22cc995e08.png)

Added highlighting of "hot" draggable thing in the game view (the thing under the  mouse).
![image](https://user-images.githubusercontent.com/6424658/195893907-06cf234c-bb4b-4cdb-b304-d4b5935cce68.png)


### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

Note: user documentation needs to be updated, will do it in separate PR

### Technical risk

low
