### PR TITLE
CMCL-0000: fix recentering defaults

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -60,7 +60,7 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Transitions)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lens)));
 
-            ux.AddHeader("Global Controls");
+            ux.AddHeader("Global Settings");
             m_CameraUtility.AddGlobalControls(ux);
 
             ux.AddHeader("Procedural Motion");

--- a/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
@@ -112,25 +112,14 @@ namespace Cinemachine.Editor
 #pragma warning restore CS0219 // Variable is assigned but its value is never used
                     var inputName = "";
                     var invertY = false;
-                    controller.Recentering = new InputAxisRecenteringSettings { Enabled = true };
+                    controller.Recentering = InputAxisRecenteringSettings.Default;
 
                     if (axis.Name.Contains("Look"))
                     {
                         actionName = "Player/Look";
                         inputName = axis.AxisIndex == 0 ? "Mouse X" : (axis.AxisIndex == 1 ? "Mouse Y" : "");
                         invertY = axis.AxisIndex == 1;
-                        controller.Recentering = InputAxisRecenteringSettings.Default;
                         controller.Control = new InputAxisControl { AccelTime = 0.2f, DecelTime = 0.2f };
-                    }
-                    if (axis.Name.Contains("Move"))
-                    {
-                        actionName = "Player/Move";
-                        inputName = axis.AxisIndex == 0 ? "Horizontal" : (axis.AxisIndex == 1 ? "Vertical" : "");
-                    }
-                    if (axis.Name.Contains("Fire"))
-                    {
-                        actionName = "Player/Fire";
-                        inputName = "Fire";
                     }
 #if false
                     if (axis.Name.Contains("Zoom") || axis.Name.Contains("Scale"))
@@ -139,10 +128,23 @@ namespace Cinemachine.Editor
                         inputName = "Mouse ScrollWheel";
                     }
 #endif
+                    if (axis.Name.Contains("Move"))
+                    {
+                        actionName = "Player/Move";
+                        inputName = axis.AxisIndex == 0 ? "Horizontal" : (axis.AxisIndex == 1 ? "Vertical" : "");
+                        controller.Recentering = new InputAxisRecenteringSettings { Enabled = true };
+                    }
+                    if (axis.Name.Contains("Fire"))
+                    {
+                        actionName = "Player/Fire";
+                        inputName = "Fire";
+                        controller.Recentering = new InputAxisRecenteringSettings { Enabled = true };
+                    }
                     if (axis.Name.Contains("Jump"))
                     {
                         actionName = "UI/RightClick"; // best we can do
                         inputName = "Jump";
+                        controller.Recentering = new InputAxisRecenteringSettings { Enabled = true };
                     }
 
 #if CINEMACHINE_UNITY_INPUTSYSTEM

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -345,45 +345,34 @@ namespace Cinemachine.Editor
         /// </summary>
         public void AddGlobalControls(VisualElement ux)
         {
-            var row = ux.AddChild(new InspectorUtility.LeftRightContainer());
-
             var helpBox = ux.AddChild(new HelpBox("CmCamera settings changes made during Play Mode will be "
                     + "propagated back to the scene when Play Mode is exited.", 
                 HelpBoxMessageType.Info));
             helpBox.SetVisible(SaveDuringPlay.SaveDuringPlay.Enabled && Application.isPlaying);
 
-            row.Left.Add(new Label(CinemachineCorePrefs.s_SaveDuringPlayLabel.text) 
+            var toggle = ux.AddChild(new Toggle(CinemachineCorePrefs.s_SaveDuringPlayLabel.text) 
             { 
                 tooltip = CinemachineCorePrefs.s_SaveDuringPlayLabel.tooltip,
-                style = { alignSelf = Align.Center, flexGrow = 1, height = InspectorUtility.SingleLineHeight }
-            });
-            var toggle = row.Right.AddChild(new Toggle("") 
-            { 
-                tooltip = CinemachineCorePrefs.s_SaveDuringPlayLabel.tooltip,
-                style = { alignSelf = Align.Center },
                 value = SaveDuringPlay.SaveDuringPlay.Enabled
             });
+            toggle.AddToClassList(InspectorUtility.kAlignFieldClass);
             toggle.RegisterValueChangedCallback((evt) => 
             {
                 SaveDuringPlay.SaveDuringPlay.Enabled = evt.newValue;
                 helpBox.SetVisible(evt.newValue && Application.isPlaying);
             });
 
-            row.Right.Add(new Label("Game Guides:") 
-            { 
-                tooltip = CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip,
-                style = { marginLeft = 8, alignSelf = Align.Center, flexGrow = 0, height = InspectorUtility.SingleLineHeight }
-            });
             var choices = new List<string>() { "Disabled", "Passive", "Interactive" };
             int index = CinemachineCorePrefs.ShowInGameGuides.Value 
                 ? (CinemachineCorePrefs.DraggableComposerGuides.Value ? 2 : 1) : 0;
-            var dropdown = row.Right.AddChild(new DropdownField
+            var dropdown = ux.AddChild(new DropdownField("Game View Guides")
             {
                 tooltip = CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip,
                 choices = choices,
                 index = index,
                 style = { flexGrow = 1 }
             });
+            dropdown.AddToClassList(InspectorUtility.kAlignFieldClass);
             dropdown.RegisterValueChangedCallback((evt) => 
             {
                 CinemachineCorePrefs.ShowInGameGuides.Value = evt.newValue != choices[0];


### PR DESCRIPTION

### Purpose of this PR

Recentering defaulted to enabled(0, 0) in input axis controller.  Changed to something more reasonable.
Also separated Global Controls back into 2 lines.  Single-line version was weird.

![image](https://user-images.githubusercontent.com/6424658/199832482-2dd50470-19fe-43fc-8290-b373b7df174f.png)

