### PR TITLE
CMCL-0000: InputAxis is now a struct

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.Data.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.Data.cs
@@ -142,9 +142,9 @@ namespace Cinemachine.Editor
                     { "BindingMode", new("TrackerSettings.BindingMode", typeof(CinemachineOrbitalFollow)) },
                     { "AngularDampingMode", new("TrackerSettings.AngularDampingMode", typeof(CinemachineOrbitalFollow)) },
                     { "AngularDamping", new("TrackerSettings.QuaternionDamping", typeof(CinemachineOrbitalFollow)) },
-                    { "XAxis.Value", new("managedReferences[HorizontalAxis].Value", typeof(CinemachineOrbitalFollow)) },
-                    { "YAxis.Value", new("managedReferences[VerticalAxis].Value", typeof(CinemachineOrbitalFollow)) },
-                    { "ZAxis.Value", new("managedReferences[RadialAxis].Value", typeof(CinemachineOrbitalFollow)) }
+                    { "XAxis.Value", new("HorizontalAxis.Value", typeof(CinemachineOrbitalFollow)) },
+                    { "YAxis.Value", new("VerticalAxis.Value", typeof(CinemachineOrbitalFollow)) },
+                    { "ZAxis.Value", new("RadialAxis.Value", typeof(CinemachineOrbitalFollow)) }
                 }
             },
             {
@@ -219,15 +219,15 @@ namespace Cinemachine.Editor
             {
                 typeof(CinemachinePOV), new Dictionary<string, Tuple<string, Type>>
                 {
-                    { "HorizontalAxis.Value", new("managedReferences[PanAxis].Value", typeof(CinemachinePanTilt)) },
-                    { "VerticalAxis.Value", new("managedReferences[TiltAxis].Value", typeof(CinemachinePanTilt)) }
+                    { "HorizontalAxis.Value", new("PanAxis.Value", typeof(CinemachinePanTilt)) },
+                    { "VerticalAxis.Value", new("TiltAxis.Value", typeof(CinemachinePanTilt)) }
                 }
             },
             {
                 typeof(CinemachineFreeLook), new Dictionary<string, Tuple<string, Type>>
                 {
-                    { "XAxis.Value", new("managedReferences[HorizontalAxis].Value", typeof(CinemachineOrbitalFollow)) },
-                    { "YAxis.Value", new("managedReferences[VerticalAxis].Value", typeof(CinemachineOrbitalFollow)) },
+                    { "XAxis.Value", new("HorizontalAxis.Value", typeof(CinemachineOrbitalFollow)) },
+                    { "YAxis.Value", new("VerticalAxis.Value", typeof(CinemachineOrbitalFollow)) },
                 }
             },
             {

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -53,21 +53,18 @@ namespace Cinemachine
         /// and represents a rotation about the up vector</summary>
         [Tooltip("Axis representing the current horizontal rotation.  Value is in degrees "
             + "and represents a rotation about the up vector.")]
-        [SerializeReference]
         public InputAxis HorizontalAxis = DefaultHorizontal;
 
         /// <summary>Axis representing the current vertical rotation.  Value is in degrees
         /// and represents a rotation about the right vector</summary>
         [Tooltip("Axis representing the current vertical rotation.  Value is in degrees "
             + "and represents a rotation about the right vector.")]
-        [SerializeReference]
         public InputAxis VerticalAxis = DefaultVertical;
 
         /// <summary>Axis controlling the scale of the current distance.  Value is a scalar
         /// multiplier and is applied to the specified camera distance</summary>
         [Tooltip("Axis controlling the scale of the current distance.  Value is a scalar "
             + "multiplier and is applied to the specified camera distance.")]
-        [SerializeReference]
         public InputAxis RadialAxis = DefaultRadial;
 
         // State information
@@ -125,9 +122,9 @@ namespace Cinemachine
         /// <param name="axes">Output list to which the axes will be added</param>
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = HorizontalAxis, Name = "Look Orbit X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = VerticalAxis, Name = "Look Orbit Y", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = RadialAxis, Name = "Orbit Scale", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref HorizontalAxis, Name = "Look Orbit X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref VerticalAxis, Name = "Look Orbit Y", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref RadialAxis, Name = "Orbit Scale", AxisIndex = 2 });
         }
 
         /// <summary>Register a handler that will be called when input needs to be reset</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -122,9 +122,9 @@ namespace Cinemachine
         /// <param name="axes">Output list to which the axes will be added</param>
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref HorizontalAxis, Name = "Look Orbit X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref VerticalAxis, Name = "Look Orbit Y", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref RadialAxis, Name = "Orbit Scale", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref HorizontalAxis, Name = "Look Orbit X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref VerticalAxis, Name = "Look Orbit Y", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref RadialAxis, Name = "Orbit Scale", AxisIndex = 2 });
         }
 
         /// <summary>Register a handler that will be called when input needs to be reset</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -80,8 +80,8 @@ namespace Cinemachine
         /// <param name="axes">Output list to which the axes will be added</param>
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref PanAxis, Name = "Look X (Pan)", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref TiltAxis, Name = "Look Y (Tilt)", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref PanAxis, Name = "Look X (Pan)", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref TiltAxis, Name = "Look Y (Tilt)", AxisIndex = 1 });
         }
 
         /// <summary>Register a handler that will be called when input needs to be reset</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -43,14 +43,12 @@ namespace Cinemachine
         /// and represents a rotation about the up vector</summary>
         [Tooltip("Axis representing the current horizontal rotation.  Value is in degrees "
             + "and represents a rotation about the Y axis.")]
-        [SerializeReference]
         public InputAxis PanAxis = DefaultPan;
 
         /// <summary>Axis representing the current vertical rotation.  Value is in degrees
         /// and represents a rotation about the right vector</summary>
         [Tooltip("Axis representing the current vertical rotation.  Value is in degrees "
             + "and represents a rotation about the X axis.")]
-        [SerializeReference]
         public InputAxis TiltAxis = DefaultTilt;
 
         Quaternion m_PreviousCameraRotation;
@@ -82,8 +80,8 @@ namespace Cinemachine
         /// <param name="axes">Output list to which the axes will be added</param>
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = PanAxis, Name = "Look X (Pan)", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = TiltAxis, Name = "Look Y (Tilt)", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref PanAxis, Name = "Look X (Pan)", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref TiltAxis, Name = "Look Y (Tilt)", AxisIndex = 1 });
         }
 
         /// <summary>Register a handler that will be called when input needs to be reset</summary>

--- a/com.unity.cinemachine/Runtime/Core/InputAxis.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxis.cs
@@ -20,7 +20,7 @@ namespace Cinemachine
             public delegate ref InputAxis AxisGetter();
 
             /// <summary>The axis to drive</summary>
-            public AxisGetter GetAxis;
+            public AxisGetter DrivenAxis;
 
             /// <summary>The name to display for the axis</summary>
             public string Name;

--- a/com.unity.cinemachine/Runtime/Core/InputAxis.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxis.cs
@@ -15,10 +15,16 @@ namespace Cinemachine
         /// </summary>
         public struct AxisDescriptor
         {
+            /// <summary>Delegate to get a reference to the axis being driven</summary>
+            /// <returns>A reference to the axis being driven</returns>
+            public delegate ref InputAxis AxisGetter();
+
             /// <summary>The axis to drive</summary>
-            public InputAxis Axis;
+            public AxisGetter GetAxis;
+
             /// <summary>The name to display for the axis</summary>
             public string Name;
+
             /// <summary>Indicates what axis is being driven: 0=x, 1=y, 2=z.  
             /// Used only for setting up default values.</summary>
             public int AxisIndex;
@@ -59,7 +65,7 @@ namespace Cinemachine
     /// with optional wrapping to form a loop.
     /// </summary>
     [Serializable]
-    public class InputAxis
+    public struct InputAxis
     {
         /// <summary>The current value of the axis.  You can drive this directly from a script</summary>
         [Tooltip("The current value of the axis.  You can drive this directly from a script.")]
@@ -207,7 +213,7 @@ namespace Cinemachine
         /// <param name="axis">The InputAxisValue to update</param>
         /// <param name="control">Parameter for controlling the behaviour of the axis</param>
         public void ProcessInput(
-            float deltaTime, InputAxis axis, 
+            float deltaTime, ref InputAxis axis, 
             ref InputAxisControl control)
         {
             var input = control.InputValue;
@@ -239,7 +245,7 @@ namespace Cinemachine
         /// <param name="deltaTime">Current deltaTime</param>
         /// <param name="axis">The axis to recenter</param>
         /// <param name="recentering">The recentering settings</param>
-        public void DoRecentering(float deltaTime, InputAxis axis, in InputAxisRecenteringSettings recentering)
+        public void DoRecentering(float deltaTime, ref InputAxis axis, in InputAxisRecenteringSettings recentering)
         {
             if (m_ForceRecenter || 
                 (recentering.Enabled 
@@ -285,7 +291,7 @@ namespace Cinemachine
         /// <summary>Reset axis to at-rest state</summary>
         /// <param name="axis">The axis to reset</param>
         /// <param name="recentering">The recentering settings</param>
-        public void Reset(InputAxis axis, in InputAxisRecenteringSettings recentering)
+        public void Reset(ref InputAxis axis, in InputAxisRecenteringSettings recentering)
         {
             m_LastUpdateTime = CurrentTime;
             m_CurrentSpeed = 0;

--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -202,7 +202,7 @@ namespace Cinemachine
         void OnResetInput()
         {
             for (int i = 0; i < Controllers.Count; ++i)
-                Controllers[i].Driver.Reset(m_Axes[i].Axis, Controllers[i].Recentering);
+                Controllers[i].Driver.Reset(ref m_Axes[i].GetAxis(), Controllers[i].Recentering);
         }
 
         void Update()
@@ -231,7 +231,7 @@ namespace Cinemachine
                         c.Control.InputValue = inputValue;
                 }
 #endif
-                c.Driver.ProcessInput(deltaTime, m_Axes[i].Axis, ref c.Control);
+                c.Driver.ProcessInput(deltaTime, ref m_Axes[i].GetAxis(), ref c.Control);
                 gotInput |= Mathf.Abs(c.Control.InputValue) > 0.001f;
             }
 
@@ -241,7 +241,7 @@ namespace Cinemachine
                 // If we got any input, cancel all recentering
                 if (gotInput && Controllers[i].Recentering.Wait > 0.01f)
                     Controllers[i].Driver.CancelRecentering();
-                Controllers[i].Driver.DoRecentering(deltaTime, m_Axes[i].Axis, Controllers[i].Recentering);
+                Controllers[i].Driver.DoRecentering(deltaTime, ref m_Axes[i].GetAxis(), Controllers[i].Recentering);
             }
         }
 

--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -202,7 +202,7 @@ namespace Cinemachine
         void OnResetInput()
         {
             for (int i = 0; i < Controllers.Count; ++i)
-                Controllers[i].Driver.Reset(ref m_Axes[i].GetAxis(), Controllers[i].Recentering);
+                Controllers[i].Driver.Reset(ref m_Axes[i].DrivenAxis(), Controllers[i].Recentering);
         }
 
         void Update()
@@ -231,7 +231,7 @@ namespace Cinemachine
                         c.Control.InputValue = inputValue;
                 }
 #endif
-                c.Driver.ProcessInput(deltaTime, ref m_Axes[i].GetAxis(), ref c.Control);
+                c.Driver.ProcessInput(deltaTime, ref m_Axes[i].DrivenAxis(), ref c.Control);
                 gotInput |= Mathf.Abs(c.Control.InputValue) > 0.001f;
             }
 
@@ -241,7 +241,7 @@ namespace Cinemachine
                 // If we got any input, cancel all recentering
                 if (gotInput && Controllers[i].Recentering.Wait > 0.01f)
                     Controllers[i].Driver.CancelRecentering();
-                Controllers[i].Driver.DoRecentering(deltaTime, ref m_Axes[i].GetAxis(), Controllers[i].Recentering);
+                Controllers[i].Driver.DoRecentering(deltaTime, ref m_Axes[i].DrivenAxis(), Controllers[i].Recentering);
             }
         }
 

--- a/com.unity.cinemachine/Samples~/3D Samples/FreeLook deoccluder.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/FreeLook deoccluder.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -443,9 +443,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  PlayerIndex: -1
+  AutoEnableInputs: 1
   Controllers:
   - Name: Look Orbit X
     Owner: {fileID: 1727080744}
+    InputAction: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+    Gain: 4
     LegacyInput: Mouse X
     LegacyGain: 200
     Control:
@@ -458,6 +462,8 @@ MonoBehaviour:
       Time: 2
   - Name: Look Orbit Y
     Owner: {fileID: 1727080744}
+    InputAction: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+    Gain: -4
     LegacyInput: Mouse Y
     LegacyGain: -200
     Control:
@@ -470,6 +476,8 @@ MonoBehaviour:
       Time: 2
   - Name: Orbit Scale
     Owner: {fileID: 1727080744}
+    InputAction: {fileID: 0}
+    Gain: 4
     LegacyInput: 
     LegacyGain: 200
     Control:
@@ -557,38 +565,23 @@ MonoBehaviour:
       Height: 0.1
     SplineCurvature: 0.5
   HorizontalAxis:
-    rid: 1709466907129151517
+    Value: 0
+    Center: 0
+    Range: {x: -180, y: 180}
+    Wrap: 1
+    Restrictions: 0
   VerticalAxis:
-    rid: 1709466907129151518
+    Value: 17.5
+    Center: 17.5
+    Range: {x: -10, y: 45}
+    Wrap: 0
+    Restrictions: 0
   RadialAxis:
-    rid: 1709466907129151519
-  references:
-    version: 2
-    RefIds:
-    - rid: 1709466907129151517
-      type: {class: InputAxis, ns: Cinemachine, asm: Cinemachine}
-      data:
-        Value: 0
-        Center: 0
-        Range: {x: -180, y: 180}
-        Wrap: 1
-        Restrictions: 0
-    - rid: 1709466907129151518
-      type: {class: InputAxis, ns: Cinemachine, asm: Cinemachine}
-      data:
-        Value: 17.5
-        Center: 17.5
-        Range: {x: -10, y: 45}
-        Wrap: 0
-        Restrictions: 0
-    - rid: 1709466907129151519
-      type: {class: InputAxis, ns: Cinemachine, asm: Cinemachine}
-      data:
-        Value: 1
-        Center: 1
-        Range: {x: 1, y: 5}
-        Wrap: 0
-        Restrictions: 0
+    Value: 1
+    Center: 1
+    Range: {x: 1, y: 5}
+    Wrap: 0
+    Restrictions: 0
 --- !u!114 &1727080745
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleCarController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleCarController.cs
@@ -36,9 +36,9 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Brake, Name = "Brake",  AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref Brake, Name = "Brake",  AxisIndex = 2 });
         }
 
         void Update()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleCarController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleCarController.cs
@@ -36,9 +36,9 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = MoveX, Name = "Move X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = MoveZ, Name = "Move Z", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = Brake, Name = "Brake",  AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Brake, Name = "Brake",  AxisIndex = 2 });
         }
 
         void Update()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
@@ -29,8 +29,8 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref HorizontalLook, Name = "Horizontal Look", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref VerticalLook, Name = "Vertical Look", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref HorizontalLook, Name = "Horizontal Look", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref VerticalLook, Name = "Vertical Look", AxisIndex = 1 });
         }
 
         void OnValidate()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
@@ -29,8 +29,8 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = HorizontalLook, Name = "Horizontal Look", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = VerticalLook, Name = "Vertical Look", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref HorizontalLook, Name = "Horizontal Look", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref VerticalLook, Name = "Vertical Look", AxisIndex = 1 });
         }
 
         void OnValidate()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -67,10 +67,10 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = MoveX, Name = "Move X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = MoveZ, Name = "Move Z", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = Jump, Name = "Jump", AxisIndex = 2 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = Sprint, Name = "Sprint", AxisIndex = 3 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Jump, Name = "Jump", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Sprint, Name = "Sprint", AxisIndex = 3 });
         }
 
         void Start()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -67,10 +67,10 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Jump, Name = "Jump", AxisIndex = 2 });
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Sprint, Name = "Sprint", AxisIndex = 3 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref MoveX, Name = "Move X", AxisIndex = 0 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref MoveZ, Name = "Move Z", AxisIndex = 1 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref Jump, Name = "Jump", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref Sprint, Name = "Sprint", AxisIndex = 3 });
         }
 
         void Start()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerShoot.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerShoot.cs
@@ -24,7 +24,7 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Fire, Name = "Fire", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { DrivenAxis = () => ref Fire, Name = "Fire", AxisIndex = 2 });
         }
 
         void OnValidate()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerShoot.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerShoot.cs
@@ -24,7 +24,7 @@ namespace Cinemachine.Examples
         /// want it to work everywhere.
         void IInputAxisSource.GetInputAxes(List<IInputAxisSource.AxisDescriptor> axes)
         {
-            axes.Add(new IInputAxisSource.AxisDescriptor { Axis = Fire, Name = "Fire", AxisIndex = 2 });
+            axes.Add(new IInputAxisSource.AxisDescriptor { GetAxis = () => ref Fire, Name = "Fire", AxisIndex = 2 });
         }
 
         void OnValidate()

--- a/com.unity.cinemachine/Tests/Editor/InputAxisTests.cs
+++ b/com.unity.cinemachine/Tests/Editor/InputAxisTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Editor
             // Accelerate to speed
             for (int i = 0; i < 20; ++i)
             {
-                driver.ProcessInput(k_DeltaTime, axis, ref control);
+                driver.ProcessInput(k_DeltaTime, ref axis, ref control);
                 var delta = axis.Value - prevValue;
                 UnityEngine.Assertions.Assert.IsTrue(delta > prevDelta); // must be speeding up
                 prevValue = axis.Value;
@@ -56,7 +56,7 @@ namespace Tests.Editor
             control.InputValue = 0;
             for (int i = 0; i < 20; ++i)
             {
-                driver.ProcessInput(k_DeltaTime, axis, ref control);
+                driver.ProcessInput(k_DeltaTime, ref axis, ref control);
                 var delta = axis.Value - prevValue;
                 UnityEngine.Assertions.Assert.IsTrue(delta < prevDelta); // must be slowing down
                 prevValue = axis.Value;
@@ -111,7 +111,7 @@ namespace Tests.Editor
             var driver = new InputAxisDriver();
             foreach (var result in expectedResults)
             {
-                driver.ProcessInput(k_DeltaTime, axis, ref control);
+                driver.ProcessInput(k_DeltaTime, ref axis, ref control);
                 UnityEngine.Assertions.Assert.AreApproximatelyEqual(axis.Value, result);
             }
         }
@@ -167,8 +167,8 @@ namespace Tests.Editor
             var driver = new InputAxisDriver();
             foreach (var result in expectedResults)
             {
-                driver.ProcessInput(k_DeltaTime, axis, ref control);
-                driver.DoRecentering(k_DeltaTime, axis, recentering);
+                driver.ProcessInput(k_DeltaTime, ref axis, ref control);
+                driver.DoRecentering(k_DeltaTime, ref axis, recentering);
                 control.InputValue = 0; // cancel input, so recentering can start
                 CinemachineCore.CurrentUnscaledTimeTimeOverride += k_DeltaTime; // control time for deterministic tests
                 UnityEngine.Assertions.Assert.AreApproximatelyEqual(axis.Value, result);


### PR DESCRIPTION
### Purpose of this PR

We were getting serialization problems because InputAxis was a class and required [SerializedReference] to work with animator.  Changing it to a struct solves that.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

