### PR TITLE
CMCL-1311: manager ux handles priority properly

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -12,7 +12,7 @@ namespace Cinemachine.Editor
     class CinemachineStateDrivenCameraEditor : CinemachineVirtualCameraBaseEditor<CinemachineStateDrivenCamera>
     {
         EmbeddeAssetEditor<CinemachineBlenderSettings> m_BlendsEditor;
-        UnityEditorInternal.ReorderableList m_ChildList;
+        ChildListInspectorHelper m_ChildListHelper = new();
         UnityEditorInternal.ReorderableList m_InstructionList;
 
         string[] m_LayerNames;
@@ -45,7 +45,7 @@ namespace Cinemachine.Editor
                         editor.GetAllVirtualCameras = (list) => list.AddRange(Target.ChildCameras);
                 }
             };
-            m_ChildList = null;
+            m_ChildListHelper.OnEnable();
             m_InstructionList = null;
         }
 
@@ -61,8 +61,6 @@ namespace Cinemachine.Editor
             BeginInspector();
             if (m_InstructionList == null)
                 SetupInstructionList();
-            if (m_ChildList == null)
-                SetupChildList();
 
             if (Target.AnimatedTarget == null)
                 EditorGUILayout.HelpBox("An Animated Target is required", MessageType.Warning);
@@ -105,12 +103,8 @@ namespace Cinemachine.Editor
 
             // vcam children
             EditorGUILayout.Separator();
-            m_ChildList.DoLayoutList();
-            if (EditorGUI.EndChangeCheck())
-            {
-                serializedObject.ApplyModifiedProperties();
+            if (m_ChildListHelper.OnInspectorGUI(FindProperty(x => x.m_ChildCameras)))
                 Target.ValidateInstructions();
-            }
 
             // Extensions
             DrawExtensionsWidgetInInspector();
@@ -384,74 +378,6 @@ namespace Cinemachine.Editor
                     },
                         null);
                     menu.ShowAsContext();
-                };
-        }
-
-        void SetupChildList()
-        {
-            var vSpace = 2f;
-            var hSpace = 3f;
-            var floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
-            var hBigSpace = EditorGUIUtility.singleLineHeight * 2 / 3;
-
-            m_ChildList = new UnityEditorInternal.ReorderableList(serializedObject,
-                    serializedObject.FindProperty(() => Target.m_ChildCameras),
-                    true, true, true, true);
-
-            m_ChildList.drawHeaderCallback = (Rect rect) =>
-                {
-                    EditorGUI.LabelField(rect, "Virtual Camera Children");
-                    var priorityText = new GUIContent("Priority");
-                    var textDimensions = GUI.skin.label.CalcSize(priorityText);
-                    rect.x += rect.width - textDimensions.x;
-                    rect.width = textDimensions.x;
-                    EditorGUI.LabelField(rect, priorityText);
-                };
-            m_ChildList.drawElementCallback
-                = (Rect rect, int index, bool isActive, bool isFocused) =>
-                {
-                    rect.y += vSpace; rect.height = EditorGUIUtility.singleLineHeight;
-                    rect.width -= floatFieldWidth + hBigSpace;
-                    SerializedProperty element = m_ChildList.serializedProperty.GetArrayElementAtIndex(index);
-                    GUI.enabled = false;
-                    EditorGUI.PropertyField(rect, element, GUIContent.none);
-                    GUI.enabled = true;
-
-                    float oldWidth = EditorGUIUtility.labelWidth;
-                    EditorGUIUtility.labelWidth = hBigSpace;
-                    var obj = new SerializedObject(element.objectReferenceValue);
-                    rect.x += rect.width + hSpace; rect.width = floatFieldWidth + hBigSpace;
-                    var priorityProp = obj.FindProperty(
-                        () => Target.PriorityAndChannel).FindPropertyRelative("Priority");
-                    EditorGUI.PropertyField(rect, priorityProp, new GUIContent(" ", priorityProp.tooltip));
-                    EditorGUIUtility.labelWidth = oldWidth;
-                    obj.ApplyModifiedProperties();
-                };
-            m_ChildList.onChangedCallback = (UnityEditorInternal.ReorderableList l) =>
-                {
-                    if (l.index < 0 || l.index >= l.serializedProperty.arraySize)
-                        return;
-                    Object o = l.serializedProperty.GetArrayElementAtIndex(
-                            l.index).objectReferenceValue;
-                    CinemachineVirtualCameraBase vcam = (o != null)
-                        ? (o as CinemachineVirtualCameraBase) : null;
-                    if (vcam != null)
-                        vcam.transform.SetSiblingIndex(l.index);
-                };
-            m_ChildList.onAddCallback = (UnityEditorInternal.ReorderableList l) =>
-                {
-                    var index = l.serializedProperty.arraySize;
-                    var vcam = CinemachineMenu.CreatePassiveCmCamera(parentObject: Target.gameObject);
-                    vcam.transform.SetSiblingIndex(index);
-                };
-            m_ChildList.onRemoveCallback = (UnityEditorInternal.ReorderableList l) =>
-                {
-                    Object o = l.serializedProperty.GetArrayElementAtIndex(
-                            l.index).objectReferenceValue;
-                    CinemachineVirtualCameraBase vcam = (o != null)
-                        ? (o as CinemachineVirtualCameraBase) : null;
-                    if (vcam != null)
-                        Undo.DestroyObjectImmediate(vcam.gameObject);
                 };
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -25,16 +25,8 @@ namespace Cinemachine.Editor
     /// <typeparam name="T">The type of CinemachineVirtualCameraBase being edited</typeparam>
     class CinemachineVirtualCameraBaseEditor<T> : BaseEditor<T> where T : CinemachineVirtualCameraBase
     {    
-        /// <summary>A collection of GUIContent for use in the inspector</summary>
-        public static class Styles
-        {
-            /// <summary>GUIContent for Add Extension</summary>
-            public static GUIContent addExtensionLabel = new GUIContent("Add Extension");
-            /// <summary>GUIContent for no-multi-select message</summary>
-            public static GUIContent virtualCameraChildrenInfoMsg 
-                = new GUIContent("The Virtual Camera Children field is not available when multiple objects are selected.");
-        }
-        
+        static GUIContent s_AddExtensionLabel = new ("Add Extension", "Add a Cinemachine Extension behaviour");
+
         static Type[] sExtensionTypes;  // First entry is null
         static string[] sExtensionNames;
         bool IsPrefabBase { get; set; }
@@ -200,7 +192,7 @@ namespace Cinemachine.Editor
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("Extensions", EditorStyles.boldLabel);
                 Rect rect = EditorGUILayout.GetControlRect(true, EditorGUIUtility.singleLineHeight);
-                rect = EditorGUI.PrefixLabel(rect, Styles.addExtensionLabel);
+                rect = EditorGUI.PrefixLabel(rect, s_AddExtensionLabel);
 
                 int selection = EditorGUI.Popup(rect, 0, sExtensionNames);
                 if (selection > 0)

--- a/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
+++ b/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
@@ -46,9 +46,9 @@ namespace Cinemachine.Editor
 
         void SetupChildList(SerializedProperty property)
         {
-            float vSpace = 2;
-            float hSpace = 3;
-            float floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
+            const float vSpace = 2;
+            const float hSpace = 3;
+            var floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
 
             m_ChildList = new (property.serializedObject, property, true, true, true, true);
 
@@ -114,8 +114,8 @@ namespace Cinemachine.Editor
                     Undo.DestroyObjectImmediate(vcam.gameObject);
             };
         }
-
-        void DrawPriorityField(Rect rect, SerializedObject serializedObject)
+        
+        static void DrawPriorityField(Rect rect, SerializedObject serializedObject)
         {
             var prop = serializedObject.FindProperty("PriorityAndChannel");
             var enabledProp = prop.FindPropertyRelative("Enabled");

--- a/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
+++ b/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
@@ -7,15 +7,19 @@ namespace Cinemachine.Editor
     {
         UnityEditorInternal.ReorderableList m_ChildList;
 
+        /// <summary>
+        /// Use this delegate to control the display of warning icons next to the child cameras
+        /// </summary>
         public delegate string GetChildWarningMessageDelegate(object childObject);
         public GetChildWarningMessageDelegate GetChildWarningMessage = (object childObject) => "";
 
+        /// <summary>Call from inspector's OnEnable</summary>
         public void OnEnable()
         {
             m_ChildList = null;
         }
 
-        /// <summary>Returns true if child list was edited</summary>
+        /// <summary>Call from inspector's OnInspectorGUI.  Returns true if child list was edited</summary>
         public bool OnInspectorGUI(SerializedProperty property)
         {
             if (Selection.objects.Length == 1)
@@ -34,7 +38,8 @@ namespace Cinemachine.Editor
             else
             {
                 EditorGUILayout.HelpBox(
-                    "Child Cameras cannot be displayed when multiple objects are selected.", MessageType.Info);
+                    "Child Cameras cannot be displayed when multiple objects are selected.", 
+                    MessageType.Info);
             }
             return false;
         }
@@ -56,6 +61,7 @@ namespace Cinemachine.Editor
                 rect.width = textDimensions.x;
                 EditorGUI.LabelField(rect, priorityText);
             };
+
             m_ChildList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
             {
                 rect.y += vSpace;
@@ -75,15 +81,13 @@ namespace Cinemachine.Editor
                 EditorGUI.PropertyField(rect, element, GUIContent.none);
                 GUI.enabled = true;
 
-                var obj = new SerializedObject(element.objectReferenceValue);
                 rect.x += rect.width + hSpace; rect.width = floatFieldWidth;
-                var priorityProp = obj.FindProperty("PriorityAndChannel").FindPropertyRelative("Priority");
                 var oldWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = hSpace * 2;
-                EditorGUI.PropertyField(rect, priorityProp, new GUIContent(" "));
+                DrawPropertyField(rect, new SerializedObject(element.objectReferenceValue));
                 EditorGUIUtility.labelWidth = oldWidth;
-                obj.ApplyModifiedProperties();
             };
+
             m_ChildList.onChangedCallback = (UnityEditorInternal.ReorderableList l) =>
             {
                 if (l.index < 0 || l.index >= l.serializedProperty.arraySize)
@@ -93,20 +97,38 @@ namespace Cinemachine.Editor
                 if (vcam != null)
                     vcam.transform.SetSiblingIndex(l.index);
             };
-        m_ChildList.onAddCallback = (UnityEditorInternal.ReorderableList l) =>
+
+            m_ChildList.onAddCallback = (UnityEditorInternal.ReorderableList l) =>
             {
                 var b = property.serializedObject.targetObject as MonoBehaviour;
                 var index = l.serializedProperty.arraySize;
                 var vcam = CinemachineMenu.CreatePassiveCmCamera(parentObject: b == null ? null : b.gameObject);
                 vcam.transform.SetSiblingIndex(index);
             };
-        m_ChildList.onRemoveCallback = (UnityEditorInternal.ReorderableList l) =>
+
+            m_ChildList.onRemoveCallback = (UnityEditorInternal.ReorderableList l) =>
             {
                 var o = l.serializedProperty.GetArrayElementAtIndex(l.index).objectReferenceValue;
                 var vcam = (o != null) ? (o as CinemachineVirtualCameraBase) : null;
                 if (vcam != null)
                     Undo.DestroyObjectImmediate(vcam.gameObject);
             };
+        }
+
+        void DrawPropertyField(Rect rect, SerializedObject serializedObject)
+        {
+            var prop = serializedObject.FindProperty("PriorityAndChannel");
+            var enabledProp = prop.FindPropertyRelative("Enabled");
+            var priorityProp = prop.FindPropertyRelative("Priority");
+            var priority = enabledProp.boolValue ? priorityProp.intValue : 0;
+            var newPriority = EditorGUI.IntField(rect, " ", priority);
+            if (newPriority != priority)
+            {
+                if (newPriority != 0)
+                    enabledProp.boolValue = true;
+                priorityProp.intValue = newPriority;
+                serializedObject.ApplyModifiedProperties();
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
+++ b/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
@@ -1,0 +1,112 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Cinemachine.Editor
+{
+    class ChildListInspectorHelper
+    {
+        UnityEditorInternal.ReorderableList m_ChildList;
+
+        public delegate string GetChildWarningMessageDelegate(object childObject);
+        public GetChildWarningMessageDelegate GetChildWarningMessage = (object childObject) => "";
+
+        public void OnEnable()
+        {
+            m_ChildList = null;
+        }
+
+        /// <summary>Returns true if child list was edited</summary>
+        public bool OnInspectorGUI(SerializedProperty property)
+        {
+            if (Selection.objects.Length == 1)
+            {
+                if (m_ChildList == null)
+                    SetupChildList(property);
+
+                EditorGUI.BeginChangeCheck();
+                m_ChildList.DoLayoutList();
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.serializedObject.ApplyModifiedProperties();
+                    return true;
+                }
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(
+                    "Child Cameras cannot be displayed when multiple objects are selected.", MessageType.Info);
+            }
+            return false;
+        }
+
+        void SetupChildList(SerializedProperty property)
+        {
+            float vSpace = 2;
+            float hSpace = 3;
+            float floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
+
+            m_ChildList = new (property.serializedObject, property, true, true, true, true);
+
+            m_ChildList.drawHeaderCallback = (Rect rect) =>
+            {
+                EditorGUI.LabelField(rect, "Child Camera");
+                var priorityText = new GUIContent("Priority");
+                var textDimensions = GUI.skin.label.CalcSize(priorityText);
+                rect.x += rect.width - textDimensions.x;
+                rect.width = textDimensions.x;
+                EditorGUI.LabelField(rect, priorityText);
+            };
+            m_ChildList.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
+            {
+                rect.y += vSpace;
+                rect.width -= floatFieldWidth + hSpace;
+                rect.height = EditorGUIUtility.singleLineHeight;
+                var element = m_ChildList.serializedProperty.GetArrayElementAtIndex(index);
+                var warningText = GetChildWarningMessage(element.objectReferenceValue);
+                if (!string.IsNullOrEmpty(warningText))
+                {
+                    var width = rect.width;
+                    rect.width = rect.height;
+                    EditorGUI.LabelField(rect, new GUIContent("", warningText) 
+                        { image = EditorGUIUtility.IconContent("console.warnicon.sml").image });
+                    width -= rect.width; rect.x += rect.width; rect.width = width;
+                }
+                GUI.enabled = false;
+                EditorGUI.PropertyField(rect, element, GUIContent.none);
+                GUI.enabled = true;
+
+                var obj = new SerializedObject(element.objectReferenceValue);
+                rect.x += rect.width + hSpace; rect.width = floatFieldWidth;
+                var priorityProp = obj.FindProperty("PriorityAndChannel").FindPropertyRelative("Priority");
+                var oldWidth = EditorGUIUtility.labelWidth;
+                EditorGUIUtility.labelWidth = hSpace * 2;
+                EditorGUI.PropertyField(rect, priorityProp, new GUIContent(" "));
+                EditorGUIUtility.labelWidth = oldWidth;
+                obj.ApplyModifiedProperties();
+            };
+            m_ChildList.onChangedCallback = (UnityEditorInternal.ReorderableList l) =>
+            {
+                if (l.index < 0 || l.index >= l.serializedProperty.arraySize)
+                    return;
+                var o = l.serializedProperty.GetArrayElementAtIndex(l.index).objectReferenceValue;
+                var vcam = (o != null) ? (o as CinemachineVirtualCameraBase) : null;
+                if (vcam != null)
+                    vcam.transform.SetSiblingIndex(l.index);
+            };
+        m_ChildList.onAddCallback = (UnityEditorInternal.ReorderableList l) =>
+            {
+                var b = property.serializedObject.targetObject as MonoBehaviour;
+                var index = l.serializedProperty.arraySize;
+                var vcam = CinemachineMenu.CreatePassiveCmCamera(parentObject: b == null ? null : b.gameObject);
+                vcam.transform.SetSiblingIndex(index);
+            };
+        m_ChildList.onRemoveCallback = (UnityEditorInternal.ReorderableList l) =>
+            {
+                var o = l.serializedProperty.GetArrayElementAtIndex(l.index).objectReferenceValue;
+                var vcam = (o != null) ? (o as CinemachineVirtualCameraBase) : null;
+                if (vcam != null)
+                    Undo.DestroyObjectImmediate(vcam.gameObject);
+            };
+        }
+    }
+}

--- a/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
+++ b/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs
@@ -84,7 +84,7 @@ namespace Cinemachine.Editor
                 rect.x += rect.width + hSpace; rect.width = floatFieldWidth;
                 var oldWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = hSpace * 2;
-                DrawPropertyField(rect, new SerializedObject(element.objectReferenceValue));
+                DrawPriorityField(rect, new SerializedObject(element.objectReferenceValue));
                 EditorGUIUtility.labelWidth = oldWidth;
             };
 
@@ -115,7 +115,7 @@ namespace Cinemachine.Editor
             };
         }
 
-        void DrawPropertyField(Rect rect, SerializedObject serializedObject)
+        void DrawPriorityField(Rect rect, SerializedObject serializedObject)
         {
             var prop = serializedObject.FindProperty("PriorityAndChannel");
             var enabledProp = prop.FindPropertyRelative("Enabled");

--- a/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs.meta
+++ b/com.unity.cinemachine/Editor/Utility/ChildListInspectorHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3edb90a2415241249bb1492b6bbbd976
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1311: changing child's priority in manager camera UX should enable PriorityAndChannel in child.
This applies to BlendList, ClearShot, and SateDriven.

![image](https://user-images.githubusercontent.com/6424658/209477406-6afba2bc-0dbc-454a-bbbb-2f2f8da1531c.png)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
