### PR TITLE
CMCL-0000: fix foldout collapse state bug

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -71,8 +71,11 @@ namespace Cinemachine.Editor
             });
             foldout.RegisterValueChangedCallback((evt) => 
             {
-                m_EventsExpanded = evt.newValue;
-                evt.StopPropagation();
+                if (evt.target == foldout)
+                {
+                    m_EventsExpanded = evt.newValue;
+                    evt.StopPropagation();
+                }
             });
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraCutEvent)));
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));

--- a/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
@@ -79,9 +79,12 @@ namespace Cinemachine.Editor
             var foldout = new Foldout { text = property.displayName, tooltip = property.tooltip, value = property.isExpanded };
             foldout.RegisterValueChangedCallback((evt) => 
             {
-                property.isExpanded = evt.newValue;
-                property.serializedObject.ApplyModifiedProperties();
-                evt.StopPropagation();
+                if (evt.target == foldout)
+                {
+                    property.isExpanded = evt.newValue;
+                    property.serializedObject.ApplyModifiedProperties();
+                    evt.StopPropagation();
+                }
             });
             var valueProp = property.FindPropertyRelative(() => def.Value);
             var valueLabel = new Label(" ") { style = { minWidth = InspectorUtility.SingleLineHeight * 2}};

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -94,9 +94,12 @@ namespace Cinemachine.Editor
             var foldout = new Foldout { text = property.displayName, tooltip = property.tooltip, value = property.isExpanded };
             foldout.RegisterValueChangedCallback((evt) => 
             {
-                property.isExpanded = evt.newValue;
-                property.serializedObject.ApplyModifiedProperties();
-                evt.StopPropagation();
+                if (evt.target == foldout)
+                {
+                    property.isExpanded = evt.newValue;
+                    property.serializedObject.ApplyModifiedProperties();
+                    evt.StopPropagation();
+                }
             });
 
             var fovControl = new FovPropertyControl(property, true) { style = { flexGrow = 1 }};

--- a/com.unity.cinemachine/Editor/Utility/EmbeddedAssetHelpers.cs
+++ b/com.unity.cinemachine/Editor/Utility/EmbeddedAssetHelpers.cs
@@ -208,8 +208,11 @@ namespace Cinemachine.Editor
             var foldout = new Foldout() { text = property.displayName, tooltip = property.tooltip, value = s_CustomBlendsExpanded };
             foldout.RegisterValueChangedCallback((evt) => 
             {
-                s_CustomBlendsExpanded = evt.newValue;
-                evt.StopPropagation();
+                if (evt.target == foldout)
+                {
+                    s_CustomBlendsExpanded = evt.newValue;
+                    evt.StopPropagation();
+                }
             });
             m_EmbeddedInspectorParent = new VisualElement();
             m_AssignedUx = ux.AddChild(new InspectorUtility.FoldoutWithOverlay(

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -510,28 +510,35 @@ namespace Cinemachine.Editor
 
                 // Swap the open and closed foldouts when the foldout is opened or closed
                 closedContainer.SetVisible(!foldout.value);
+                foldout.SetVisible(foldout.value);
+
                 closedFoldout.RegisterValueChangedCallback((evt) =>
                 {
-                    if (evt.newValue)
+                    if (evt.target == closedFoldout)
                     {
-                        closedContainer.SetVisible(false);
-                        foldout.SetVisible(true);
-                        foldout.value = true;
-                        closedFoldout.SetValueWithoutNotify(false);
-                        foldout.Focus(); // GML why doesn't this work?
+                        if (evt.newValue && evt.target == closedFoldout)
+                        {
+                            closedContainer.SetVisible(false);
+                            foldout.SetVisible(true);
+                            foldout.value = true;
+                            closedFoldout.SetValueWithoutNotify(false);
+                            //foldout.Focus(); // GML why doesn't this work?
+                        }
                         evt.StopPropagation();
                     }
                 });
-                foldout.SetVisible(foldout.value);
                 foldout.RegisterValueChangedCallback((evt) =>
                 {
-                    if (!evt.newValue)
+                    if (evt.target == foldout)
                     {
-                        closedContainer.SetVisible(true);
-                        foldout.SetVisible(false);
-                        closedFoldout.SetValueWithoutNotify(false);
-                        foldout.value = false;
-                        closedFoldout.Focus(); // GML why doesn't this work?
+                        if (!evt.newValue)
+                        {
+                            closedContainer.SetVisible(true);
+                            foldout.SetVisible(false);
+                            closedFoldout.SetValueWithoutNotify(false);
+                            foldout.value = false;
+                            //closedFoldout.Focus(); // GML why doesn't this work?
+                        }
                         evt.StopPropagation();
                     }
                 });


### PR DESCRIPTION
### Purpose of this PR

Input axis foldout collapsed when you unchecked the "wrap" property.  I thought this was a UITK bug, but it was our bug.  The issue was that we we not properly filtering the ValueChanged<bool> events in the foldout handlers.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

