### PR TITLE
CMCL-1206: timeline inspector in uitk

### DIFF
--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -30,7 +30,7 @@ namespace Cinemachine.Editor
 
         public override VisualElement CreateInspectorGUI()
         {
-            var m_ParentElement = new VisualElement();
+            m_ParentElement = new VisualElement();
 
             // Auto-create shots
             var toggle = m_ParentElement.AddChild(new Toggle(CinemachineTimelinePrefs.s_AutoCreateLabel.text) 
@@ -124,7 +124,7 @@ namespace Cinemachine.Editor
         }
 
 #else
-        // IMGUI version
+        // IMGUI version - will be deleted asap
 
         UnityEditor.Editor[] m_Editors = null;
 

--- a/com.unity.cinemachine/Runtime/Timeline/CinemachineShot.cs
+++ b/com.unity.cinemachine/Runtime/Timeline/CinemachineShot.cs
@@ -11,10 +11,12 @@ namespace Cinemachine
     /// </summary>
     public sealed class CinemachineShot : PlayableAsset, IPropertyPreview
     {
-        /// <summary>The name to display on the track</summary>
+        /// <summary>The name to display on the track.  If empty, the CmCamera's name will be used.</summary>
+        [Tooltip("The name to display on the track.  If empty, the CmCamera's name will be used.")]
         public string DisplayName;
 
-        /// <summary>The virtual camera to activate</summary>
+        /// <summary>The Cinemachine camera to use for this shot</summary>
+        [Tooltip("The Cinemachine camera to use for this shot")]
         public ExposedReference<CinemachineVirtualCameraBase> VirtualCamera;
 
         /// <summary>PlayableAsset implementation</summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1206: Timeline shot inspector is broken because many of the sub-inspectors don't have IMGUI implementations and are displaying the default IMGUI inspectors instead of the correct ones.

Solution is in 2 parts:

1. Implement CM's Shot inspector in UITK (this PR)
2. Timeline must implement its clip inspector in UITK, so that the UITK version of CM's inspector gets invoked

We are blocked on (2), waiting for timeline team to implement this.  Slack discussion: https://unity.slack.com/archives/C06TQFQ7P/p1669224167686899

### Testing status

Not really tested, because the code is never called.  Commented out for now.

