### PR TITLE
Prepare to publish 2.9.4 candidate

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.9.3] - 2022-11-18
+## [2.9.4] - 2022-11-18
 - Bugfix: VirtualCameras did not set the focal length property of physical cameras.
 - Bugfix: could not set main camera to physical mode while a vcam with ModeOverride = None was active
 

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.3] - 2022-11-18
 - Bugfix: VirtualCameras did not set the focal length property of physical cameras.
 - Bugfix: could not set main camera to physical mode while a vcam with ModeOverride = None was active
 

--- a/com.unity.cinemachine/ValidationExceptions.json
+++ b/com.unity.cinemachine/ValidationExceptions.json
@@ -3,32 +3,32 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"Cinemachine.Runtime.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"Cinemachine.Editor.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.2"
+            "PackageVersion": "2.9.3"
         }
     ],
     "WarningExceptions": []

--- a/com.unity.cinemachine/ValidationExceptions.json
+++ b/com.unity.cinemachine/ValidationExceptions.json
@@ -3,32 +3,32 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Additions require a new minor or major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"com.unity.cinemachine.EditorTests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"Cinemachine.Runtime.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         },
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "New assembly \"Cinemachine.Editor.Tests\" may only be added in a new minor or major version.",
-            "PackageVersion": "2.9.3"
+            "PackageVersion": "2.9.4"
         }
     ],
     "WarningExceptions": []

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.9.2",
+    "version": "2.9.3",
     "unity": "2019.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "unity": "2019.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR

Bump the version to 2.9.4. I accidentally burned the 2.9.3 version by publishing from the wrong branch and then doing a squash merge. I prefer to burn a patch version than to have the discrepancy. 

### Testing status

Ran a successful publishing dry-run. 
