### PR TITLE
CMCL-0000: Remove some GC allocs

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -85,7 +85,7 @@ namespace Cinemachine.Editor
             {
                 CinemachineSceneToolHelpers.FovToolHandle(cmCam, 
                     new SerializedObject(cmCam).FindProperty(() => cmCam.Lens), 
-                    cmCam.Lens, Target.Lens.UseHorizontalFOV);
+                    cmCam.Lens, InspectorUtility.GetUseHorizontalFOV(Target.Lens.SourceCamera));
             }
             else if (CinemachineSceneToolUtility.IsToolActive(typeof(FarNearClipTool)))
             {

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -33,8 +33,9 @@ namespace Cinemachine.Editor
         static Vector2 SensorSize(SerializedProperty property) => AccessProperty<Vector2>(
             typeof(LensSettings), SerializedPropertyHelper.GetPropertyValue(property), "SensorSize");
 
-        static bool UseHorizontalFOV(SerializedProperty property) => AccessProperty<bool>(
-            typeof(LensSettings), SerializedPropertyHelper.GetPropertyValue(property), "UseHorizontalFOV");
+        static bool UseHorizontalFOV(SerializedProperty property) => 
+            InspectorUtility.GetUseHorizontalFOV(AccessProperty<Camera>(
+                typeof(LensSettings), SerializedPropertyHelper.GetPropertyValue(property), "SourceCamera"));
 
         static T AccessProperty<T>(Type type, object obj, string memberName)
         {

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -363,6 +363,15 @@ namespace Cinemachine.Editor
             return s_AssignableTypes[inputType];
         }
 
+        public static bool GetUseHorizontalFOV(Camera camera)
+        {
+            if (camera == null)
+                return false;
+
+            // This should really be a global setting, but for now there is no better way than this!
+            var p = new SerializedObject(camera).FindProperty("m_FOVAxisMode");
+            return (p != null && p.intValue == (int)Camera.FieldOfViewAxis.Horizontal);
+        }
 
         ///==============================================================================================
         ///==============================================================================================

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -101,6 +101,9 @@ namespace Cinemachine
         [FormerlySerializedAs("m_StandbyUpdate")]
         public StandbyUpdateMode StandbyUpdate = StandbyUpdateMode.RoundRobin;
 
+        // Cache for GameObject name, to avoid GC allocs
+        string m_CachedName;
+
         //============================================================================
         // Legacy streaming support
 
@@ -388,8 +391,21 @@ namespace Cinemachine
         }
 
         /// <summary>Get the name of the Virtual Camera.  Base implementation
-        /// returns the owner GameObject's name.</summary>
-        public string Name => name;
+        /// returns a cache of the owner GameObject's name.</summary>
+        public string Name 
+        {
+            get 
+            {
+#if UNITY_EDITOR
+                // Allow vcam name changes when not playing
+                if (!Application.isPlaying || m_CachedName == null)
+#else
+                if (m_CachedName == null)
+#endif
+                    m_CachedName = name;
+                return m_CachedName;
+            }
+        }
 
         /// <summary>Gets a brief debug description of this virtual camera, for use when displayiong debug info</summary>
         public virtual string Description => "";

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -132,7 +132,7 @@ namespace Cinemachine
         }
 
 #if UNITY_EDITOR
-        internal bool UseHorizontalFOV { get; private set; }
+        internal Camera SourceCamera { get; private set; }
 #endif
 
         /// <summary>For physical cameras only: position of the gate relative to 
@@ -209,9 +209,6 @@ namespace Cinemachine
         {
             m_OrthoFromCamera = false;
             m_PhysicalFromCamera = false;
-#if UNITY_EDITOR
-            UseHorizontalFOV = false;
-#endif
             if (camera != null && ModeOverride == OverrideModes.None)
             {
                 m_OrthoFromCamera = camera.orthographic;
@@ -235,9 +232,7 @@ namespace Cinemachine
                 LensShift = Vector2.zero;
             }
 #if UNITY_EDITOR
-            // This should really be a global setting, but for now there is no better way than this!
-            var p = new UnityEditor.SerializedObject(camera).FindProperty("m_FOVAxisMode");
-            UseHorizontalFOV = (p != null && p.intValue == (int)Camera.FieldOfViewAxis.Horizontal);
+            SourceCamera = camera;
 #endif
         }
 


### PR DESCRIPTION
### Purpose of this PR

1. GC allocs every frame (editor only, but it was very distracting and alarming) when getting UnseHorizontalFOV setting.
2. GC allocs accessing vcam name when looking up blends.  Vcams now cache their names.
