### PR TITLE
CMCL-1244: physical lens settings not properly applied

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2022-11-01
+- Bugfix: Physical lens settings were not being properly applied
+
+
 ## [3.0.0-pre.3] - 2022-10-28
 - Bugfix: rotation composer lookahead sometimes popped
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -324,7 +324,7 @@ namespace Cinemachine.Editor
                 {
                     // Convert and clamp
                     var sensorHeight = SensorSize(property).y;
-                    var vfov =Camera.FocalLengthToFieldOfView(evt.newValue, sensorHeight);
+                    var vfov = Camera.FocalLengthToFieldOfView(Mathf.Max(0.01f, evt.newValue), sensorHeight);
                     if (vfov < 1 || vfov > 179)
                     {
                         vfov = Mathf.Clamp(vfov, 1, 179);
@@ -362,7 +362,7 @@ namespace Cinemachine.Editor
                         if (index >= 0)
                         {
                             var v = CinemachineLensPresets.Instance.m_PhysicalPresets[index];
-                            focalProperty.floatValue = Camera.FocalLengthToFieldOfView(v.m_FocalLength, SensorSize(property).y);
+                            focalProperty.floatValue = Camera.FocalLengthToFieldOfView(Mathf.Max(0.01f, v.m_FocalLength), SensorSize(property).y);
 #if CINEMACHINE_HDRP
                             property.FindPropertyRelative(() => m_LensSettingsDef.Aperture).floatValue = v.Aperture;
                             property.FindPropertyRelative(() => m_LensSettingsDef.Iso).intValue = v.Iso;
@@ -626,7 +626,7 @@ namespace Cinemachine.Editor
             float f = Camera.FieldOfViewToFocalLength(FOVProperty.floatValue, m_Snapshot.SensorSize.y);
             EditorGUI.BeginProperty(rect, label, FOVProperty);
             f = EditorGUI.FloatField(rect, label, f);
-            f = Camera.FocalLengthToFieldOfView(Mathf.Max(f, 0.0001f), m_Snapshot.SensorSize.y);
+            f = Camera.FocalLengthToFieldOfView(Mathf.Max(0.01f, f), m_Snapshot.SensorSize.y);
             if (!Mathf.Approximately(FOVProperty.floatValue, f))
                 FOVProperty.floatValue = Mathf.Clamp(f, 1, 179);
             EditorGUI.EndProperty();
@@ -662,7 +662,7 @@ namespace Cinemachine.Editor
             else if (selection >= 0 && selection < m_Snapshot.m_PhysicalPresetOptions.Length-1)
             {
                 var v = presets.m_PhysicalPresets[selection];
-                FOVProperty.floatValue = Camera.FocalLengthToFieldOfView(v.m_FocalLength, m_Snapshot.SensorSize.y);
+                FOVProperty.floatValue = Camera.FocalLengthToFieldOfView(Mathf.Max(0.01f, v.m_FocalLength), m_Snapshot.SensorSize.y);
                 property.FindPropertyRelative(() => m_LensSettingsDef.Aperture).floatValue = v.Aperture;
                 property.FindPropertyRelative(() => m_LensSettingsDef.Iso).intValue = v.Iso;
                 property.FindPropertyRelative(() => m_LensSettingsDef.ShutterSpeed).floatValue = v.ShutterSpeed;
@@ -686,7 +686,7 @@ namespace Cinemachine.Editor
             else if (selection >= 0 && selection < m_Snapshot.m_PhysicalPresetOptions.Length-1)
             {
                 FOVProperty.floatValue = Camera.FocalLengthToFieldOfView(
-                    presets.m_PhysicalPresets[selection].m_FocalLength, m_Snapshot.SensorSize.y);
+                    Mathf.Max(0.01f, presets.m_PhysicalPresets[selection].m_FocalLength), m_Snapshot.SensorSize.y);
                 property.serializedObject.ApplyModifiedProperties();
             }
 #endif

--- a/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
+++ b/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
@@ -169,8 +169,9 @@ namespace Cinemachine.Editor
             cameraRect.yMin = cameraRect.yMax - h;
 
             // Shift the guides along with the lens
-            cameraRect.position += new Vector2(
-                -screenWidth * lens.LensShift.x, screenHeight * lens.LensShift.y);
+            if (lens.IsPhysicalCamera)
+                cameraRect.position += new Vector2(
+                    -screenWidth * lens.LensShift.x, screenHeight * lens.LensShift.y);
 
             return cameraRect;
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -1048,13 +1048,14 @@ namespace Cinemachine
                             cam.orthographic = LensModeOverride.DefaultMode == LensSettings.OverrideModes.Orthographic;
                         }
                         cam.usePhysicalProperties = isPhysical;
-                        cam.lensShift = state.Lens.LensShift;
                     }
 
                     if (isPhysical)
                     {
                         cam.sensorSize = state.Lens.SensorSize;
                         cam.gateFit = state.Lens.GateFit;
+                        cam.focalLength = Camera.FieldOfViewToFocalLength(state.Lens.FieldOfView, state.Lens.SensorSize.y);
+                        cam.lensShift = state.Lens.LensShift;
 #if CINEMACHINE_HDRP
                         cam.focusDistance = state.Lens.FocusDistance;
                         cam.iso = state.Lens.Iso;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
@@ -237,9 +237,8 @@ namespace Cinemachine
                 CinemachineVirtualCameraBase vcam, 
                 ref CameraState state, float deltaTime, float modifierValue) 
             {
-                Top.SnapshotCameraReadOnlyProperties(ref state.Lens);
-                Bottom.SnapshotCameraReadOnlyProperties(ref state.Lens);
-                Top.ModeOverride = Bottom.ModeOverride = LensSettings.OverrideModes.None;
+                Top.CopyCameraMode(ref state.Lens);
+                Bottom.CopyCameraMode(ref state.Lens);
                 if (modifierValue >= 0)
                     state.Lens.Lerp(Top, modifierValue);
                 else

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -770,8 +770,8 @@ namespace Cinemachine
             state.ReferenceUp = worldUp;
 
             CinemachineBrain brain = CinemachineCore.Instance.FindPotentialTargetBrain(this);
-            if (brain != null)
-                lens.SnapshotCameraReadOnlyProperties(brain.OutputCamera);
+            if (brain != null && brain.OutputCamera != null)
+                lens.PullInheritedPropertiesFromCamera(brain.OutputCamera);
 
             state.Lens = lens;
             return state;

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -177,17 +177,20 @@ namespace Cinemachine
             LensSettings lens = Default;
             if (fromCamera != null)
             {
+                lens.PullInheritedPropertiesFromCamera(fromCamera);
+
                 lens.FieldOfView = fromCamera.fieldOfView;
                 lens.OrthographicSize = fromCamera.orthographicSize;
                 lens.NearClipPlane = fromCamera.nearClipPlane;
                 lens.FarClipPlane = fromCamera.farClipPlane;
-                lens.LensShift = fromCamera.lensShift;
-                lens.GateFit = fromCamera.gateFit;
-                lens.SnapshotCameraReadOnlyProperties(fromCamera);
 
-#if CINEMACHINE_HDRP
                 if (lens.IsPhysicalCamera)
                 {
+                    lens.FieldOfView = Camera.FocalLengthToFieldOfView(Mathf.Max(0.01f, fromCamera.focalLength), fromCamera.sensorSize.y);
+                    lens.SensorSize = fromCamera.sensorSize;
+                    lens.LensShift = fromCamera.lensShift;
+                    lens.GateFit = fromCamera.gateFit;
+#if CINEMACHINE_HDRP
                     lens.Iso = fromCamera.iso;
                     lens.ShutterSpeed = fromCamera.shutterSpeed;
                     lens.Aperture = fromCamera.aperture;
@@ -195,61 +198,54 @@ namespace Cinemachine
                     lens.Curvature = fromCamera.curvature;
                     lens.BarrelClipping = fromCamera.barrelClipping;
                     lens.Anamorphism = fromCamera.anamorphism;
-                }
 #endif
+                }
             }
             return lens;
         }
 
         /// <summary>
-        /// Snapshot the properties that are read-only in the Camera
+        /// In the event that there is no camera mode override, camera mode is driven
+        /// by the Camera's state.
         /// </summary>
         /// <param name="camera">The Camera from which we will take the info</param>
-        public void SnapshotCameraReadOnlyProperties(Camera camera)
+        public void PullInheritedPropertiesFromCamera(Camera camera)
         {
-            m_OrthoFromCamera = false;
-            m_PhysicalFromCamera = false;
-            if (camera != null && ModeOverride == OverrideModes.None)
+            if (ModeOverride == OverrideModes.None)
             {
                 m_OrthoFromCamera = camera.orthographic;
                 m_PhysicalFromCamera = camera.usePhysicalProperties;
-                m_SensorSize = camera.sensorSize;
-                GateFit = camera.gateFit;
             }
-            if (IsPhysicalCamera)
+            if (!IsPhysicalCamera)
             {
-                // If uninitialized, do an initial pull from the camera
-                if (camera != null && m_SensorSize == Vector2.zero)
-                {
-                    m_SensorSize = camera.sensorSize;
-                    GateFit = camera.gateFit;
-                }
-            }
-            else
-            {
-                if (camera != null)
-                    m_SensorSize = new Vector2(camera.aspect, 1f);
+                // For nonphysical cameras, aspect is encoded in the sensor size
+                m_SensorSize = new Vector2(camera.aspect, 1f);
                 LensShift = Vector2.zero;
             }
+
 #if UNITY_EDITOR
-            SourceCamera = camera;
+            SourceCamera = camera; // hack because of missng Unity API to get horizontal or vertical fov mode
 #endif
         }
 
         /// <summary>
-        /// Snapshot the properties that are read-only in the Camera
+        /// Copy the properties controlled by camera mode.  If ModeOverride is None, then
+        /// some internal state information must be transferred.
         /// </summary>
-        /// <param name="lens">The LensSettings from which we will take the info</param>
-        public void SnapshotCameraReadOnlyProperties(ref LensSettings lens)
+        /// <param name="fromLens">The LensSettings from which we will take the info</param>
+        public void CopyCameraMode(ref LensSettings fromLens)
         {
+            ModeOverride = fromLens.ModeOverride;
             if (ModeOverride == OverrideModes.None)
             {
-                m_OrthoFromCamera = lens.Orthographic;
-                m_SensorSize = lens.m_SensorSize;
-                m_PhysicalFromCamera = lens.IsPhysicalCamera;
+                m_OrthoFromCamera = fromLens.Orthographic;
+                m_PhysicalFromCamera = fromLens.IsPhysicalCamera;
             }
             if (!IsPhysicalCamera)
+            {
                 LensShift = Vector2.zero;
+                m_SensorSize = fromLens.m_SensorSize;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1244

- camera.focalLength was not being set
- gateFit, sensorSize, lensShift were not settable from inspector when mode override is none
- dragging focalLength setting in inspector has weird wraparound when dragged past 0

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
