### PR TITLE
CMCL-1321: FindClosestPoint fix (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 ## [unreleased]
 - Bugfix: Tranpsoser with LockToTarget binding could have gimbal lock
 - Freelook ForcePosition is more precise now.
+- CinemachinePathBase search radius fixed for not looped paths.
 
 
 ## [2.6.17] - 2022-08-15

--- a/Runtime/Core/CinemachinePathBase.cs
+++ b/Runtime/Core/CinemachinePathBase.cs
@@ -91,13 +91,16 @@ namespace Cinemachine
             float end = MaxPos;
             if (searchRadius >= 0)
             {
-                int r = Mathf.FloorToInt(Mathf.Min(searchRadius, (end - start) / 2f));
-                start = startSegment - r;
-                end = startSegment + r + 1;
-                if (!Looped)
+                if (Looped)
                 {
-                    start = Mathf.Max(start, MinPos);
-                    end = Mathf.Min(end, MaxPos);
+                    var r = Mathf.Min(searchRadius, Mathf.FloorToInt((end - start) / 2f));
+                    start = startSegment - r;
+                    end = startSegment + r + 1;
+                }
+                else
+                {
+                    start = Mathf.Max(startSegment - searchRadius, MinPos);
+                    end = Mathf.Min(startSegment + searchRadius + 1, MaxPos);
                 }
             }
             stepsPerSegment = Mathf.RoundToInt(Mathf.Clamp(stepsPerSegment, 1f, 100f));


### PR DESCRIPTION
### Purpose of this PR

[CMCL-1321](https://jira.unity3d.com/browse/CMCL-1321), backport of [CMCL-1307](https://jira.unity3d.com/browse/CMCL-1307) - [PR](https://github.com/Unity-Technologies/com.unity.cinemachine/pull/708)

I saw we have a few unreleased fixes on 2.6, so I added this simple to backport fix, in case we want to release them.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
