### PR TITLE
CMCL-0000: Split tests in a separate package

### DIFF
--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -1,16 +1,17 @@
 {% metadata_file .yamato/metadata.metafile %}
 ---
-pack:
-  name: Pack project
+{% for test_project in all_testprojects %}
+pack_{{test_project.name}}:
+  name: Pack project {{test_project.name}}
   agent:
     type: Unity::VM
     image: package-ci/ubuntu:stable
     flavor: b1.large
   commands:
-    - rm com.unity.cinemachine/Tests/.tests.json
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project pack --project-path Projects/Standalone
+    - upm-ci project pack --project-path {{test_project.path}}
   artifacts:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
+{% endfor %}

--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -8,6 +8,7 @@ pack_{{test_project.name}}:
     image: package-ci/ubuntu:stable
     flavor: b1.large
   commands:
+    - rm com.unity.cinemachine/Tests/.tests.json
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci project pack --project-path {{test_project.path}}
   artifacts:

--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -7,6 +7,7 @@ pack:
     image: package-ci/ubuntu:stable
     flavor: b1.large
   commands:
+    - rm com.unity.cinemachine/Tests/.tests.json
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci project pack --project-path Projects/Standalone
   artifacts:

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -17,7 +17,7 @@ test_ubuntu_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack{{test_project.name}}
+    - .yamato/project-pack.yml#pack_{{test_project.name}}
 
 test_windows_{{editor}}_{{test_project.name}}:
   name : Test project windows {{editor}} {{test_project.name}}
@@ -33,7 +33,7 @@ test_windows_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack{{test_project.name}}
+    - .yamato/project-pack.yml#pack_{{test_project.name}}
 
 test_macos_{{editor}}_{{test_project.name}}:
   name : Test project macos {{editor}} {{test_project.name}}
@@ -49,6 +49,6 @@ test_macos_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack{{test_project.name}}
+    - .yamato/project-pack.yml#pack_{{test_project.name}}
   {% endfor %}
 {% endfor %}

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -17,7 +17,7 @@ test_ubuntu_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack
+    - .yamato/project-pack.yml#pack{{test_project.name}}
 
 test_windows_{{editor}}_{{test_project.name}}:
   name : Test project windows {{editor}} {{test_project.name}}
@@ -33,7 +33,7 @@ test_windows_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack
+    - .yamato/project-pack.yml#pack{{test_project.name}}
 
 test_macos_{{editor}}_{{test_project.name}}:
   name : Test project macos {{editor}} {{test_project.name}}
@@ -49,6 +49,6 @@ test_macos_{{editor}}_{{test_project.name}}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/project-pack.yml#pack
+    - .yamato/project-pack.yml#pack{{test_project.name}}
   {% endfor %}
 {% endfor %}

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -9,6 +9,7 @@ test_ubuntu_{{editor}}_{{test_project.name}}:
     image: package-ci/ubuntu:stable
     flavor: b1.large
   commands:
+    - rm com.unity.cinemachine/Tests/.tests.json
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci project test -u {{editor}} --project-path {{test_project.path}} --type project-tests
   artifacts:

--- a/Projects/HDRPInputSystem/Packages/manifest.json
+++ b/Projects/HDRPInputSystem/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.cinemachine": "file:../../../com.unity.cinemachine",
+    "com.unity.cinemachine.hdrptests": "file:../../../com.unity.cinemachine.hdrptests",
     "com.unity.ide.rider": "3.0.16",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
@@ -46,6 +47,7 @@
     "com.unity.modules.xr": "1.0.0"
   },
   "testables": [
-    "com.unity.cinemachine"
+    "com.unity.cinemachine",
+    "com.unity.cinemachine.hdrptests"
   ]
 }

--- a/com.unity.cinemachine.hdrptests/Tests.meta
+++ b/com.unity.cinemachine.hdrptests/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a68b96707f0384e71a6cd31b44117777
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Editor.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac0d8fe7d2cbb47f08f34f42b5b5431c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs
@@ -9,7 +9,6 @@ namespace Tests.Editor.HDRP
         [Test]
         public void IsHDRP()
         {
-
             UnityEngine.Assertions.Assert.IsNotNull(GraphicsSettings.renderPipelineAsset);
         }
     }

--- a/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+using UnityEngine.Rendering;
+
+namespace Tests.Editor.HDRP
+{
+    [TestFixture]
+    public class IsHDRPTests
+    {
+        [Test]
+        public void IsHDRP()
+        {
+
+            UnityEngine.Assertions.Assert.IsNotNull(GraphicsSettings.renderPipelineAsset);
+        }
+    }
+}

--- a/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor/IsHDRP.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b32b03fcb9df4916b1462d0e384d519
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Editor/com.unity.cinemachine.hdrpeditor.tests.asmdef
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor/com.unity.cinemachine.hdrpeditor.tests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "com.unity.cinemachine.hdrpeditor.tests",
+    "rootNamespace": "",
+    "references": [
+        "com.unity.cinemachine",
+        "com.unity.cinemachine.editor",
+        "com.unity.cinemachine.shared.tests",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/com.unity.cinemachine.hdrptests/Tests/Editor/com.unity.cinemachine.hdrpeditor.tests.asmdef.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Editor/com.unity.cinemachine.hdrpeditor.tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 541e26bcf556a45f0ae16a8ece0a564e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Runtime.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5868b5abb1d344084bc31720e7f78bf2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Runtime/IsHDRP.cs
+++ b/com.unity.cinemachine.hdrptests/Tests/Runtime/IsHDRP.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+using UnityEngine.Rendering;
+
+namespace Tests.Runtime.HDRP
+{
+    [TestFixture]
+    public class IsHDRPTests
+    {
+        [Test]
+        public void IsHDRP()
+        {
+
+            UnityEngine.Assertions.Assert.IsNotNull(GraphicsSettings.renderPipelineAsset);
+        }
+    }
+}

--- a/com.unity.cinemachine.hdrptests/Tests/Runtime/IsHDRP.cs.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Runtime/IsHDRP.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9db5d4847a1f44f8ad6127e2b691d6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/Runtime/com.unity.cinemachine.hdrp.tests.asmdef
+++ b/com.unity.cinemachine.hdrptests/Tests/Runtime/com.unity.cinemachine.hdrp.tests.asmdef
@@ -1,0 +1,52 @@
+{
+    "name": "com.unity.cinemachine.hdrpruntime.tests",
+    "rootNamespace": "",
+    "references": [
+        "com.unity.cinemachine",
+        "com.unity.cinemachine.editor",
+        "com.unity.cinemachine.shared.tests",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.Splines",
+        "Unity.Mathematics"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS_2D"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
+        },
+        {
+            "name": "com.unity.splines",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_SPLINES"
+        },
+        {
+            "name": "com.unity.cinemachine",
+            "expression": "3.0.0-pre.1",
+            "define": "CINEMACHINE_V3_OR_HIGHER"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/com.unity.cinemachine.hdrptests/Tests/Runtime/com.unity.cinemachine.hdrp.tests.asmdef.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/Runtime/com.unity.cinemachine.hdrp.tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04146243703e141a4b2b34f0b756bdee
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/Tests/com.unity.cinemachine.hdrp.tests.asmdef
+++ b/com.unity.cinemachine.hdrptests/Tests/com.unity.cinemachine.hdrp.tests.asmdef
@@ -1,0 +1,39 @@
+{
+    "name": "com.unity.cinemachine.hdrp.tests",
+    "rootNamespace": "",
+    "references": [
+        "com.unity.cinemachine",
+        "com.unity.cinemachine.editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS_2D"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/com.unity.cinemachine.hdrptests/Tests/com.unity.cinemachine.hdrp.tests.asmdef.meta
+++ b/com.unity.cinemachine.hdrptests/Tests/com.unity.cinemachine.hdrp.tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: feefad7b22bcf421f9d1cd2c1839925b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine.hdrptests/package.json
+++ b/com.unity.cinemachine.hdrptests/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "com.unity.cinemachine.hdrptests",
+  "displayName": "Cinemachine HDRP tests",
+  "version": "3.0.0-pre.4",
+  "unity": "2022.2",
+  "unityRelease": "0b8",
+  "description": "Smart camera tools for passionate creators. \n\n Cinemachine 3.0 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
+  "keywords": [
+    "camera",
+    "follow",
+    "rig",
+    "fps",
+    "cinematography",
+    "aim",
+    "orbit",
+    "cutscene",
+    "cinematic",
+    "collision",
+    "freelook",
+    "cinemachine",
+    "compose",
+    "composition",
+    "dolly",
+    "track",
+    "clearshot",
+    "noise",
+    "framing",
+    "handheld",
+    "lens",
+    "impulse"
+  ],
+  "category": "cinematography",
+  "dependencies": {
+    "com.unity.splines": "2.0.0-pre.4",
+    "com.unity.test-framework": "1.1.33"
+  }
+}

--- a/com.unity.cinemachine.hdrptests/package.json.meta
+++ b/com.unity.cinemachine.hdrptests/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 025bbe08149064fe88ebbf2bdd068958
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/.tests.json
+++ b/com.unity.cinemachine/.tests.json
@@ -1,0 +1,7 @@
+{
+    "createSeparatePackage": true,
+    "displayName": "CM ests Package",
+    "dependencies": {
+       "com.unity.test-framework": "1.1.33"
+    }
+}

--- a/com.unity.cinemachine/Tests/.tests.json
+++ b/com.unity.cinemachine/Tests/.tests.json
@@ -1,6 +1,6 @@
 {
     "createSeparatePackage": true,
-    "displayName": "CM ests Package",
+    "displayName": "Cinemachine Test Package",
     "dependencies": {
        "com.unity.test-framework": "1.1.33"
     }

--- a/com.unity.cinemachine/Tests/Runtime/StateDrivenCameraTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/StateDrivenCameraTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Runtime
 
             // Create a minimal character controller
             var character = CreateGameObject("Character", typeof(Animator));
-            var controller = AssetDatabase.LoadMainAssetAtPath("Packages/com.unity.cinemachine/Tests/Runtime/TestController.controller") as AnimatorController;
+            var controller = AssetDatabase.LoadMainAssetAtPath("Packages/com.unity.cinemachine.tests/Tests/Runtime/TestController.controller") as AnimatorController;
             character.GetComponent<Animator>().runtimeAnimatorController = controller;
 
             // Create a state-driven camera with two vcams 

--- a/com.unity.cinemachine/Tests/Runtime/StateDrivenCameraTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/StateDrivenCameraTests.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR // AssetDatabase.LoadMainAssetAtPath
 #if CINEMACHINE_UNITY_ANIMATION
+using System;
 using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
@@ -25,7 +26,18 @@ namespace Tests.Runtime
 
             // Create a minimal character controller
             var character = CreateGameObject("Character", typeof(Animator));
-            var controller = AssetDatabase.LoadMainAssetAtPath("Packages/com.unity.cinemachine.tests/Tests/Runtime/TestController.controller") as AnimatorController;
+            AnimatorController controller = null;
+            foreach (var asset in AssetDatabase.FindAssets("t:AnimatorController TestController"))
+            {
+                var path = AssetDatabase.GUIDToAssetPath(asset);
+                controller = AssetDatabase.LoadMainAssetAtPath(path) as AnimatorController;
+            }
+
+            if (controller == null)
+            {
+                throw new ArgumentNullException("controller", "FindAssets did not find the TestController in the project.");
+            }
+            
             character.GetComponent<Animator>().runtimeAnimatorController = controller;
 
             // Create a state-driven camera with two vcams 


### PR DESCRIPTION
### Purpose of this PR

Use the .tests.json method to extract the tests in a new package. This means that we won't deliver tests with the next version of cinemachine. 

We decided it's the least of the two evils, between creating an empty tests in the main package or using CI magic to do the split. 

### Testing status

Passed isolation tests. Package is still ready to release.