### PR TITLE
[DRAFT] CMCL-1230: Make Unit Test deterministic and Time independent

### DIFF
--- a/com.unity.cinemachine/Tests/Runtime/CmColliderTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CmColliderTests.cs
@@ -6,9 +6,9 @@ using UnityEngine.TestTools;
 using Cinemachine;
 using UnityEngine.TestTools.Utils;
 
+#if CINEMACHINE_PHYSICS
 namespace Tests.Runtime
 {
-#if CINEMACHINE_PHYSICS
     public class CmColliderTests : CinemachineFixtureBase
     {
         CinemachineBrain m_Brain;
@@ -176,5 +176,5 @@ namespace Tests.Runtime
             Assert.That(new Vector3(0, 0, -4.71081734f), Is.EqualTo(finalPosition).Using(Vector3EqualityComparer.Instance));
         }
     }
-#endif
 }
+#endif


### PR DESCRIPTION
### Purpose of this PR
**Draft until Yamato passes**

[CMCL-1230](https://jira.unity3d.com/browse/CMCL-1230)
Some of our Unit tests were failing on trunk. It is possibly due to the dependency on CurrentTime -> Time.time. We are controlling that in the tests now.

**Draft until Yamato passes**

### Testing status
- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 