### PR TITLE
Improved performance of gizmo curve rendering in 2.9

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineSmoothPathEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSmoothPathEditor.cs
@@ -1,3 +1,5 @@
+#define MESH_EXPERIMENT
+
 using UnityEditor;
 using UnityEngine;
 using System;
@@ -247,7 +249,7 @@ namespace Cinemachine.Editor
             }
         }
 
-#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
+#if !MESH_EXPERIMENT && CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         static Vector4[] m_BezierWeights;
         static int m_BezierWeightsResolution = -1;
         static Vector3[] m_StepPoints;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSmoothPathEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSmoothPathEditor.cs
@@ -247,6 +247,7 @@ namespace Cinemachine.Editor
             }
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         static Vector4[] m_BezierWeights;
         static int m_BezierWeightsResolution = -1;
         static Vector3[] m_StepPoints;
@@ -380,5 +381,16 @@ namespace Cinemachine.Editor
 
             Gizmos.color = colorOld;
         }
+#else
+        // !#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
+        [DrawGizmo(GizmoType.Active | GizmoType.NotInSelectionHierarchy
+             | GizmoType.InSelectionHierarchy | GizmoType.Pickable, typeof(CinemachineSmoothPath))]
+        static void DrawGizmos(CinemachineSmoothPath path, GizmoType selectionType)
+        {
+            var isActive = Selection.activeGameObject == path.gameObject;
+            CinemachinePathEditor.DrawPathGizmo(path,
+                isActive ? path.m_Appearance.pathColor : path.m_Appearance.inactivePathColor, isActive);
+        }
+#endif  // #if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
     }
 }

--- a/com.unity.cinemachine/Editor/com.unity.cinemachine.Editor.asmdef
+++ b/com.unity.cinemachine/Editor/com.unity.cinemachine.Editor.asmdef
@@ -85,6 +85,11 @@
             "name": "com.unity.inputsystem",
             "expression": "1.0.0",
             "define": "CINEMACHINE_UNITY_INPUTSYSTEM"
+        },
+        {
+            "name": "Unity",
+            "expression": "2022.2.0b16",
+            "define": "CINEMACHINE_USE_BATCH_POINT_LINE_APIS"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
@@ -98,10 +98,10 @@ namespace Cinemachine
             return pos;
         }
 
-        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <summary>Get a curvespace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be normalized.</param>
-        /// <returns>World-space position of the point along at path at pos</returns>
-        public override Vector3 EvaluatePosition(float pos)
+        /// <returns>Curve-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluateCurvePosition(float pos)
         {
             Vector3 result = new Vector3();
             if (m_Waypoints.Length == 0)
@@ -122,7 +122,15 @@ namespace Cinemachine
                         wpB.position - wpB.tangent, wpB.position);
                 }
             }
-            return transform.TransformPoint(result);
+            return result;
+        }
+
+        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <param name="pos">Postion along the path.  Need not be normalized.</param>
+        /// <returns>World-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluatePosition(float pos)
+        {
+            return transform.TransformPoint(EvaluateCurvePosition(pos));
         }
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
@@ -98,10 +98,17 @@ namespace Cinemachine
             return pos;
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         /// <summary>Get a curvespace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be normalized.</param>
         /// <returns>Curve-space position of the point along at path at pos</returns>
         public override Vector3 EvaluateCurvePosition(float pos)
+#else
+        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <param name="pos">Postion along the path.  Need not be normalized.</param>
+        /// <returns>World-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluatePosition(float pos)
+#endif
         {
             Vector3 result = new Vector3();
             if (m_Waypoints.Length == 0)
@@ -122,9 +129,14 @@ namespace Cinemachine
                         wpB.position - wpB.tangent, wpB.position);
                 }
             }
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
             return result;
+#else
+            return transform.TransformPoint(result);
+#endif
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         /// <summary>Get a worldspace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be normalized.</param>
         /// <returns>World-space position of the point along at path at pos</returns>
@@ -132,6 +144,7 @@ namespace Cinemachine
         {
             return transform.TransformPoint(EvaluateCurvePosition(pos));
         }
+#endif
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>
         /// <param name="pos">Postion along the path.  Need not be normalized.</param>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -161,10 +161,17 @@ namespace Cinemachine
             return pos;
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         /// <summary>Get a curvespace position of a point along the path</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
         /// <returns>Curve-space position of the point along at path at pos</returns>
         public override Vector3 EvaluateCurvePosition(float pos)
+#else
+        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <param name="pos">Position along the path.  Need not be normalized.</param>
+        /// <returns>World-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluatePosition(float pos)
+#endif
         {
             Vector3 result = Vector3.zero;
             if (m_Waypoints.Length > 0)
@@ -179,9 +186,14 @@ namespace Cinemachine
                         m_Waypoints[indexA].position, m_ControlPoints1[indexA].position,
                         m_ControlPoints2[indexA].position, m_Waypoints[indexB].position);
             }
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
             return result;
+#else
+            return transform.TransformPoint(result);
+#endif
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         /// <summary>Get a worldspace position of a point along the path</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
         /// <returns>World-space position of the point along at path at pos</returns>
@@ -189,6 +201,7 @@ namespace Cinemachine
         {
             return transform.TransformPoint(EvaluateCurvePosition(pos));
         }
+#endif
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -97,11 +97,11 @@ namespace Cinemachine
             m_ControlPoints2 = null;
         }
 
-        Waypoint[] m_ControlPoints1;
-        Waypoint[] m_ControlPoints2;
+        internal Waypoint[] m_ControlPoints1;
+        internal Waypoint[] m_ControlPoints2;
         bool m_IsLoopedCache;
 
-        void UpdateControlPoints()
+        internal void UpdateControlPoints()
         {
             int numPoints = (m_Waypoints == null) ? 0 : m_Waypoints.Length;
             if (numPoints > 1 
@@ -161,10 +161,10 @@ namespace Cinemachine
             return pos;
         }
 
-        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <summary>Get a curvespace position of a point along the path</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
-        /// <returns>World-space position of the point along at path at pos</returns>
-        public override Vector3 EvaluatePosition(float pos)
+        /// <returns>Curve-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluateCurvePosition(float pos)
         {
             Vector3 result = Vector3.zero;
             if (m_Waypoints.Length > 0)
@@ -179,7 +179,15 @@ namespace Cinemachine
                         m_Waypoints[indexA].position, m_ControlPoints1[indexA].position,
                         m_ControlPoints2[indexA].position, m_Waypoints[indexB].position);
             }
-            return transform.TransformPoint(result);
+            return result;
+        }
+
+        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <param name="pos">Position along the path.  Need not be normalized.</param>
+        /// <returns>World-space position of the point along at path at pos</returns>
+        public override Vector3 EvaluatePosition(float pos)
+        {
+            return transform.TransformPoint(EvaluateCurvePosition(pos));
         }
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>
@@ -237,7 +245,7 @@ namespace Cinemachine
         }
         
         // same as Quaternion.AngleAxis(roll, Vector3.forward), just simplified
-        Quaternion RollAroundForward(float angle)
+        internal static Quaternion RollAroundForward(float angle)
         {
             float halfAngle = angle * 0.5F * Mathf.Deg2Rad;
             return new Quaternion(

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
@@ -58,10 +58,12 @@ namespace Cinemachine
             return Mathf.Clamp(pos, 0, MaxPos);
         }
 
+#if CINEMACHINE_USE_BATCH_POINT_LINE_APIS
         /// <summary>Get a curvespace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be standardized.</param>
         /// <returns>Curve-space position of the point along at path at pos</returns>
         public abstract Vector3 EvaluateCurvePosition(float pos);
+#endif
 
         /// <summary>Get a worldspace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be standardized.</param>

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
@@ -58,6 +58,11 @@ namespace Cinemachine
             return Mathf.Clamp(pos, 0, MaxPos);
         }
 
+        /// <summary>Get a curvespace position of a point along the path</summary>
+        /// <param name="pos">Postion along the path.  Need not be standardized.</param>
+        /// <returns>Curve-space position of the point along at path at pos</returns>
+        public abstract Vector3 EvaluateCurvePosition(float pos);
+
         /// <summary>Get a worldspace position of a point along the path</summary>
         /// <param name="pos">Postion along the path.  Need not be standardized.</param>
         /// <returns>World-space position of the point along at path at pos</returns>

--- a/com.unity.cinemachine/Runtime/Core/SplineHelpers.cs
+++ b/com.unity.cinemachine/Runtime/Core/SplineHelpers.cs
@@ -23,6 +23,23 @@ namespace Cinemachine.Utility
                 + 3f * d * t * t * p2 + t * t * t * p3;
         }
 
+        /// <summary>Compute the weights for the tangent of a 4-point 3-dimensional bezier spline</summary>
+        /// <param name="p0">First point</param>
+        /// <param name="p1">First tangent</param>
+        /// <param name="p2">Second point</param>
+        /// <param name="p3">Second tangent</param>
+        /// <returns>Weights for the bezier tangent</returns>
+        public static Vector3[] BezierTangentWeights3(
+            Vector3 p0, Vector3 p1, Vector3 p2, Vector3 p3)
+        {
+            return new Vector3[]
+            {
+                -3f * p0 + 9f * p1 - 9f * p2 + 3f * p3, 
+                6f * p0 - 12f * p1 + 6f * p2, 
+                -3f * p0 + 3f * p1
+            };
+        }
+
         /// <summary>Compute the tangent of a 4-point 3-dimensional bezier spline</summary>
         /// <param name="t">How far along the spline (0...1)</param>
         /// <param name="p0">First point</param>

--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -84,7 +84,12 @@
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "14.0.0",
             "define": "CINEMACHINE_HDRP_14"
+        },
+        {
+            "name": "Unity",
+            "expression": "2022.2.0b16",
+            "define": "CINEMACHINE_USE_BATCH_POINT_LINE_APIS"
         }
-    ],
+   ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
### Purpose of this PR

While profiling slow editor scene view performance in the _Volvo Test Track_ project it was found that a large proportion of the time was being spent rendering the Cinemachine (2.9) curves as part of gizmo rendering.  To improve the performance of such operations some new batch APIs have been added to Unity allowing multiple points to be transformed or multiple lines drawn by a single API call:

**NOTE: This PR must not land before the Unity PR "Added batch versions of Transform.TransformXXX and Gizmo.Drawline APIs [2022.2]" (https://github.cds.internal.unity3d.com/unity/unity/pull/18472) does - it is open purely for review at this time.**

Batch versions of Transform.TransformPoint

- Transform.TransformPoints(Span<Vector3> positions)
- Transform.TransformPoints(ReadOnlySpan<Vector3> positions, Span<Vector3> transformedPositions)- 

Batch version of Transform.InverseTransformPoint

- Transform.InverseTransformPoints(Span<Vector3> positions)
- Transform.InverseTransformPoints(ReadOnlySpan<Vector3> positions, Span<Vector3> transformedPositions)- 

Batch version of Transform.TransformVector

- Transform.TransformVectors(Span<Vector3> vectors)
- Transform.TransformVectors(ReadOnlySpan<Vector3> vectors, Span<Vector3> transformedVectors)- 

Batch version of Transform.InverseTransformVector

- Transform.InverseTransformVectors(Span<Vector3> vectors)
- Transform.InverseTransformVectors(ReadOnlySpan<Vector3> vectors, Span<Vector3> transformedVectors)- 

Batch version of Transform.TransformDirection

- Transform.TransformDirections(Span<Vector3> directions)
- Transform.TransformDirections(ReadOnlySpan<Vector3> directions, Span<Vector3> Directions)- 

Batch version of Transform.InverseTransformDirection

- Transform.InverseTransformDirections(Span<Vector3> directions)
- Transform.InverseTransformDirections(ReadOnlySpan<Vector3> directions, Span<Vector3> Directions)- 

Trunk PR (landed): https://github.cds.internal.unity3d.com/unity/unity/pull/15733
2022.2 PR (under review): https://github.cds.internal.unity3d.com/unity/unity/pull/18472

This PR adds support for these APIs to Cinemachine 2.9 more than doubling the performance of it's gizmo curve rendering.  

A version define CINEMACHINE_USE_BATCH_POINT_LINE_APIS has been added to the editor and runtime asmdefs allowing the new code to only apply to the current 2022.2.0b16 version and later, the original gizmo curve rendering code remains in place for use when the package is used with earlier Unity versions.

### Testing status

Functional tests for the API additions were part of the original PRs.  Manual testing of the Cinemachine changes in this PR was done using one of the sample scenes included with the CM package plus the _Volvo Test Track_ project to make sure that the curves looked the same before and after then change.

![image](https://user-images.githubusercontent.com/35338585/203091946-0240b972-f8f8-4650-846f-49f561c60779.png)
![image](https://user-images.githubusercontent.com/35338585/203092152-bf8f5a7c-af66-4407-822b-08f22e9856ca.png)
![image](https://user-images.githubusercontent.com/35338585/203092651-037402c1-4fcb-4a0f-9b41-cc868a8ed0fa.png)
![image](https://user-images.githubusercontent.com/35338585/203092669-65ad734a-2622-477f-b795-6702a053bc61.png)
![image](https://user-images.githubusercontent.com/35338585/203092678-ddf65b53-0ad3-40c6-b6ee-382b25093969.png)
![image](https://user-images.githubusercontent.com/35338585/203092692-2b0dc496-a8d1-47ff-bebe-d11a584b29d3.png)

A non-automated performance test was used to verify the improvement in scene rendering performance, taking the median of ten redraws in the _Volvo Test Track_ project the scene view render time reduced from 181ms to 89ms.  

Looking more in depth using the Superluminal profiler it was shown that `CinemachineSmoothPathEditor.DrawGizmos()` in this scene reduced from 135ms to 28ms (so over 4.8x the speed)

Backwards compatibility testing of the `CINEMACHINE_USE_BATCH_POINT_LINE_APIS `version define was done by manually changing the asmdef so it only applied to a future version then re-testing the Cinemachine sample scene and Volvo Test Track project to ensure curve rendering was unaffected (apart from performance which was verified to be slower once again)

- [*] Added an automated test
- [*] Passed all automated tests
- [*] Manually tested 

### Documentation status

Is purely a performance improvement, there is no functional change so it wasn't thought that documentation changes were necessary

### Technical risk

Functional tests for the API additions were part of the original PRs.  Manual functional testing of curve rendering was also performed with the Volvo Test Track project as described above to minimise technical risk

There is limited halo risk as only the rendering of curves is affected, not their function or any user interface code

### Comments to reviewers

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
