### PR TITLE
CMCL-1306: FindClosestPoint fix

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CinemachineConfiner is deprecated.  New behaviour CinemachineConfiner3D to handle 3D confining.  Use CinemachineConfiner2D for 2D confining.
 - Cinemachine Samples can import their package dependencies.
 - CinemachineSmoothPath is upgraded to Splines correctly now. 
+- CinemachinePathBase search radius fixed for not looped paths.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -113,15 +113,14 @@ namespace Cinemachine
             {
                 if (Looped)
                 {
-                    var r = Mathf.FloorToInt(Mathf.Min(searchRadius, (end - start) / 2f));
+                    var r = Mathf.Min(searchRadius, Mathf.FloorToInt((end - start) / 2f));
                     start = startSegment - r;
                     end = startSegment + r + 1;
                 }
                 else
                 {
-                    var r = Mathf.FloorToInt(searchRadius);
-                    start = Mathf.Max(startSegment - r, MinPos);
-                    end = Mathf.Min(startSegment + r + 1, MaxPos);
+                    start = Mathf.Max(startSegment - searchRadius, MinPos);
+                    end = Mathf.Min(startSegment + searchRadius + 1, MaxPos);
                 }
             }
             stepsPerSegment = Mathf.RoundToInt(Mathf.Clamp(stepsPerSegment, 1f, 100f));

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -119,7 +119,7 @@ namespace Cinemachine
                 }
                 else
                 {
-                    var r = Mathf.FloorToInt(Mathf.Min(searchRadius, end - start));
+                    var r = Mathf.FloorToInt(searchRadius);
                     start = Mathf.Max(startSegment - r, MinPos);
                     end = Mathf.Min(startSegment + r + 1, MaxPos);
                 }

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePathBase.cs
@@ -111,13 +111,17 @@ namespace Cinemachine
             float end = MaxPos;
             if (searchRadius >= 0)
             {
-                int r = Mathf.FloorToInt(Mathf.Min(searchRadius, (end - start) / 2f));
-                start = startSegment - r;
-                end = startSegment + r + 1;
-                if (!Looped)
+                if (Looped)
                 {
-                    start = Mathf.Max(start, MinPos);
-                    end = Mathf.Min(end, MaxPos);
+                    var r = Mathf.FloorToInt(Mathf.Min(searchRadius, (end - start) / 2f));
+                    start = startSegment - r;
+                    end = startSegment + r + 1;
+                }
+                else
+                {
+                    var r = Mathf.FloorToInt(Mathf.Min(searchRadius, end - start));
+                    start = Mathf.Max(startSegment - r, MinPos);
+                    end = Mathf.Min(startSegment + r + 1, MaxPos);
                 }
             }
             stepsPerSegment = Mathf.RoundToInt(Mathf.Clamp(stepsPerSegment, 1f, 100f));


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1306](https://jira.unity3d.com/browse/CMCL-1306): CinemachinePathBase.FindClosestPoint doesn't search the last segment of its path when there are more than 2 segments.

The problem was that the search radius was clamped to half the radius, but when the path is not looped this may clamp the search radius too short.

For example:
Spline with n points. Not looped.
Search Radius: n. => search whole path even when starting from spline point 0.
However, search radius was clamped to n/2. So now we don't search whole spline just half when starting from 0. 

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation