### PR TITLE
CMCL-1294: Improve sample dependency importer pop-up window

### DIFF
--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -99,14 +99,14 @@ namespace Cinemachine.Editor
                             {
                                 switch (PromptUserConfirmation(dependenciesToImport))
                                 {
-                                    case UserChoice.ImportPackageDependencies:
+                                    case UserChoice.ImportSamplesWithDependencies:
                                         // only import dependencies that are missing
                                         m_PackageDependencies = dependenciesToImport;
                                         // Import package dependencies using the editor update loop, because
                                         // adding packages need to be done in sequence one after the other
                                         EditorApplication.update += ImportPackageDependencies;
                                         break;
-                                    case UserChoice.AbortImport:
+                                    case UserChoice.CancelImport:
                                         // if samples were already imported, don't delete them
                                         if (!localAssetsReimported)
                                             DeleteSampleImported(sample.importPath, 
@@ -114,7 +114,7 @@ namespace Cinemachine.Editor
                                                 localAssetsImported, sampleEntry.AssetDependencies);
                                         break;
                                     default:
-                                    case UserChoice.ImportSampleButNotPackageDependencies:
+                                    case UserChoice.ImportSamplesWithoutDependencies:
                                         break;
                                 }
                             }
@@ -205,9 +205,9 @@ namespace Cinemachine.Editor
 
         enum UserChoice
         {
-            ImportPackageDependencies = 0,
-            ImportSampleButNotPackageDependencies = 1,
-            AbortImport = 2
+            ImportSamplesWithDependencies = 0,
+            CancelImport = 1,
+            ImportSamplesWithoutDependencies = 2,
         }
         static UserChoice PromptUserConfirmation(List<string> dependencies)
         {
@@ -216,8 +216,8 @@ namespace Cinemachine.Editor
                 "These samples contain package dependencies that your project does not have: \n" +
                 dependencies.Aggregate("", (current, dependency) => current + (dependency + "\n")),
                 "Import samples and their dependencies", 
-                "Import samples without their dependencies",
-                "Cancel importing the samples");
+                "Cancel importing the samples",
+                "Import samples without their dependencies");
         }
 
         /// <summary>Copies a directory from the source to target path. Overwrites existing directories.</summary>

--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -215,9 +215,9 @@ namespace Cinemachine.Editor
                 "Import Sample Package Dependencies",
                 "These samples contain package dependencies that your project does not have: \n" +
                 dependencies.Aggregate("", (current, dependency) => current + (dependency + "\n")),
-                "Import samples and its dependencies", 
-                "Import samples but not its dependencies",
-                "Abort importing samples");
+                "Import samples and their dependencies", 
+                "Import samples without their dependencies",
+                "Cancel importing the samples");
         }
 
         /// <summary>Copies a directory from the source to target path. Overwrites existing directories.</summary>

--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -106,9 +106,8 @@ namespace Cinemachine.Editor
                                         EditorApplication.update += ImportPackageDependencies;
                                         break;
                                     case UserChoice.AbortImport:
-                                        // Hack
-                                        // Package import cannot be cancelled and it triggers a domain reload, so we
-                                        // need something persistent to delete samples after they are imported -> file
+                                        AssetDatabase.Refresh();
+                                        
                                         var fullPath = sample.importPath;
                                         var relativePath = fullPath.Substring(fullPath.IndexOf(k_SampleName));
                                         var version = relativePath.Substring(k_SampleName.Length);
@@ -124,25 +123,13 @@ namespace Cinemachine.Editor
                                                 deleteInstructions += k_SampleName + version + folder + ",";
                                                         
                                         deleteInstructions += relativePath;
-                                        File.WriteAllText("Assets/" + k_SampleName + k_DeleteFile, deleteInstructions);
+
+                                        var instructions = deleteInstructions.Split(",");
+                                        foreach (var instruction in instructions) 
+                                            AssetDatabase.DeleteAsset("Assets/" + instruction); // delete samples that were aborted
+                                        
                                         AssetDatabase.Refresh();
-                                        DeleteSamplesIfUserAborted();
                                         break;
-                                    
-                                        static void DeleteSamplesIfUserAborted()
-                                        {
-                                            var path = "Assets/" + k_SampleName + k_DeleteFile;
-                                            if (File.Exists(path)) // user aborted importing samples
-                                            {
-                                                var contents = File.ReadAllText(path);
-                                                var instructions = contents.Split(",");
-                                                AssetDatabase.DeleteAsset(path); // delete instruction file
-                                                foreach (var instruction in instructions) 
-                                                    AssetDatabase.DeleteAsset("Assets/" + instruction); // delete samples that were aborted
-                    
-                                                AssetDatabase.Refresh();
-                                            }
-                                        }
                                     default:
                                     case UserChoice.ImportSampleButNotPackageDependencies:
                                         break;

--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -126,7 +126,23 @@ namespace Cinemachine.Editor
                                         deleteInstructions += relativePath;
                                         File.WriteAllText("Assets/" + k_SampleName + k_DeleteFile, deleteInstructions);
                                         AssetDatabase.Refresh();
+                                        DeleteSamplesIfUserAborted();
                                         break;
+                                    
+                                        static void DeleteSamplesIfUserAborted()
+                                        {
+                                            var path = "Assets/" + k_SampleName + k_DeleteFile;
+                                            if (File.Exists(path)) // user aborted importing samples
+                                            {
+                                                var contents = File.ReadAllText(path);
+                                                var instructions = contents.Split(",");
+                                                AssetDatabase.DeleteAsset(path); // delete instruction file
+                                                foreach (var instruction in instructions) 
+                                                    AssetDatabase.DeleteAsset("Assets/" + instruction); // delete samples that were aborted
+                    
+                                                AssetDatabase.Refresh();
+                                            }
+                                        }
                                     default:
                                     case UserChoice.ImportSampleButNotPackageDependencies:
                                         break;
@@ -278,23 +294,7 @@ namespace Cinemachine.Editor
 
             public PackageChecker()
             {
-                DeleteSamplesIfUserAborted();
                 RefreshPackageCache();
-            }
-
-            void DeleteSamplesIfUserAborted()
-            {
-                var path = "Assets/" + k_SampleName + k_DeleteFile;
-                if (File.Exists(path)) // user aborted importing samples
-                {
-                    var contents = File.ReadAllText(path);
-                    var instructions = contents.Split(",");
-                    AssetDatabase.DeleteAsset(path); // delete instruction file
-                    foreach (var instruction in instructions) 
-                        AssetDatabase.DeleteAsset("Assets/" + instruction); // delete samples that were aborted
-                    
-                    AssetDatabase.Refresh();
-                }
             }
 
             public void RefreshPackageCache()

--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -299,7 +299,7 @@ namespace Cinemachine.Editor
                 if (m_Request != null && !m_Request.IsCompleted)
                     return; // need to wait for previous request to finish
                 
-                m_Request = Client.List(offlineMode: true);
+                m_Request = Client.List(true);
                 EditorApplication.update += WaitForRequestToComplete;
             }
  

--- a/com.unity.cinemachine/Samples~/samples.json
+++ b/com.unity.cinemachine/Samples~/samples.json
@@ -19,7 +19,9 @@
       "AssetDependencies": [
         "Shared Assets"
       ],
-      "PackageDependencies": []
+      "PackageDependencies": [
+        "com.unity.visualscripting"
+      ]
     },
     {
       "Path": "Old Samples from CM2",

--- a/com.unity.cinemachine/Samples~/samples.json
+++ b/com.unity.cinemachine/Samples~/samples.json
@@ -19,9 +19,7 @@
       "AssetDependencies": [
         "Shared Assets"
       ],
-      "PackageDependencies": [
-        "com.unity.visualscripting"
-      ]
+      "PackageDependencies": []
     },
     {
       "Path": "Old Samples from CM2",


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1294](https://jira.unity3d.com/browse/CMCL-1294)

Import dependency pop-up is only showed when a dependency is missing.
User has 3 options:
1. Import samples and its dependencies
Samples and **missing** dependencies are imported.
2. Import samples but not its dependencies
Samples are imported without dependencies.

---------------------------

**Removed option to abort samples**
Little hack: Samples cannot be stopped from importing, but we can delete it right away. Samples are not deleted if they were already in the user's project (e.g. they import without dependencies and click on reimport again and select Abort). Shared files are also not deleted if they were already there (e.g. user imported another sample that shared some files with the current import).

---------------------------

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation