### PR TITLE
CMCL-0000: SmoothPath upgrade fix

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
@@ -660,7 +660,8 @@ namespace Cinemachine.Editor
                 case CinemachineSmoothPath smoothPath:
                 {
                     var waypoints = smoothPath.m_Waypoints;
-                    spline.Spline = new Spline(waypoints.Length, smoothPath.Looped) { EditType = SplineType.CatmullRom };
+                    spline.Spline = new Spline(waypoints.Length, smoothPath.Looped);
+                    
                     for (var i = 0; i < waypoints.Length; i++)
                     {
                         spline.Spline.Add(new BezierKnot
@@ -670,6 +671,7 @@ namespace Cinemachine.Editor
                         });
                         splineRoll.Roll.Add(new DataPoint<float>(i, waypoints[i].roll));
                     }
+                    spline.Spline.SetTangentMode(TangentMode.AutoSmooth);
                     break;
                 }
                 default:


### PR DESCRIPTION
### Purpose of this PR
SmoothPath was not upgraded properly. It was upgraded to a linear spline, now it is upgraded to a smooth spline (not identical to SmoothPath, but close enough).