### PR TITLE
CMCL-0000: bugfix: rotation composer lookahead was wrong

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2022-10-20
+- Bugfix: rotation composer lookahead sometimes popped
+
+
 ## [3.0.0-pre.2] - 2022-10-20
 - Add Show Hierarchy Icon preference option.
 - New icons for cinemachine (cameras, components, extensions, tracks).

--- a/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using Cinemachine.Utility;
 using UnityEditor;
-using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
-using UnityEditor.Rendering;
 
 namespace Cinemachine.Editor
 {

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
@@ -79,8 +79,7 @@ namespace Cinemachine
 
         /// <summary>State information for damping</summary>
         Vector3 m_PreviousCameraPosition = Vector3.zero;
-        internal PositionPredictor m_Predictor = new PositionPredictor();
-        float m_prevFOV; // State for frame damping
+        internal PositionPredictor m_Predictor = new PositionPredictor(); // internal for tests
         Quaternion m_prevRotation;
 
         bool m_InheritingPosition;
@@ -232,7 +231,6 @@ namespace Cinemachine
             if (!previousStateIsValid)
             {
                 m_PreviousCameraPosition = curState.RawPosition;
-                m_prevFOV = lens.Orthographic ? lens.OrthographicSize : lens.FieldOfView;
                 m_prevRotation = curState.RawOrientation;
                 if (!m_InheritingPosition && CenterOnActivate)
                 {
@@ -252,14 +250,12 @@ namespace Cinemachine
             if (Lookahead.Enabled && Lookahead.Time > Epsilon)
             {
                 m_Predictor.Smoothing = Lookahead.Smoothing;
-                m_Predictor.AddPosition(followTargetPosition, deltaTime, Lookahead.Time);
+                m_Predictor.AddPosition(followTargetPosition, deltaTime);
                 var delta = m_Predictor.PredictPositionDelta(Lookahead.Time);
                 if (Lookahead.IgnoreY)
                     delta = delta.ProjectOntoPlane(curState.ReferenceUp);
-                var p = followTargetPosition + delta;
-                TrackedPoint = p;
+                TrackedPoint = followTargetPosition + delta;
             }
-
             if (!curState.HasLookAt())
                 curState.ReferenceLookAt = followTargetPosition;
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
@@ -85,7 +85,7 @@ namespace Cinemachine
         /// <param name="up">Currest effective world up</param>
         /// <param name="deltaTime">Current effective deltaTime</param>
         /// <returns>The LookAt point with the offset applied</returns>
-        internal protected virtual Vector3 GetLookAtPointAndSetTrackedPoint(
+        Vector3 GetLookAtPointAndSetTrackedPoint(
             Vector3 lookAt, Vector3 up, float deltaTime)
         {
             var pos = lookAt;
@@ -98,13 +98,13 @@ namespace Cinemachine
             {
                 var resetLookahead = VirtualCamera.LookAtTargetChanged || !VirtualCamera.PreviousStateIsValid;
                 m_Predictor.Smoothing = Lookahead.Smoothing;
-                m_Predictor.AddPosition(pos, resetLookahead ? -1 : deltaTime, Lookahead.Time);
+                m_Predictor.AddPosition(pos, resetLookahead ? -1 : deltaTime);
                 var delta = m_Predictor.PredictPositionDelta(Lookahead.Time);
                 if (Lookahead.IgnoreY)
                     delta = delta.ProjectOntoPlane(up);
                 TrackedPoint = pos + delta;
             }
-            return pos;
+            return TrackedPoint;
         }
 
         /// <summary>State information for damping</summary>
@@ -112,7 +112,7 @@ namespace Cinemachine
         Vector3 m_LookAtPrevFrame = Vector3.zero;
         Vector2 m_ScreenOffsetPrevFrame = Vector2.zero;
         Quaternion m_CameraOrientationPrevFrame = Quaternion.identity;
-        internal PositionPredictor m_Predictor = new PositionPredictor();
+        internal PositionPredictor m_Predictor = new PositionPredictor(); // internal for tests
 
         /// <summary>This is called to notify the user that a target got warped,
         /// so that we can update its internal state to make the camera

--- a/com.unity.cinemachine/Runtime/Core/Predictor.cs
+++ b/com.unity.cinemachine/Runtime/Core/Predictor.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 namespace Cinemachine.Utility
 {
     /// <summary>
-    /// This is a utility class to implement position predicting.
+    /// This is a utility to implement position predicting.
     /// </summary>
-    public class PositionPredictor
+    public struct PositionPredictor
     {
         Vector3 m_Velocity;
         Vector3 m_SmoothDampVelocity;
@@ -21,7 +21,9 @@ namespace Cinemachine.Utility
         /// Have any positions been logged for smoothing?
         /// </summary>
         /// <returns>True if no positions have yet been logged, in which case smoothing is impossible</returns>
-        public bool IsEmpty() { return !m_HavePos; }
+        public bool IsEmpty => !m_HavePos;
+
+        public Vector3 CurrentPosition => m_Pos;
 
         /// <summary>
         /// Apply a delta to the target's position, which will be ignored for 
@@ -41,8 +43,7 @@ namespace Cinemachine.Utility
         /// <summary>Add a new target position to the history buffer</summary>
         /// <param name="pos">The new target position</param>
         /// <param name="deltaTime">deltaTime since the last target position was added</param>
-        /// <param name="lookaheadTime">Current lookahead time setting (unused)</param>
-        public void AddPosition(Vector3 pos, float deltaTime, float lookaheadTime)
+        public void AddPosition(Vector3 pos, float deltaTime)
         {
             if (deltaTime < 0)
                 Reset();
@@ -64,14 +65,6 @@ namespace Cinemachine.Utility
         public Vector3 PredictPositionDelta(float lookaheadTime)
         {
             return m_Velocity * lookaheadTime;
-        }
-
-        /// <summary>Predict the target's position a given time from now</summary>
-        /// <param name="lookaheadTime">How far ahead in time to predict</param>
-        /// <returns>The predicted position</returns>
-        public Vector3 PredictPosition(float lookaheadTime)
-        {
-            return m_Pos + PredictPositionDelta(lookaheadTime);
         }
     }
 

--- a/com.unity.cinemachine/Runtime/Core/Predictor.cs
+++ b/com.unity.cinemachine/Runtime/Core/Predictor.cs
@@ -12,17 +12,16 @@ namespace Cinemachine.Utility
         Vector3 m_Pos;
         bool m_HavePos;
 
-        /// <summary>
-        /// How much to smooth the predicted result.  Must be >= 0, roughly coresponds to smoothing time.
-        /// </summary>
+        /// <summary>How much to smooth the predicted result.  Must be >= 0, roughly coresponds to smoothing time.</summary>
         public float Smoothing;
 
-        /// <summary>
-        /// Have any positions been logged for smoothing?
-        /// </summary>
+        /// <summary>Have any positions been logged for smoothing?</summary>
         /// <returns>True if no positions have yet been logged, in which case smoothing is impossible</returns>
         public bool IsEmpty => !m_HavePos;
 
+        /// <summary>Get the current position of the tracked object, as set by the last call to AddPosition().
+        /// This is only valid if IsEmpty returns false.</summary>
+        /// <returns>The current position of the tracked object, as set by the last call to AddPosition()</returns>
         public Vector3 CurrentPosition => m_Pos;
 
         /// <summary>
@@ -30,7 +29,7 @@ namespace Cinemachine.Utility
         /// smoothing purposes.  Use this whent he target's position gets warped.
         /// </summary>
         /// <param name="positionDelta">The position change of the target object</param>
-        public void ApplyTransformDelta(Vector3 positionDelta) { m_Pos += positionDelta; }
+        public void ApplyTransformDelta(Vector3 positionDelta) => m_Pos += positionDelta;
 
         /// <summary>Reset the lookahead data, clear all the buffers.</summary>
         public void Reset() 
@@ -62,10 +61,7 @@ namespace Cinemachine.Utility
         /// <summary>Predict the target's position change over a given time from now</summary>
         /// <param name="lookaheadTime">How far ahead in time to predict</param>
         /// <returns>The predicted position change (current velocity * lokahead time)</returns>
-        public Vector3 PredictPositionDelta(float lookaheadTime)
-        {
-            return m_Velocity * lookaheadTime;
-        }
+        public Vector3 PredictPositionDelta(float lookaheadTime) => m_Velocity * lookaheadTime;
     }
 
     /// <summary>Utility to perform realistic damping of float or Vector3 values.
@@ -76,16 +72,11 @@ namespace Cinemachine.Utility
         const float Epsilon = UnityVectorExtensions.Epsilon;
 
         // Get the decay constant that would leave a given residual after a given time
-        static float DecayConstant(float time, float residual)
-        {
-            return Mathf.Log(1f / residual) / time;
-        }
+        static float DecayConstant(float time, float residual) => Mathf.Log(1f / residual) / time;
 
         // Exponential decay: decay a given quantity opver a period of time
-        static float DecayedRemainder(float initial, float decayConstant, float deltaTime)
-        {
-            return initial / Mathf.Exp(decayConstant * deltaTime);
-        }
+        static float DecayedRemainder(float initial, float decayConstant, float deltaTime) 
+            => initial / Mathf.Exp(decayConstant * deltaTime);
 
         /// <summary>Standard residual</summary>
         public const float kNegligibleResidual = 0.01f;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
@@ -151,7 +151,7 @@ namespace Cinemachine
             {
                 var resetLookahead = VirtualCamera.LookAtTargetChanged || !VirtualCamera.PreviousStateIsValid;
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
-                m_Predictor.AddPosition(pos, resetLookahead ? -1 : deltaTime, m_LookaheadTime);
+                m_Predictor.AddPosition(pos, resetLookahead ? -1 : deltaTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)
                     delta = delta.ProjectOntoPlane(up);

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -448,7 +448,7 @@ namespace Cinemachine
             if (m_LookaheadTime > Epsilon)
             {
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
-                m_Predictor.AddPosition(followTargetPosition, deltaTime, m_LookaheadTime);
+                m_Predictor.AddPosition(followTargetPosition, deltaTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)
                     delta = delta.ProjectOntoPlane(curState.ReferenceUp);


### PR DESCRIPTION
### Purpose of this PR

Rotation composer lookahead sometimes popped without apparent reason
Also a little cleanup here and there.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Was visible in simple car sample when you drive in a circle
