### PR TITLE
CMCL-0000: invalidate manager parents when upgrading vcams

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -67,7 +67,7 @@ namespace Cinemachine.Editor
                 + "Upgrade scene?",
                 "Upgrade", "Cancel"))
             {
-                var manager = new CinemachineUpgradeManager();
+                var manager = new CinemachineUpgradeManager(false);
                 var scene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
                 var rootObjects = scene.GetRootGameObjects();
                 var upgradable = manager.GetUpgradables(
@@ -102,7 +102,7 @@ namespace Cinemachine.Editor
                 + "Upgrade project?",
                 "I made a backup, go ahead", "Cancel"))
             {
-                var manager = new CinemachineUpgradeManager();
+                var manager = new CinemachineUpgradeManager(true);
 
                 manager.PrepareUpgrades(out var conversionLinksPerScene, out var timelineRenames);
                 manager.UpgradePrefabAssets(true);
@@ -584,7 +584,7 @@ namespace Cinemachine.Editor
 #endif
         }
 
-        CinemachineUpgradeManager(bool initPrefabManager = true)
+        CinemachineUpgradeManager(bool initPrefabManager)
         {
             m_ObjectUpgrader = new UpgradeObjectToCm3();
             m_SceneManager = new SceneManager();

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
@@ -44,9 +44,19 @@ namespace Cinemachine.Editor
                 // It's some kind of vcam.  Check for FreeLook first because it has
                 // hidden child VirtualCameras and we need to remove them
                 if (go.TryGetComponent<CinemachineFreeLook>(out var freelook))
+                {
                     notUpgradable = UpgradeFreelook(freelook);
+                    var manager = freelook.ParentCamera as CinemachineCameraManagerBase;
+                    if (manager != null)
+                        manager.InvalidateCameraCache();
+                }
                 else if (go.TryGetComponent<CinemachineVirtualCamera>(out var vcam))
+                {
                     notUpgradable = UpgradeVcam(vcam);
+                    var manager = vcam.ParentCamera as CinemachineCameraManagerBase;
+                    if (manager != null)
+                        manager.InvalidateCameraCache();
+                }
 
                 // Upgrade the pipeline components (there will be more of these...)
                 if (ReplaceComponent<CinemachineComposer, CinemachineRotationComposer>(go))

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -402,7 +402,7 @@ namespace Cinemachine
 #else
                 if (m_CachedName == null)
 #endif
-                    m_CachedName = name;
+                    m_CachedName = (this == null) ? "(deleted)" : name;
                 return m_CachedName;
             }
         }


### PR DESCRIPTION
When upgrading a scene with managers (e.g. ClearShot sample) the scene breaks after the upgrade because managers are still holding references to the deleted children.  Fix this.
Also: don't init prefab manager when upgrading scene.