### PR TITLE
CMCL-1242: Fix for 2.8.X: Focal Length is not set by CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: POV starts up in its centered position, if recentering is enabled
 - Bugfix: When recording with an accumulation buffer, camera lens was not always set correctly
 - Freelook ForcePosition is more precise now.
+- Bugfix: VirtualCameras did not set the focal length property of physical cameras.
 
 
 ## [2.8.9] - 2022-08-24

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -910,6 +910,7 @@ namespace Cinemachine
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
+                        cam.focalLength = Camera.FieldOfViewToFocalLength(state.Lens.FieldOfView, state.Lens.SensorSize.y);
 #if CINEMACHINE_HDRP
     #if UNITY_2019_2_OR_NEWER
                         cam.TryGetComponent<HDAdditionalCameraData>(out var hda);


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1240](https://jira.unity3d.com/browse/CMCL-1240): Focal length is not set by Cinemachine. We only set field of view, but that value is overwritten and we need to set focal length instead.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation