### PR TITLE
CMCL-1283: Upgrade CinemachineSmoothPath to Splines with 1 to 1 matching

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Confiner2D does less gc alloc.
 - TargetGroup now ignores members whose gameObjects are inactive.
 - CinemachineConfiner is deprecated.  New behaviour CinemachineConfiner3D to handle 3D confining.  Use CinemachineConfiner2D for 2D confining.
+- CinemachineSmoothPath is upgraded to Splines correctly now. 
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
@@ -703,17 +703,19 @@ namespace Cinemachine.Editor
                 {
                     var waypoints = smoothPath.m_Waypoints;
                     spline.Spline = new Spline(waypoints.Length, smoothPath.Looped);
-                    
                     for (var i = 0; i < waypoints.Length; i++)
                     {
+                        var tangent = smoothPath.EvaluateLocalTangent(i); 
+                        tangent /= 3f; // divide by magic number to match spline tangent scale correctly
                         spline.Spline.Add(new BezierKnot
                         {
                             Position = waypoints[i].position,
                             Rotation = Quaternion.identity,
+                            TangentIn = -tangent,
+                            TangentOut = tangent,
                         });
                         splineRoll.Roll.Add(new DataPoint<float>(i, waypoints[i].roll));
                     }
-                    spline.Spline.SetTangentMode(TangentMode.AutoSmooth);
                     break;
                 }
                 default:


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1283](https://jira.unity3d.com/browse/CMCL-1283): SmoothPath should be upgraded correctly. 1 to 1 matching.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version
