### PR TITLE
CMCL-0000: fix sample player rotation

### DIFF
--- a/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
@@ -365,6 +365,7 @@ MonoBehaviour:
     LensShift: {x: 0, y: 0}
     GateFit: 2
     m_SensorSize: {x: 1, y: 1}
+    FocusDistance: 10
   Transitions:
     BlendHint: 0
     Events:
@@ -795,6 +796,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5995860984952935429, guid: 7f3bfd07f0528a94d8f6e1d503f7bb61, type: 3}
       propertyPath: Strafe
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5995860984952935429, guid: 7f3bfd07f0528a94d8f6e1d503f7bb61, type: 3}
+      propertyPath: LockCursor
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6106646561195116106, guid: 7f3bfd07f0528a94d8f6e1d503f7bb61, type: 3}

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAimController.cs
@@ -60,6 +60,8 @@ namespace Cinemachine.Examples
             var delta = rot.y - parentRot.y;
             if (delta > 180)
                 delta -= 360;
+            if (delta < -180)
+                delta += 360;
             delta = Damper.Damp(delta, damping, Time.deltaTime);
             parentRot.y += delta;
             m_Controller.transform.rotation = Quaternion.Euler(parentRot);

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -20,6 +20,7 @@ namespace Cinemachine.Examples
         public UpModes UpMode = UpModes.World;
 
         public bool Strafe = false;
+        public bool LockCursor = false;
 
         public Action PreUpdate;
         public Action PostUpdate;
@@ -83,6 +84,8 @@ namespace Cinemachine.Examples
             m_CurrentVelocityY = 0;
             m_IsSprinting = false;
             m_IsJumping = false;
+            if (LockCursor)
+                Cursor.lockState = CursorLockMode.Locked;
         }
 
         void Update()

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -147,8 +147,7 @@ namespace Cinemachine.Examples
                 _ => Vector3.forward,
             };
             fwd = fwd.ProjectOntoPlane(up);
-            fwd = fwd.normalized;
-            if (fwd.sqrMagnitude < 0.01f)
+            if (fwd.sqrMagnitude < 0.001f)
             {
                 inputFrame = Quaternion.identity;
                 return false;


### PR DESCRIPTION
Fix weird rotation in third person sample when moving and rotating past +z axis.
Also: add LockCursor option to character controller, enable it in ThirdPersonShooter.