### PR TITLE
CMCL-1328: pov referenceup regression fix for 2.9

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: When recording with an accumulation buffer, camera lens was not always set correctly
 - Bugfix: POV starts up in its centered position, if recentering is enabled
 - Freelook ForcePosition is more precise now.
+- CinemachinePathBase search radius fixed for not looped paths.
+- Regression fix: POV was not handling ReferenceUp correctly
 
 
 ## [2.9.1] - 2022-08-24

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePOV.cs
@@ -135,13 +135,10 @@ namespace Cinemachine
             // If we have a transform parent, then apply POV in the local space of the parent
             Quaternion rot = Quaternion.Euler(m_VerticalAxis.Value, m_HorizontalAxis.Value, 0);
             Transform parent = VirtualCamera.transform.parent;
-            var up = Vector3.up;
             if (parent != null)
-            {
                 rot = parent.rotation * rot;
-                up = parent.up;
-            }
-            rot = Quaternion.FromToRotation(curState.ReferenceUp, up) * rot;
+            else
+                rot = Quaternion.FromToRotation(Vector3.up, curState.ReferenceUp) * rot;
             curState.RawOrientation = rot;
 
             if (VirtualCamera.PreviousStateIsValid)


### PR DESCRIPTION
### Purpose of this PR

CMCL-1325: POV was not handling ReferenceUp correctly.
https://forum.unity.com/threads/regression-referenceup-no-longer-works-with-transpose.1378473/#post-8685612
Introduced in Jun/July 2022 by the fix for [CMCL-1005](https://jira.unity3d.com/browse/CMCL-1005)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
