### PR TITLE
CMCL-0000: Remove project tests from the PR pipeline and the publishing pipeline

### DIFF
--- a/.yamato/package-ci.yml
+++ b/.yamato/package-ci.yml
@@ -27,7 +27,7 @@ ci_trigger:
     {% endfor %}
     {% endfor %}
     - .yamato/package-coverage.yml#coverage_ubuntu_trunk
-    - .yamato/package-validation.yml.yml#api_doc_validation
+    - .yamato/package-validation.yml#api_doc_validation
 
 nightly_trigger:
   name: Package Nightly tests
@@ -60,5 +60,5 @@ nightly_trigger:
     {% endfor %}
     {% endfor %}
     - .yamato/package-coverage.yml#coverage_ubuntu_trunk
-    - .yamato/package-validation.yml.yml#api_doc_validation
+    - .yamato/package-validation.yml#api_doc_validation
 

--- a/.yamato/package-ci.yml
+++ b/.yamato/package-ci.yml
@@ -11,12 +11,6 @@ ci_trigger:
           only:
             - "/.*/"
   dependencies:
-    {% for test_project in all_testprojects %}
-      {% for editor in test_project.editors %}
-    - .yamato/project-test.yml#test_windows_{{editor}}_{{test_project.name}}
-      {% endfor %}
-    {% endfor %}
-
     {% for test_name in all_configurations.ci.test_names %}
     {% for test in all_tests %}
     {% if test.name == test_name %}
@@ -33,6 +27,7 @@ ci_trigger:
     {% endfor %}
     {% endfor %}
     - .yamato/package-coverage.yml#coverage_ubuntu_trunk
+    - .yamato/package-validation.yml.yml#api_doc_validation
 
 nightly_trigger:
   name: Package Nightly tests
@@ -65,3 +60,5 @@ nightly_trigger:
     {% endfor %}
     {% endfor %}
     - .yamato/package-coverage.yml#coverage_ubuntu_trunk
+    - .yamato/package-validation.yml.yml#api_doc_validation
+

--- a/.yamato/package-promotion.yml
+++ b/.yamato/package-promotion.yml
@@ -22,7 +22,6 @@ promote:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/package-pack.yml#pack
-    - .yamato/package-publish.yml#publish
     {% for test_name in all_configurations.promote.test_names %}
     {% for test in all_tests %}
     {% if test.name == test_name %}

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -23,12 +23,6 @@ publish:
   dependencies:
     - .yamato/package-pack.yml#pack
     - .yamato/project-pack.yml#pack
-    {% for test_project in all_testprojects %}
-      {% for editor in test_project.editors %}
-    - .yamato/project-test.yml#test_windows_{{editor}}_{{test_project.name}}
-    - .yamato/project-test.yml#test_macos_{{editor}}_{{test_project.name}}
-      {% endfor %}
-    {% endfor %}
     {% for test_name in all_configurations.publish.test_names %}
     {% for test in all_tests %}
     {% if test.name == test_name %}

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -22,7 +22,6 @@ publish:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/package-pack.yml#pack
-    - .yamato/project-pack.yml#pack
     {% for test_name in all_configurations.publish.test_names %}
     {% for test in all_tests %}
     {% if test.name == test_name %}


### PR DESCRIPTION
### Purpose of this PR
The projects are unreliable at the moment. Until we fix them, I'm disabling them from the tests running on PR and from the publishing pipeline. 

Also, this PR runs the the doc validation job on PRs and at night. 
