### PR TITLE
CMCL-0000: don't show obsolete classes in UX helpers

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -4,6 +4,7 @@ using Cinemachine.Editor;
 using System.Collections.Generic;
 using Cinemachine.Utility;
 using System;
+using System.Reflection;
 
 namespace Cinemachine
 {
@@ -120,7 +121,8 @@ namespace Cinemachine
                 // Get all Modifier types
                 var allTypes
                     = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                        (Type t) => typeof(CinemachineFreeLookModifier.Modifier).IsAssignableFrom(t) && !t.IsAbstract);
+                        (Type t) => typeof(CinemachineFreeLookModifier.Modifier).IsAssignableFrom(t) 
+                        && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
                 s_AllModifiers.Clear();
                 s_AllModifiers.Add(null);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cinemachine.Utility;
+using System.Reflection;
 
 #if CINEMACHINE_UNITY_INPUTSYSTEM
 using UnityEngine.InputSystem;
@@ -66,7 +67,8 @@ namespace Cinemachine.Editor
                 names.Add("(select)");
                 var allExtensions
                     = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t) && !t.IsAbstract);
+                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t)
+                            && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 foreach (Type t in allExtensions)
                 {
                     exts.Add(t);

--- a/com.unity.cinemachine/Editor/Obsolete/VcamStageEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/VcamStageEditor.cs
@@ -38,7 +38,7 @@ namespace Cinemachine.Editor
                 // Get all ICinemachineComponents
                 var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies((Type t) =>
                     typeof(CinemachineComponentBase).IsAssignableFrom(t) && !t.IsAbstract &&
-                    t.GetCustomAttribute<CameraPipelineAttribute>() != null);
+                    t.GetCustomAttribute<CameraPipelineAttribute>() != null); // we allow obsolete attributes here
 
                 foreach (var t in allTypes)
                 {

--- a/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -4,6 +4,7 @@ using System;
 using Cinemachine.Utility;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Cinemachine.Editor
 {
@@ -188,7 +189,8 @@ namespace Cinemachine.Editor
             Type type = EmbeddedAssetType(property);
             if (mAssetTypes == null)
                 mAssetTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                    (Type t) => type.IsAssignableFrom(t) && !t.IsAbstract).ToArray();
+                    (Type t) => type.IsAssignableFrom(t) && !t.IsAbstract 
+                        && t.GetCustomAttribute<ObsoleteAttribute>() == null).ToArray();
 
             float iconSize = r.height + 4;
             r.width -= iconSize;

--- a/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
@@ -4,6 +4,7 @@ using Cinemachine.Utility;
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
+using System.Reflection;
 
 namespace Cinemachine.Editor
 {
@@ -106,7 +107,8 @@ namespace Cinemachine.Editor
                 // Get all eligible types
                 var allTypes
                     = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                        (Type t) => typeof(SplineAutoDolly.ISplineAutoDolly).IsAssignableFrom(t) && !t.IsAbstract);
+                        (Type t) => typeof(SplineAutoDolly.ISplineAutoDolly).IsAssignableFrom(t) 
+                            && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
                 s_AllItems.Clear();
                 s_AllItems.Add(null);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -331,7 +331,8 @@ namespace Cinemachine.Editor
                 s_ExtentionNames.Add("(select)");
                 var allExtensions
                     = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t) && !t.IsAbstract);
+                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t) 
+                                && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 foreach (Type t in allExtensions)
                 {
                     s_ExtentionTypes.Add(t);

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -349,7 +349,8 @@ namespace Cinemachine.Editor
             {
                 var allSources = ReflectionHelpers.GetTypesInAllDependentAssemblies(
                     (Type t) => inputType.IsAssignableFrom(t) && !t.IsAbstract 
-                        && typeof(MonoBehaviour).IsAssignableFrom(t));
+                        && typeof(MonoBehaviour).IsAssignableFrom(t)
+                        && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 var s = string.Empty;
                 foreach (var t in allSources)
                 {

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
@@ -15,7 +15,7 @@ namespace Cinemachine
     [SaveDuringPlay]
     [ExecuteAlways]
     [DisallowMultipleComponent]
-    public class CinemachineCollider : CinemachineExtension
+    public class CinemachineCollider : CinemachineExtension, IShotQualityEvaluator
     {
         /// <summary>Objects on these layers will be detected.</summary>
         [Header("Obstacle Detection")]


### PR DESCRIPTION
### Purpose of this PR

Make sure obsolete classes don't appear in UX unless explicitly wanted
