### PR TITLE
CMCL-1243: Fix for 3.0.X: Focal Length is not set by CM

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Bugfix: VirtualCameras did not set the focal length property of physical cameras.
+
+
 ## [3.0.0-pre.3] - 2022-10-28
 - Bugfix: rotation composer lookahead sometimes popped
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -1055,6 +1055,7 @@ namespace Cinemachine
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
+                        cam.focalLength = Camera.FieldOfViewToFocalLength(state.Lens.FieldOfView, state.Lens.SensorSize.y);
 #if CINEMACHINE_HDRP
                         cam.focusDistance = state.Lens.FocusDistance;
                         cam.iso = state.Lens.Iso;


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1240](https://jira.unity3d.com/browse/CMCL-1240): Focal length is not set by Cinemachine. We only set field of view, but that value is overwritten and we need to set focal length instead.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation