### PR TITLE
CMCL-0000: cameron animation scales properly with speed

### DIFF
--- a/com.unity.cinemachine/Samples~/Shared Assets/Cameron/Model/CameronSimpleController.controller
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Cameron/Model/CameronSimpleController.controller
@@ -1,66 +1,68 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-7061757097289198402
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Jump Walk
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -400134937491866966}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 1
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: 0c6f7469db3db6d4ba890e20f1f0d353, type: 3}
+  m_Tag: 
+  m_SpeedParameter: JumpScale
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-3686201905407010574
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Walking
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Running
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5351786783861475141}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.24407329
+  m_TransitionOffset: 0
+  m_ExitTime: 0.000000008504299
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!206 &-3149639009288007864
 BlendTree:
   m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Blend Tree
-  m_Childs:
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: b88ec26a83b701044a543a7dad051099, type: 3}
-    m_Threshold: 0
-    m_Position: {x: 0, y: 0}
-    m_TimeScale: 0.2
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Speed
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: 6fe0448cc546d024e8eb1521b77353d0, type: 3}
-    m_Threshold: 0.16666667
-    m_Position: {x: 0, y: 0.5}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Speed
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: 6fe0448cc546d024e8eb1521b77353d0, type: 3}
-    m_Threshold: 0.33333334
-    m_Position: {x: 0, y: -0.5}
-    m_TimeScale: -1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: SpeedX
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: 73cf8af30ffe5074588bc680b589e7c4, type: 3}
-    m_Threshold: 0.5
-    m_Position: {x: 0, y: 1}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Speed
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: 73cf8af30ffe5074588bc680b589e7c4, type: 3}
-    m_Threshold: 0.6666667
-    m_Position: {x: 0, y: -1}
-    m_TimeScale: -1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: SpeedX
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: 73b4eac3cdf025a468538278eb2ccb13, type: 3}
-    m_Threshold: 0.8333333
-    m_Position: {x: -1, y: 0}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Speed
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 1827226128182048838, guid: ba720bc5ef3a17244afcdb1f0792f842, type: 3}
-    m_Threshold: 1
-    m_Position: {x: 1, y: 0}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Speed
-    m_Mirror: 0
+  m_Childs: []
   m_BlendParameter: SpeedX
   m_BlendParameterY: SpeedZ
   m_MinThreshold: 0
@@ -68,58 +70,147 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 2
+--- !u!1102 &-2151006468185585992
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Walk
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3792351554367551019}
+  - {fileID: -3686201905407010574}
+  - {fileID: 1490814412725467169}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 1
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 3327091629554249476}
+  m_Tag: 
+  m_SpeedParameter: MotionScale
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-2087256297465246186
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Running
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8420703450221908322}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1941328
+  m_TransitionOffset: 5.4970884
+  m_ExitTime: 0.9044675
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-400134937491866966
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Land
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2151006468185585992}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.06615287
+  m_TransitionOffset: 0
+  m_ExitTime: 0.58234453
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: CameronSimpleController
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: SpeedX
+  - m_Name: DirX
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: SpeedY
-    m_Type: 1
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: SpeedZ
-    m_Type: 1
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: WalkScale
+    m_Controller: {fileID: 0}
+  - m_Name: DirZ
     m_Type: 1
     m_DefaultFloat: 1
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: MotionScale
+    m_Type: 1
+    m_DefaultFloat: 1
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: JumpScale
     m_Type: 1
     m_DefaultFloat: 1
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Land
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: Walking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: Running
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
     m_StateMachine: {fileID: 5252751724755048829}
+    m_Mask: {fileID: 0}
     m_Motions: []
     m_Behaviours: []
     m_BlendingMode: 0
@@ -131,11 +222,15 @@ AnimatorController:
 --- !u!1101 &775935384185778692
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Land
     m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 5351786783861475141}
   m_Solo: 0
   m_Mute: 0
@@ -149,11 +244,211 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1490814412725467169
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Running
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8420703450221908322}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.68085104
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3070331966817909641
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Walking
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Running
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5351786783861475141}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.17489767
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5522389
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!206 &3327091629554249476
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blend Tree
+  m_Childs:
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 6fe0448cc546d024e8eb1521b77353d0, type: 3}
+    m_Threshold: 0.25
+    m_Position: {x: 0, y: 1}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: SpeedX
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 6fe0448cc546d024e8eb1521b77353d0, type: 3}
+    m_Threshold: 0.5
+    m_Position: {x: 0, y: -1}
+    m_TimeScale: -1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: SpeedX
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: ba720bc5ef3a17244afcdb1f0792f842, type: 3}
+    m_Threshold: 0.75
+    m_Position: {x: 1, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: Speed
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 73b4eac3cdf025a468538278eb2ccb13, type: 3}
+    m_Threshold: 1
+    m_Position: {x: -1, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: Speed
+    m_Mirror: 0
+  m_BlendParameter: DirX
+  m_BlendParameterY: DirZ
+  m_MinThreshold: 0.25
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 2
+--- !u!1101 &3691152097968358944
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Land
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8420703450221908322}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.06615287
+  m_TransitionOffset: 0
+  m_ExitTime: 0.58234453
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!206 &3712578732204055543
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blend Tree
+  m_Childs:
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 73cf8af30ffe5074588bc680b589e7c4, type: 3}
+    m_Threshold: 0.25
+    m_Position: {x: 0, y: 1}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: SpeedX
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 73cf8af30ffe5074588bc680b589e7c4, type: 3}
+    m_Threshold: 0.5
+    m_Position: {x: 0, y: -1}
+    m_TimeScale: -1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: SpeedX
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: ba720bc5ef3a17244afcdb1f0792f842, type: 3}
+    m_Threshold: 0.75
+    m_Position: {x: 1, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: Speed
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 1827226128182048838, guid: 73b4eac3cdf025a468538278eb2ccb13, type: 3}
+    m_Threshold: 1
+    m_Position: {x: -1, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: Speed
+    m_Mirror: 0
+  m_BlendParameter: DirX
+  m_BlendParameterY: DirZ
+  m_MinThreshold: 0.25
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 2
+--- !u!1101 &3792351554367551019
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7061757097289198402}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.099303246
+  m_TransitionOffset: 0
+  m_ExitTime: 0.73747194
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &3847384438597556834
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
-  m_Name: Jump
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Jump Idle
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -173,37 +468,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1107 &5252751724755048829
-AnimatorStateMachine:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_Name: Base Layer
-  m_ChildStates:
-  - serializedVersion: 1
-    m_State: {fileID: 5351786783861475141}
-    m_Position: {x: 30, y: 230, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 3847384438597556834}
-    m_Position: {x: 290, y: 230, z: 0}
-  m_ChildStateMachines: []
-  m_AnyStateTransitions: []
-  m_EntryTransitions: []
-  m_StateMachineTransitions: {}
-  m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 50, y: 350, z: 0}
-  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 5351786783861475141}
---- !u!1102 &5351786783861475141
+--- !u!1102 &4380426822070008261
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
-  m_Name: Movement
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Jump Run
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 5406036619693422872}
+  - {fileID: 3691152097968358944}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -213,20 +489,90 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: -3149639009288007864}
+  m_Motion: {fileID: 1827226128182048838, guid: 0c6f7469db3db6d4ba890e20f1f0d353, type: 3}
   m_Tag: 
-  m_SpeedParameter: WalkScale
+  m_SpeedParameter: JumpScale
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &5252751724755048829
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 5351786783861475141}
+    m_Position: {x: 70, y: 230, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3847384438597556834}
+    m_Position: {x: 490, y: 230, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2151006468185585992}
+    m_Position: {x: 220, y: 310, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7061757097289198402}
+    m_Position: {x: 490, y: 310, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4380426822070008261}
+    m_Position: {x: 490, y: 390, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8420703450221908322}
+    m_Position: {x: 70, y: 390, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 50, y: 520, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 5351786783861475141}
+--- !u!1102 &5351786783861475141
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 0.2
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5406036619693422872}
+  - {fileID: -2087256297465246186}
+  - {fileID: 9102725391783152931}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: b88ec26a83b701044a543a7dad051099, type: 3}
+  m_Tag: 
+  m_SpeedParameter: Speed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
 --- !u!1101 &5406036619693422872
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Jump
     m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3847384438597556834}
   m_Solo: 0
   m_Mute: 0
@@ -235,6 +581,116 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.099303246
   m_TransitionOffset: 0
   m_ExitTime: 0.73747194
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5969063405154933277
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4380426822070008261}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.099303246
+  m_TransitionOffset: 0
+  m_ExitTime: 0.73747194
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &6577597960447181989
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Walking
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Running
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2151006468185585992}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5522388
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &8420703450221908322
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Run
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5969063405154933277}
+  - {fileID: 3070331966817909641}
+  - {fileID: 6577597960447181989}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 1
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 3712578732204055543}
+  m_Tag: 
+  m_SpeedParameter: MotionScale
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &9102725391783152931
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Walking
+    m_EventTreshold: 0.1
+  - m_ConditionMode: 2
+    m_ConditionEvent: Running
+    m_EventTreshold: 0.1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2151006468185585992}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player.prefab
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player.prefab
@@ -645,6 +645,7 @@ MonoBehaviour:
   InputForward: 0
   UpMode: 1
   Strafe: 0
+  LockCursor: 0
   MoveX:
     Value: 0
     Center: 0
@@ -686,10 +687,10 @@ MonoBehaviour:
   Controllers:
   - Name: Move X
     Owner: {fileID: 5995860984952935429}
-    LegacyInput: Horizontal
-    LegacyGain: 200
     InputAction: {fileID: -1680190386980627800, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
     Gain: 4
+    LegacyInput: Horizontal
+    LegacyGain: 200
     Control:
       InputValue: 0
       AccelTime: 0
@@ -700,10 +701,10 @@ MonoBehaviour:
       Time: 0
   - Name: Move Z
     Owner: {fileID: 5995860984952935429}
-    LegacyInput: Vertical
-    LegacyGain: 200
     InputAction: {fileID: -1680190386980627800, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
     Gain: 4
+    LegacyInput: Vertical
+    LegacyGain: 200
     Control:
       InputValue: 0
       AccelTime: 0
@@ -714,10 +715,10 @@ MonoBehaviour:
       Time: 0
   - Name: Jump
     Owner: {fileID: 5995860984952935429}
-    LegacyInput: Jump
-    LegacyGain: 200
     InputAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
     Gain: 1
+    LegacyInput: Jump
+    LegacyGain: 200
     Control:
       InputValue: 0
       AccelTime: 0.1
@@ -728,10 +729,10 @@ MonoBehaviour:
       Time: 0.01
   - Name: Sprint
     Owner: {fileID: 5995860984952935429}
-    LegacyInput: Fire3
-    LegacyGain: 200
     InputAction: {fileID: 1120369429361536294, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
     Gain: 4
+    LegacyInput: Fire3
+    LegacyGain: 200
     Control:
       InputValue: 0
       AccelTime: 0
@@ -752,8 +753,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be929e8436c3caf46b4ef616ef0e824e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NormalWalkSpeed: 1.75
-  SprintAnimationScale: 1
+  NormalWalkSpeed: 1.7
+  NormalSprintSpeed: 5
+  MaxSprintScale: 1.4
   JumpAnimationScale: 0.65
 --- !u!1 &6960710989245956327
 GameObject:

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAnimator.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAnimator.cs
@@ -5,51 +5,82 @@ namespace Cinemachine.Examples
     /// <summary>
     /// Add-on for SimplePlayerController that controls animation for the Cameron character.
     /// </summary>
-    [RequireComponent(typeof(SimplePlayerController))]
     [RequireComponent(typeof(Animator))]
     public class SimplePlayerAnimator : MonoBehaviour
     {
-        // Tune this to the animation in the model: feet should not slide when walking at this speed
-        public float NormalWalkSpeed = 1; 
+        [Tooltip("Tune this to the animation in the model: feet should not slide when walking at this speed")]
+        public float NormalWalkSpeed = 1.7f;
 
-        public float SprintAnimationScale = 1;
-        public float JumpAnimationScale = 1;
+        [Tooltip("Tune this to the animation in the model: feet should not slide when sprinting at this speed")]
+        public float NormalSprintSpeed = 5;
+
+        [Tooltip("Never speed up the sprint animation more than this, to avoid absurdly fast movement")]
+        public float MaxSprintScale = 1.4f;
+
+        [Tooltip("Scale factor for the overall speed of the jump animation")]
+        public float JumpAnimationScale = 0.65f;
 
         Animator m_Animator;
         SimplePlayerController m_Controller;
+        Vector3 m_PreviousPosition; // used if m_Controller == null
+        const float k_IdleThreshold = 0.3f;
 
         void Start()
         {
+            m_PreviousPosition = transform.position;
             TryGetComponent(out m_Animator);
             if (TryGetComponent(out m_Controller))
             {
                 m_Controller.StartJump += () => m_Animator.SetTrigger("Jump");
                 m_Controller.EndJump += () => m_Animator.SetTrigger("Land");
-                m_Controller.PostUpdate += UpdateAnimation;
+                m_Controller.PostUpdate += () =>
+                {
+                    var vel = m_Controller.GetPlayerVelocity();
+                    UpdateAnimation(vel);
+                    m_Animator.SetFloat("JumpScale", JumpAnimationScale * (m_Controller.IsSprinting 
+                        ? m_Controller.JumpSpeed / m_Controller.SprintJumpSpeed : 1));
+                };
             }
         }
 
-        void UpdateAnimation()
+        // LateUpdate so we normally don't have to worry about script execution order:
+        // we can assume that the player has already been moved
+        void LateUpdate()
         {
-            var vel = m_Controller.GetPlayerVelocity();
-            var speed = new Vector2(vel.x, vel.z).magnitude;
+            // In no-controller mode, we monitor the player's motion and deduce the appropriate animation.
+            // We don't support jumping in this mode.
+            if (m_Controller == null)
+            {
+                // Get velocity in player-local coords
+                var pos = transform.position;
+                var vel = Quaternion.Inverse(transform.rotation) * (pos - m_PreviousPosition) / Time.deltaTime;
+                m_PreviousPosition = pos;
+                UpdateAnimation(vel);
+            }
+        }
 
-            var speedX = m_Controller.Strafe ? vel.x : 0;
-            var speedZ = m_Controller.Strafe ? vel.z : speed;
+        void UpdateAnimation(Vector3 vel)
+        {
+            // Set animation params for current velocity
+            vel.y = 0; // we don't consider vertical movement
+            var speed = vel.magnitude;
+            bool isRunning = speed > NormalWalkSpeed * 2;
+            bool isWalking = !isRunning && speed > k_IdleThreshold;
+            var dir = speed > k_IdleThreshold ? vel / speed : Vector3.zero;
+            var motionScale = isWalking ? speed / NormalWalkSpeed : 1;
+
+            // We scale the sprint animation speed to loosely match the actual speed, but we cheat
+            // at the high end to avoid making the animation look ridiculous
+            if (isRunning)
+                motionScale = (speed < NormalSprintSpeed) 
+                    ? speed / NormalSprintSpeed
+                    : Mathf.Min(MaxSprintScale, 1 + (speed - NormalSprintSpeed) / (3 * NormalSprintSpeed));
             
-            var animSpeedZ = Mathf.Min(speedZ, m_Controller.Speed) / (m_Controller.Speed * 2);
-            var sprintSpeed = Mathf.Abs(speedZ) - m_Controller.Speed;
-            if (sprintSpeed > 0 && speedZ > m_Controller.Speed)
-                animSpeedZ += Mathf.Sign(speedZ) * sprintSpeed / (m_Controller.SprintSpeed - m_Controller.Speed);
-
-            var animSpeedX = Mathf.Clamp(speedX / m_Controller.Speed, -1, 1);
-            var animSpeedY = Mathf.Clamp(vel.y / (m_Controller.IsSprinting ? m_Controller.SprintJumpSpeed : m_Controller.JumpSpeed), -1, 1);
-
-            m_Animator.SetFloat("SpeedZ", animSpeedZ);
-            m_Animator.SetFloat("SpeedX", animSpeedX);
-            m_Animator.SetFloat("SpeedY", animSpeedY);
-            m_Animator.SetFloat("WalkScale", m_Controller.IsSprinting ? SprintAnimationScale : m_Controller.Speed / NormalWalkSpeed);
-            m_Animator.SetFloat("JumpScale", JumpAnimationScale * (m_Controller.IsSprinting ? m_Controller.JumpSpeed / m_Controller.SprintJumpSpeed : 1));
+            m_Animator.SetFloat("DirX", dir.x);
+            m_Animator.SetFloat("DirZ", dir.z);
+            m_Animator.SetFloat("MotionScale", motionScale);
+            m_Animator.SetBool("Walking", isWalking);
+            m_Animator.SetBool("Running", isRunning);
         }
     }
 }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAnimator.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerAnimator.cs
@@ -23,7 +23,9 @@ namespace Cinemachine.Examples
         Animator m_Animator;
         SimplePlayerController m_Controller;
         Vector3 m_PreviousPosition; // used if m_Controller == null
-        const float k_IdleThreshold = 0.3f;
+        bool m_WasWalking;
+        bool m_WasRunning;
+        const float k_IdleThreshold = 0.2f;
 
         void Start()
         {
@@ -64,8 +66,14 @@ namespace Cinemachine.Examples
             // Set animation params for current velocity
             vel.y = 0; // we don't consider vertical movement
             var speed = vel.magnitude;
-            bool isRunning = speed > NormalWalkSpeed * 2;
-            bool isWalking = !isRunning && speed > k_IdleThreshold;
+
+            // Hysteresis reduction
+            bool isRunning = speed > NormalWalkSpeed * 2 + (m_WasRunning ? -0.15f : 0.15f);
+            bool isWalking = !isRunning && speed > k_IdleThreshold + (m_WasWalking ? -0.05f : 0.05f);
+            m_WasWalking = isWalking;
+            m_WasRunning = isRunning;
+
+            // Set the normalized direction of motion and scale the animation speed to match motion speed
             var dir = speed > k_IdleThreshold ? vel / speed : Vector3.zero;
             var motionScale = isWalking ? speed / NormalWalkSpeed : 1;
 

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -50,10 +50,7 @@ namespace Cinemachine.Examples
         // Get velocity relative to player transform
         public Vector3 GetPlayerVelocity()
         {
-            var up = UpDirection;
-            var vel = m_CurrentVelocityXZ.ProjectOntoPlane(up);
-            var fwd = transform.forward.ProjectOntoPlane(up);
-            vel = Quaternion.FromToRotation(fwd, Vector3.forward) * vel;
+            var vel = Quaternion.Inverse(transform.rotation) * m_CurrentVelocityXZ;
             vel.y = m_CurrentVelocityY;
             return vel;
         }


### PR DESCRIPTION
### Purpose of this PR

Refactored Cameron animation controller:
- Animation now scales properly with speed, feet don't slide
- Clean transition from walk to run, depending on speed (no need to check IsSprinting in the controller)
- Works also without SimplePlayerController.  In this mode, transform position is monitored and velocity is calculated.  The appropriate animation is chosen, depending on speed and direction relative to local forward.  Jumping not supported in this mode.

### Testing status

Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Comments to reviewers

For the ClearShot racing scene, where player is on a cart, you can now leave the SimplePlayerAnimator script on the player, and remove the controller.  Player will animate automatically based on its speed.