### PR TITLE
CMCL-0000: Add readme with description and branching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Cinemachine
+Smart camera tools for passionate creators
+
+## About Cinemachine
+
+Cinemachine is a suite of modules for operating the Unity camera. Cinemachine solves the complex mathematics and logic of tracking targets, composing, blending, and cutting between shots. It is designed to significantly reduce the number of time-consuming manual manipulations and script revisions that take place during development.
+
+## Branching Strategy 
+
+Cinemachine default branch is main and that’s where the latest version of Cinemachine lives. 
+For all other minor versions of Cinemachine, a new branch is created under release (e.g. release/2.9, release/2.8). These branches are maintenance branches. 
+
+During development, PRs are merged directly on main and maintenance branches. Those branches should always be shippable: the code compiles, features are complete and the CI pipeline is green.
+
+Once a release is done, a branch with the version name is created under releases (e.g. releases/2.9.4, releases/3.0.0-pre.1). No changes are made to those branches. They exist for reference only. 


### PR DESCRIPTION
### Purpose of this PR

Starting a ReadMe file to contain the branching strategy. With time, we can add more things to it like contribution rules. Note that having a readme file in a repo is technically required to ship a package at Unity, but Cinemachine had a grandfathered exception.
