### PR TITLE
CMCL-0000: Change unreleased changelog with next version so that promotion tests pass

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-11-01
+## [3.0.0-pre.4] - 2022-11-01
 - Bugfix: Physical lens settings were not being properly applied.
 - 3rdPersonFollow and 3rdPersonAim are deprecated and replaced by ThirdPersonFollow and ThirdPersonAim respectively.
 - Bugfix: Lens blending was wrong.


### PR DESCRIPTION
### Purpose of this PR

We run the isolation tests at night, to make sure that the package could be promoted at any time. For example, it checks that the samples can be loaded, and that we follow semver rules. Right now, those tests fail because we cannot release a package with a changelog entry that says "Unreleased". Having that changelog entry makes sense because it's accurate, but there is more value in  having the tests fail if for example, we introduced an API change without bumping the minor version.

### Testing status

Isolation tests passed