### PR TITLE
CMCL-0000: Damping bypass refactor

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -313,7 +313,7 @@ namespace Cinemachine
                     var initialCamPos = state.GetCorrectedPosition();
 
                     // Rotate the previous collision correction along with the camera
-                    var dampingBypass = Quaternion.Euler(state.PositionDampingBypass);
+                    var dampingBypass = state.RotationDampingBypass;
                     extra.PreviousDisplacement = dampingBypass * extra.PreviousDisplacement;
 
                     // Calculate the desired collision correction
@@ -380,8 +380,8 @@ namespace Cinemachine
                         var dir0 = extra.PreviousCameraPosition - state.ReferenceLookAt;
                         var dir1 = cameraPos - state.ReferenceLookAt;
                         if (dir0.sqrMagnitude > Epsilon && dir1.sqrMagnitude > Epsilon)
-                            state.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
-                                dir0, dir1, state.ReferenceUp).eulerAngles;
+                            state.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
+                                dir0, dir1, state.ReferenceUp);
                     }
 
                     extra.PreviousDisplacement = displacement;

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -362,7 +362,7 @@ namespace Cinemachine
             if (deltaTime < 0 || !VirtualCamera.PreviousStateIsValid || !CinemachineCore.Instance.IsLive(VirtualCamera))
                 m_ResetHandler?.Invoke();
 
-            var rawOffset = GetCameraPoint();
+            Vector3 offset = GetCameraPoint();
             if (TrackerSettings.BindingMode != BindingMode.SimpleFollowWithWorldUp)
                 HorizontalAxis.Restrictions 
                     &= ~(InputAxis.RestrictionFlags.NoRecentering | InputAxis.RestrictionFlags.RangeIsDriven);
@@ -373,11 +373,11 @@ namespace Cinemachine
                     |= InputAxis.RestrictionFlags.NoRecentering | InputAxis.RestrictionFlags.RangeIsDriven;
             }
             m_TargetTracker.TrackTarget(
-                this, deltaTime, curState.ReferenceUp, rawOffset, TrackerSettings,
+                this, deltaTime, curState.ReferenceUp, offset, TrackerSettings,
                 out Vector3 pos, out Quaternion orient);
 
             // Place the camera
-            var offset = orient * rawOffset;
+            offset = orient * offset;
             curState.ReferenceUp = orient * Vector3.up;
 
             // Respect minimum target distance on XZ plane

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -388,7 +388,7 @@ namespace Cinemachine
             curState.RawPosition = pos + offset;
 
             if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid
-                && m_PreviousOffset.sqrMagnitude > 0.01f && offset.sqrMagnitude > 0.01f)
+                && m_PreviousOffset.sqrMagnitude > Epsilon && offset.sqrMagnitude > Epsilon)
             {
                 curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
                     m_PreviousOffset, offset, curState.ReferenceUp);

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -387,26 +387,12 @@ namespace Cinemachine
                 curState.ReferenceUp, targetPosition);
             curState.RawPosition = pos + offset;
 
-#if true
             if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid
                 && m_PreviousOffset.sqrMagnitude > 0.01f && offset.sqrMagnitude > 0.01f)
             {
                 curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
                     m_PreviousOffset, offset, curState.ReferenceUp);
             }
-#else
-            if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
-            {
-                var lookAt = targetPosition;
-                if (LookAtTarget != null)
-                    lookAt = LookAtTargetPosition;
-                var dir0 = m_TargetTracker.PreviousTargetPosition + m_PreviousOffset - lookAt;
-                var dir1 = curState.RawPosition - lookAt;
-                if (dir0.sqrMagnitude > 0.01f && dir1.sqrMagnitude > 0.01f)
-                    curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
-                        dir0, dir1, curState.ReferenceUp);
-            }
-#endif
             m_PreviousOffset = offset;
         }
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -131,9 +131,9 @@ namespace Cinemachine
             curState.RawOrientation = Quaternion.FromToRotation(curState.ReferenceUp, up) * rot;
 
             if (VirtualCamera.PreviousStateIsValid)
-                curState.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
+                curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
                     m_PreviousCameraRotation * Vector3.forward, 
-                    rot * Vector3.forward, curState.ReferenceUp).eulerAngles;
+                    rot * Vector3.forward, curState.ReferenceUp);
             m_PreviousCameraRotation = rot;
         }
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
@@ -215,7 +215,7 @@ namespace Cinemachine
                         m_CameraOrientationPrevFrame * Vector3.forward, curState.ReferenceUp);
                 else
                 {
-                    dir = Quaternion.Euler(curState.PositionDampingBypass) * dir;
+                    dir = curState.RotationDampingBypass * dir;
                     rigOrientation = Quaternion.LookRotation(dir, curState.ReferenceUp);
                     rigOrientation = rigOrientation.ApplyCameraRotation(
                         -m_ScreenOffsetPrevFrame, curState.ReferenceUp);

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -51,11 +51,11 @@ namespace Cinemachine
         /// </summary>
         public Quaternion RawOrientation;
 
-        /// <summary>This is a way for the Body component to bypass aim damping,
+        /// <summary>This is a way for the Body component to set a bypass hint for aim damping,
         /// useful for when the body needs to rotate its point of view, but does not
-        /// want interference from the aim damping.  The value is the camera
-        /// rotation, in Euler degrees.</summary>
-        public Vector3 PositionDampingBypass;
+        /// want interference from the aim damping.  The value is the amount that the camera
+        /// has been rotated, in world coords.</summary>
+        public Quaternion RotationDampingBypass;
 
         /// <summary>
         /// Subjective estimation of how "good" the shot is.
@@ -122,7 +122,7 @@ namespace Cinemachine
             ShotQuality = 1,
             PositionCorrection = Vector3.zero,
             OrientationCorrection = Quaternion.identity,
-            PositionDampingBypass = Vector3.zero,
+            RotationDampingBypass = Quaternion.identity,
             BlendHint = BlendHintValue.Nothing
         };
 

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -254,10 +254,29 @@ namespace Cinemachine.Utility
         /// <returns>Rotation between the vectors</returns>
         public static Quaternion SafeFromToRotation(Vector3 v1, Vector3 v2, Vector3 up)
         {
+#if true
+            var a1 = Vector3.Dot(v1, up);
+            var y2 = Vector3.Dot(v2, up);
+
+            var p1 = v1.ProjectOntoPlane(up);
+            var p2 = v2.ProjectOntoPlane(up);
+            if (p1.sqrMagnitude < 0.01f || p2.sqrMagnitude < 0.01f)
+            {
+                var axis = Vector3.Cross(v1, v2);
+                if (axis.AlmostZero())
+                    axis = up; // in case they are pointing in opposite directions
+                return Quaternion.AngleAxis(Angle(v1, v2), axis);
+            }
+            var yaw = SignedAngle(p1, p2, up);
+            var qYaw = Quaternion.AngleAxis(yaw, up);
+            v1 = qYaw * v1;
+
+#else
             var axis = Vector3.Cross(v1, v2);
             if (axis.AlmostZero())
                 axis = up; // in case they are pointing in opposite directions
             return Quaternion.AngleAxis(Angle(v1, v2), axis);
+#endif
         }
 
         /// <summary>This is a slerp that mimics a camera operator's movement in that

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -254,29 +254,18 @@ namespace Cinemachine.Utility
         /// <returns>Rotation between the vectors</returns>
         public static Quaternion SafeFromToRotation(Vector3 v1, Vector3 v2, Vector3 up)
         {
-#if true
-            var a1 = Vector3.Dot(v1, up);
-            var y2 = Vector3.Dot(v2, up);
-
             var p1 = v1.ProjectOntoPlane(up);
             var p2 = v2.ProjectOntoPlane(up);
-            if (p1.sqrMagnitude < 0.01f || p2.sqrMagnitude < 0.01f)
+            if (p1.sqrMagnitude < Epsilon || p2.sqrMagnitude < Epsilon)
             {
                 var axis = Vector3.Cross(v1, v2);
                 if (axis.AlmostZero())
                     axis = up; // in case they are pointing in opposite directions
                 return Quaternion.AngleAxis(Angle(v1, v2), axis);
             }
-            var yaw = SignedAngle(p1, p2, up);
-            var qYaw = Quaternion.AngleAxis(yaw, up);
-            v1 = qYaw * v1;
-
-#else
-            var axis = Vector3.Cross(v1, v2);
-            if (axis.AlmostZero())
-                axis = up; // in case they are pointing in opposite directions
-            return Quaternion.AngleAxis(Angle(v1, v2), axis);
-#endif
+            var pitchChange = Vector3.Angle(v2, up) - Vector3.Angle(v1, up);
+            return Quaternion.AngleAxis(SignedAngle(p1, p2, up), up)
+                * Quaternion.AngleAxis(pitchChange, Vector3.Cross(up, v1).normalized);
         }
 
         /// <summary>This is a slerp that mimics a camera operator's movement in that

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineComposer.cs
@@ -271,7 +271,7 @@ namespace Cinemachine
                         m_CameraOrientationPrevFrame * Vector3.forward, curState.ReferenceUp);
                 else
                 {
-                    dir = Quaternion.Euler(curState.PositionDampingBypass) * dir;
+                    dir = curState.RotationDampingBypass * dir;
                     rigOrientation = Quaternion.LookRotation(dir, curState.ReferenceUp);
                     rigOrientation = rigOrientation.ApplyCameraRotation(
                         -m_ScreenOffsetPrevFrame, curState.ReferenceUp);

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineOrbitalTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineOrbitalTransposer.cs
@@ -513,8 +513,8 @@ namespace Cinemachine
                     var dir0 = m_LastCameraPosition - lookAt;
                     var dir1 = curState.RawPosition - lookAt;
                     if (dir0.sqrMagnitude > 0.01f && dir1.sqrMagnitude > 0.01f)
-                        curState.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
-                            dir0, dir1, curState.ReferenceUp).eulerAngles;
+                        curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
+                            dir0, dir1, curState.ReferenceUp);
                 }
                 m_LastTargetPosition = targetPosition;
                 m_LastCameraPosition = curState.RawPosition;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
@@ -155,9 +155,9 @@ namespace Cinemachine
             curState.RawOrientation = rot;
 
             if (VirtualCamera.PreviousStateIsValid)
-                curState.PositionDampingBypass = UnityVectorExtensions.SafeFromToRotation(
+                curState.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(
                     m_PreviousCameraRotation * Vector3.forward, 
-                    rot * Vector3.forward, curState.ReferenceUp).eulerAngles;
+                    rot * Vector3.forward, curState.ReferenceUp);
             m_PreviousCameraRotation = rot;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Damping bypass was reimplemented as a quaternion instead of euler.
Also, algorithm was improved to help reduce spurious rotation damping when a nonzero lookAt target offset was used.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

