### PR TITLE
CMCL-0000: add "using default" text to priority inspector

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlendListCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlendListCameraEditor.cs
@@ -44,8 +44,9 @@ namespace Cinemachine.Editor
 
             // Ordinary properties
             DrawCameraStatusInInspector();
-            DrawGlobalControlsInInspector();
+            DrawPropertyInInspector(FindProperty(x => x.StandbyUpdate));
             DrawPropertyInInspector(FindProperty(x => x.PriorityAndChannel));
+            DrawGlobalControlsInInspector();
             DrawPropertyInInspector(FindProperty(x => x.DefaultTarget));
             DrawRemainingPropertiesInInspector();
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
@@ -83,8 +83,9 @@ namespace Cinemachine.Editor
             var children = Target.ChildCameras; // force the child cache to rebuild
 
             DrawCameraStatusInInspector();
-            DrawGlobalControlsInInspector();
+            DrawPropertyInInspector(FindProperty(x => x.StandbyUpdate));
             DrawPropertyInInspector(FindProperty(x => x.PriorityAndChannel));
+            DrawGlobalControlsInInspector();
             DrawPropertyInInspector(FindProperty(x => x.DefaultTarget));
             DrawRemainingPropertiesInInspector();
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
@@ -26,8 +26,8 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             m_CameraUtility.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TransitionHint)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.LookAtTarget)));
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineMixingCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineMixingCameraEditor.cs
@@ -23,6 +23,8 @@ namespace Cinemachine.Editor
         {
             BeginInspector();
             DrawCameraStatusInInspector();
+            DrawPropertyInInspector(FindProperty(x => x.StandbyUpdate));
+            DrawPropertyInInspector(FindProperty(x => x.PriorityAndChannel));
             DrawGlobalControlsInInspector();
             DrawRemainingPropertiesInInspector();
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -69,8 +69,9 @@ namespace Cinemachine.Editor
 
             // Ordinary properties
             DrawCameraStatusInInspector();
-            DrawGlobalControlsInInspector();
+            DrawPropertyInInspector(FindProperty(x => x.StandbyUpdate));
             DrawPropertyInInspector(FindProperty(x => x.PriorityAndChannel));
+            DrawGlobalControlsInInspector();
             DrawPropertyInInspector(FindProperty(x => x.DefaultTarget));
             DrawPropertyInInspector(FindProperty(x => x.AnimatedTarget));
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -281,16 +281,36 @@ namespace Cinemachine.Editor
             }
         }
 
+        GUIContent m_GuidesLabel;
+        static GUIContent[] s_GuidesChoices = new [] { new GUIContent("Disabled"), new GUIContent("Passive"), new GUIContent("Interactive") };
+
         /// <summary>
         /// Draw the global settings controls in the inspector
         /// </summary>
         protected void DrawGlobalControlsInInspector()
         {
-            CinemachineCorePrefs.ShowInGameGuides.Value
-                = EditorGUILayout.Toggle(CinemachineCorePrefs.s_ShowInGameGuidesLabel, CinemachineCorePrefs.ShowInGameGuides.Value);
+            if (m_GuidesLabel == null)
+                m_GuidesLabel = new ("Game Guides:", CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip);
 
-            SaveDuringPlay.SaveDuringPlay.Enabled
-                = EditorGUILayout.Toggle(CinemachineCorePrefs.s_SaveDuringPlayLabel, SaveDuringPlay.SaveDuringPlay.Enabled);
+            var labelWidth = EditorGUIUtility.labelWidth;
+            var rect = EditorGUILayout.GetControlRect();
+            var w1 = labelWidth + InspectorUtility.SingleLineHeight + 5;
+            var w2 = rect.width - w1;
+            rect.width = w1;
+            SaveDuringPlay.SaveDuringPlay.Enabled = EditorGUI.Toggle(
+                rect, CinemachineCorePrefs.s_SaveDuringPlayLabel, SaveDuringPlay.SaveDuringPlay.Enabled);
+            rect.x += w1; rect.width = w2;
+            EditorGUIUtility.labelWidth = GUI.skin.label.CalcSize(m_GuidesLabel).x;
+            int index = CinemachineCorePrefs.ShowInGameGuides.Value 
+                ? (CinemachineCorePrefs.DraggableComposerGuides.Value ? 2 : 1) : 0;
+            var newIndex = EditorGUI.Popup(rect, m_GuidesLabel, index, s_GuidesChoices);
+            if (index != newIndex)
+            {
+                CinemachineCorePrefs.ShowInGameGuides.Value = newIndex != 0;
+                CinemachineCorePrefs.DraggableComposerGuides.Value = newIndex == 2;
+                InspectorUtility.RepaintGameView();
+            }
+            EditorGUIUtility.labelWidth = labelWidth;
 
             if (Application.isPlaying && SaveDuringPlay.SaveDuringPlay.Enabled)
                 EditorGUILayout.HelpBox(

--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -55,13 +55,10 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             m_CameraUtility.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Transitions)));
-            
-            ux.AddHeader("Camera");
-            var lensProperty = serializedObject.FindProperty(() => Target.Lens);
-            ux.Add(new PropertyField(lensProperty));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lens)));
 
             ux.AddHeader("Procedural Motion");
             m_CameraUtility.AddSaveDuringPlayToggle(ux);

--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -60,9 +60,10 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Transitions)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lens)));
 
+            ux.AddHeader("Global Controls");
+            m_CameraUtility.AddGlobalControls(ux);
+
             ux.AddHeader("Procedural Motion");
-            m_CameraUtility.AddSaveDuringPlayToggle(ux);
-            m_CameraUtility.AddGameViewGuidesToggle(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Target)));
             m_CameraUtility.AddPipelineDropdowns(ux);
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
@@ -17,7 +17,7 @@ namespace Cinemachine.Editor
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
             var a = (FoldoutWithEnabledButtonAttribute)attribute;
-            InspectorUtility.EnabledFoldout(rect, property, a.EnabledPropertyName);
+            InspectorUtility.EnabledFoldout(rect, property, a.EnabledPropertyName, a.ToggleDisabledText);
         }
 
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
@@ -30,7 +30,8 @@ namespace Cinemachine.Editor
             // Don't set the text of the Foldout as this will set the Toggle.text,
             // which is on the right side of the checkbox
             var foldout = new Foldout(); // { style = { marginTop = 2 }}; // GML this hack would compensate for the current uneven line spacing
-            var foldoutToggle = foldout.Q<Toggle>(className: "unity-foldout__toggle");
+            const string kToggleClassName = "unity-foldout__toggle";
+            var foldoutToggle = foldout.Q<Toggle>(className: kToggleClassName);
 
             // This is to counter the auto-adding of the "unity-foldout__toggle--inspector" class that
             // adds -12px margin-left. Not ideal. I raised this as an issue.
@@ -40,7 +41,7 @@ namespace Cinemachine.Editor
             foldoutToggle.AddToClassList(Toggle.alignedFieldUssClassName);
 
             // Change from arrow to checkbox
-            foldoutToggle.RemoveFromClassList("unity-foldout__toggle");
+            foldoutToggle.RemoveFromClassList(kToggleClassName);
 
             // Bind toggle to the enabled property while displaying the main property text
             foldoutToggle.label = property.displayName;
@@ -57,6 +58,12 @@ namespace Cinemachine.Editor
                     foldout.Add(new PropertyField(childProperty));
                 childProperty.NextVisible(false);
             }
+
+            // toggle.text is to the right side of the checkbox
+            UpdateToggleText(enabledProp);
+            foldout.TrackPropertyValue(enabledProp, UpdateToggleText);
+            void UpdateToggleText(SerializedProperty p) => foldoutToggle.text = p.boolValue ? null : a.ToggleDisabledText;
+
             return foldout;
         }
     }

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -343,43 +343,47 @@ namespace Cinemachine.Editor
         /// <summary>
         /// Draw the global settings controls in the inspector
         /// </summary>
-        public void AddSaveDuringPlayToggle(VisualElement ux)
+        public void AddGlobalControls(VisualElement ux)
         {
-            var toggle = ux.AddChild(new Toggle("Save During Play") { style = { height = InspectorUtility.SingleLineHeight }});
-            toggle.AddToClassList(InspectorUtility.kAlignFieldClass);
-            toggle.tooltip = "If checked, CmCamera settings changes made during Play Mode "
-                + "will be propagated back to the scene when Play Mode is exited.";
-            toggle.value = SaveDuringPlay.SaveDuringPlay.Enabled;
+            var row = ux.AddChild(new InspectorUtility.LeftRightContainer());
 
             var helpBox = ux.AddChild(new HelpBox("CmCamera settings changes made during Play Mode will be "
                     + "propagated back to the scene when Play Mode is exited.", 
                 HelpBoxMessageType.Info));
             helpBox.SetVisible(SaveDuringPlay.SaveDuringPlay.Enabled && Application.isPlaying);
 
+            row.Left.Add(new Label(CinemachineCorePrefs.s_SaveDuringPlayLabel.text) 
+            { 
+                tooltip = CinemachineCorePrefs.s_SaveDuringPlayLabel.tooltip,
+                style = { alignSelf = Align.Center, flexGrow = 1, height = InspectorUtility.SingleLineHeight }
+            });
+            var toggle = row.Right.AddChild(new Toggle("") 
+            { 
+                tooltip = CinemachineCorePrefs.s_SaveDuringPlayLabel.tooltip,
+                style = { alignSelf = Align.Center },
+                value = SaveDuringPlay.SaveDuringPlay.Enabled
+            });
             toggle.RegisterValueChangedCallback((evt) => 
             {
                 SaveDuringPlay.SaveDuringPlay.Enabled = evt.newValue;
                 helpBox.SetVisible(evt.newValue && Application.isPlaying);
             });
-        }
 
-        /// <summary>
-        /// Draw the global settings controls in the inspector
-        /// </summary>
-        public void AddGameViewGuidesToggle(VisualElement ux)
-        {
+            row.Right.Add(new Label("Game Guides:") 
+            { 
+                tooltip = CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip,
+                style = { marginLeft = 8, alignSelf = Align.Center, flexGrow = 0, height = InspectorUtility.SingleLineHeight }
+            });
             var choices = new List<string>() { "Disabled", "Passive", "Interactive" };
             int index = CinemachineCorePrefs.ShowInGameGuides.Value 
                 ? (CinemachineCorePrefs.DraggableComposerGuides.Value ? 2 : 1) : 0;
-            var dropdown = ux.AddChild(new DropdownField
+            var dropdown = row.Right.AddChild(new DropdownField
             {
-                label = "Game View Guides",
                 tooltip = CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip,
                 choices = choices,
                 index = index,
                 style = { flexGrow = 1 }
             });
-            dropdown.AddToClassList(InspectorUtility.kAlignFieldClass);
             dropdown.RegisterValueChangedCallback((evt) => 
             {
                 CinemachineCorePrefs.ShowInGameGuides.Value = evt.newValue != choices[0];

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -295,7 +295,7 @@ namespace Cinemachine.Editor
         }
 
         public static bool EnabledFoldout(
-            Rect rect, SerializedProperty property, string enabledPropertyName,
+            Rect rect, SerializedProperty property, string enabledPropertyName, string disabledToggleLabel,
             GUIContent label = null)
         {
             var enabledProp = property.FindPropertyRelative(enabledPropertyName);
@@ -310,8 +310,16 @@ namespace Cinemachine.Editor
             if (label == null)
                 label = new GUIContent(property.displayName, enabledProp.tooltip);
             EditorGUI.PropertyField(rect, enabledProp, label);
-            rect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
-            if (enabledProp.boolValue)
+            if (!enabledProp.boolValue)
+            {
+                if (!string.IsNullOrEmpty(disabledToggleLabel))
+                {
+                    var w = EditorGUIUtility.labelWidth + EditorGUIUtility.singleLineHeight + 3;
+                    var r = rect; r.x += w; r.width -= w;
+                    EditorGUI.LabelField(r, disabledToggleLabel);
+                }
+            }
+            else
             {
                 ++EditorGUI.indentLevel;
                 var childProperty = property.Copy();
@@ -321,9 +329,9 @@ namespace Cinemachine.Editor
                 {
                     if (!SerializedProperty.EqualContents(childProperty, enabledProp))
                     {
+                        rect.y += rect.height + EditorGUIUtility.standardVerticalSpacing;
                         rect.height = EditorGUI.GetPropertyHeight(childProperty);
                         EditorGUI.PropertyField(rect, childProperty, true);
-                        rect.y += rect.height + EditorGUIUtility.standardVerticalSpacing;
                     }
                     childProperty.NextVisible(false);
                 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
@@ -65,6 +65,7 @@ namespace Cinemachine
 
         /// <summary>Parameters that influence how this CmCamera transitions from other CmCameras.</summary>
         [Tooltip("Parameters that influence how this CmCamera transitions from other CmCameras")]
+        [HideFoldout]
         public TransitionParams Transitions;
 
         void Reset()

--- a/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CmCamera.cs
@@ -65,7 +65,6 @@ namespace Cinemachine
 
         /// <summary>Parameters that influence how this CmCamera transitions from other CmCameras.</summary>
         [Tooltip("Parameters that influence how this CmCamera transitions from other CmCameras")]
-        [HideFoldout]
         public TransitionParams Transitions;
 
         void Reset()

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
@@ -20,13 +20,16 @@ namespace Cinemachine
         /// <summary>The name of the field controlling the enabled state</summary>
         public string EnabledPropertyName; 
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
+        /// <summary>Text to display to the right of the toggle button when disabled</summary>
+        public string ToggleDisabledText;
+
+        /// <summary>Constructor</summary>
         /// <param name="enabledProperty">The name of the field controlling the enabled state</param>
-        public FoldoutWithEnabledButtonAttribute(string enabledProperty = "Enabled") 
+        /// <param name="toggleText">Text to display to the right of the toggle button</param>
+        public FoldoutWithEnabledButtonAttribute(string enabledProperty = "Enabled", string toggleText = "") 
         { 
             EnabledPropertyName = enabledProperty; 
+            ToggleDisabledText = toggleText;
         }
     }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -47,7 +47,7 @@ namespace Cinemachine
             + "The default priority is 0.  Often it is sufficient to leave the default setting.  "
             + "In special cases where you want a CmCamera to have a higher or lower priority than 0, "
             + "the value can be set here.")]
-        [FoldoutWithEnabledButton]
+        [FoldoutWithEnabledButton(toggleText: "(using default)")]
         public OutputChannel PriorityAndChannel = OutputChannel.Default;
 
         /// <summary>A sequence number that represents object activation order of vcams.  


### PR DESCRIPTION
### Purpose of this PR

Added "(using default)" text next to Priority And Channel when disabled.
Made some inspectors more consistent (reordered fields).
Fixed up IMGUI inspectors to have dropdown for game view guides
Put global controls on one line (let's see how it feels).
