### PR TITLE
CMCL-0000: Cleanup FoldoutWithEnabledButtonPropertyDrawer

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
@@ -71,15 +71,16 @@ namespace Cinemachine.Editor
 #endif
                     if (numFields > 0)
                     {
-                        rect.x += EditorGUIUtility.labelWidth - height;
-                        rect.width -= EditorGUIUtility.labelWidth - height;
+                        var blankLabelWidth = height / numFields;
+                        rect.x += EditorGUIUtility.labelWidth - blankLabelWidth;
+                        rect.width -= EditorGUIUtility.labelWidth - blankLabelWidth;
                         rect.width /= numFields;
 
                         int oldIndent = EditorGUI.indentLevel;
                         float oldLabelWidth = EditorGUIUtility.labelWidth;
 
                         EditorGUI.indentLevel = 0;
-                        EditorGUIUtility.labelWidth = height / numFields;
+                        EditorGUIUtility.labelWidth = blankLabelWidth;
 
                         if (actionProperty != null)
                         {

--- a/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
@@ -27,29 +27,37 @@ namespace Cinemachine.Editor
             if (enabledProp == null)
                 return new PropertyField(property);
 
-            var ux = new VisualElement();
-            ux.Add(new PropertyField(enabledProp, property.displayName) { tooltip = property.tooltip });
-            // GML todo: fix the indenting
-            var children = ux.AddChild(new VisualElement() { style = { marginLeft = InspectorUtility.SingleLineHeight }});
+            // Don't set the text of the Foldout as this will set the Toggle.text,
+            // which is on the right side of the checkbox
+            var foldout = new Foldout(); // { style = { marginTop = 2 }}; // GML this hack would compensate for the current uneven line spacing
+            var foldoutToggle = foldout.Q<Toggle>(className: "unity-foldout__toggle");
 
+            // This is to counter the auto-adding of the "unity-foldout__toggle--inspector" class that
+            // adds -12px margin-left. Not ideal. I raised this as an issue.
+            foldoutToggle.style.marginLeft = 3;
+
+            // This does the magic nested alignment if this Foldout is inside another Foldout
+            foldoutToggle.AddToClassList(Toggle.alignedFieldUssClassName);
+
+            // Change from arrow to checkbox
+            foldoutToggle.RemoveFromClassList("unity-foldout__toggle");
+
+            // Bind toggle to the enabled property while displaying the main property text
+            foldoutToggle.label = property.displayName;
+            foldoutToggle.tooltip = property.tooltip;
+            foldoutToggle.BindProperty(enabledProp);
+
+            // Add children
             var childProperty = property.Copy();
             var endProperty = childProperty.GetEndProperty();
             childProperty.NextVisible(true);
             while (!SerializedProperty.EqualContents(childProperty, endProperty))
             {
                 if (!SerializedProperty.EqualContents(childProperty, enabledProp))
-                    children.Add(new PropertyField(childProperty));
+                    foldout.Add(new PropertyField(childProperty));
                 childProperty.NextVisible(false);
             }
-
-            TrackEnabled(enabledProp);
-            ux.TrackPropertyValue(enabledProp, TrackEnabled);
-
-            void TrackEnabled(SerializedProperty p)
-            {
-                children.SetVisible(p.boolValue);
-            }
-            return ux;
+            return foldout;
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
@@ -88,7 +88,7 @@ namespace Cinemachine
             get
             {
                 var deadZoneSize = EffectiveDeadZoneSize;
-                return new Rect(ScreenPosition - deadZoneSize / 2 + new Vector2(0.5f, 0.5f), deadZoneSize);
+                return new Rect(ScreenPosition - deadZoneSize * 0.5f + new Vector2(0.5f, 0.5f), deadZoneSize);
             }
             set
             {
@@ -99,8 +99,8 @@ namespace Cinemachine
                     DeadZone.Size = deadZoneSize;
                 }
                 ScreenPosition = new Vector2(
-                    Mathf.Clamp(value.x - 0.5f + deadZoneSize.x / 2, -1.5f,  1.5f), 
-                    Mathf.Clamp(value.y - 0.5f + deadZoneSize.y / 2, -1.5f,  1.5f));
+                    Mathf.Clamp(value.x - 0.5f + deadZoneSize.x * 0.5f, -1.5f,  1.5f), 
+                    Mathf.Clamp(value.y - 0.5f + deadZoneSize.y * 0.5f, -1.5f,  1.5f));
                 HardLimits.Size = new Vector2(
                     Mathf.Clamp(HardLimits.Size.x, deadZoneSize.x, 3),
                     Mathf.Clamp(HardLimits.Size.y, deadZoneSize.y, 3));
@@ -113,8 +113,8 @@ namespace Cinemachine
             get
             {
                 if (!HardLimits.Enabled)
-                    return new Rect(Vector2.zero, EffectiveHardLimitSize);
-                var r = new Rect(ScreenPosition - HardLimits.Size / 2 + new Vector2(0.5f, 0.5f), HardLimits.Size);
+                    return new Rect(-EffectiveHardLimitSize * 0.5f, EffectiveHardLimitSize);
+                var r = new Rect(ScreenPosition - HardLimits.Size * 0.5f + new Vector2(0.5f, 0.5f), HardLimits.Size);
                 var deadZoneSize = EffectiveDeadZoneSize;
                 r.position += new Vector2(
                     HardLimits.Offset.x * 0.5f * (HardLimits.Size.x - deadZoneSize.x),


### PR DESCRIPTION
Remove some hacks, thanks to code from Damian Campeanu.
Also small bugfix: disabled hard guides were hot-highlighting at top/left screen edges.
Another small bugfix: bad indent in InputAxisController inspector if both input systems present
