### PR TITLE
Update the date for the last changelog entry

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.0.0-pre.3] - 2022-10-20
+## [3.0.0-pre.3] - 2022-10-28
 - Bugfix: rotation composer lookahead sometimes popped
 
 


### PR DESCRIPTION
### Purpose of this PR

Update the last entry of the changelog.

NOTE: I bumped the package version to 3.0.0-pre.3 without review by mistake. 

See commit: https://github.com/Unity-Technologies/com.unity.cinemachine/commit/ad2c633a316b472807d49fdf93215711ee7251f0