### PR TITLE
CMCL-1335: Fix priority comparison overflow bug

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Cinemachine Samples can import their package dependencies.
 - CinemachineSmoothPath is upgraded to Splines correctly now. 
 - CinemachinePathBase search radius fixed for not looped paths.
-- Bugfix: priority ordering was wrong when priority values were close to the integer min and max values.
+- Bugfix: priority ordering was wrong when the difference between any priority values were smaller than integer min or bigger than integer max values.
 - Regression fix: POV and PanTilt handle ReferenceUp correctly.
 
 

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Cinemachine Samples can import their package dependencies.
 - CinemachineSmoothPath is upgraded to Splines correctly now. 
 - CinemachinePathBase search radius fixed for not looped paths.
-- Fix priority comparison overflow.
+- Bugfix: priority ordering was wrong when priority values were close to the integer min and max values.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Cinemachine Samples can import their package dependencies.
 - CinemachineSmoothPath is upgraded to Splines correctly now. 
 - CinemachinePathBase search radius fixed for not looped paths.
+- Fix priority comparison overflow.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -183,7 +183,7 @@ namespace Cinemachine
             if (!m_ActiveCamerasAreSorted && m_ActiveCameras.Count > 1)
             {
                 m_ActiveCameras.Sort((x, y) => 
-                    x.Priority == y.Priority ? y.ActivationId - x.ActivationId : y.Priority - x.Priority);
+                    x.Priority == y.Priority ? y.ActivationId.CompareTo(x.ActivationId) : y.Priority.CompareTo(x.Priority));
                 m_ActiveCamerasAreSorted = true;
             }
             return m_ActiveCameras[index];

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -48,7 +48,8 @@ namespace Tests.Runtime
             yield return null;
 
             CmCamera activeCamera;
-            // Check that active vcam is cmCamera. Then disable it and check that the next is now the active one.
+            // Check that activeCamera is equal to cmCamera.
+            // Then disable it and check that the next is now the active one.
             foreach (var cmCamera in m_CmCameras)
             {
                 activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
@@ -65,7 +66,7 @@ namespace Tests.Runtime
             }
             yield return null;
                 
-            // Check that the first CmCamera in the list is the active one
+            // Check that the first CmCamera in the list is equal to activeCamera.
             activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
             Assert.NotNull(activeCamera);
             Assert.That(activeCamera, Is.EqualTo(m_CmCameras[0]));

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -15,14 +15,15 @@ namespace Tests.Runtime
         public override void SetUp()
         {
             base.SetUp();
-
-            m_Brain.DefaultBlend.m_Style = CinemachineBlendDefinition.Style.Cut;
+            
             m_CmCameras = new List<CmCamera>();
         }
 
         [TearDown]
         public override void TearDown()
         {
+            m_CmCameras.Clear();
+            
             base.TearDown();
         }
         
@@ -37,27 +38,25 @@ namespace Tests.Runtime
         [UnityTest, TestCaseSource(nameof(PriorityCases))]
         public IEnumerator CheckPriorityOrder(int[] priorities)
         {
+            yield return null;
+            
             // Create vcams and set priorities
             for (var i = 0; i < priorities.Length; ++i)
             {
                 m_CmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CmCamera)).GetComponent<CmCamera>());
-                m_CmCameras[i].PriorityAndChannel.Enabled = true;
                 m_CmCameras[i].Priority = priorities[i];
             }
-            
-            yield return null;
 
             // Check that active vcam is the current vcam. Then disable it and check that now the next is the active one.
             foreach (var cmCamera in m_CmCameras)
             {
+                yield return null;
+                
                 var activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
                 Assert.NotNull(activeCamera);
                 Assert.That(activeCamera, Is.EqualTo(cmCamera));
                 activeCamera.enabled = false;
-                yield return null;
             }
         }
-        
-        
     }
 }

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -47,7 +47,7 @@ namespace Tests.Runtime
                 m_CmCameras[i].Priority = priorities[i];
             }
 
-            // Check that active vcam is the current vcam. Then disable it and check that now the next is the active one.
+            // Check that active vcam is cmCamera. Then disable it and check that the next is now the active one.
             foreach (var cmCamera in m_CmCameras)
             {
                 yield return null;

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -27,36 +27,48 @@ namespace Tests.Runtime
             base.TearDown();
         }
         
-        static IEnumerable PriorityCases
+        static IEnumerable PriorityValues
         {
+            // Values must be in descending order
             get
             {
                 yield return new TestCaseData(new[] {40, 30, 20, 10, 0, -10, -20, -30, -40}).SetName("Standard").Returns(null);
                 yield return new TestCaseData(new[] {int.MaxValue, int.MaxValue / 2, 0, int.MinValue / 2, int.MinValue}).SetName("Edge-case limits").Returns(null);
             }
         }
-        [UnityTest, TestCaseSource(nameof(PriorityCases))]
+        [UnityTest, TestCaseSource(nameof(PriorityValues))]
         public IEnumerator CheckPriorityOrder(int[] priorities)
         {
-            yield return null;
-            
             // Create vcams and set priorities
             for (var i = 0; i < priorities.Length; ++i)
             {
                 m_CmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CmCamera)).GetComponent<CmCamera>());
                 m_CmCameras[i].Priority = priorities[i];
             }
+            yield return null;
 
+            CmCamera activeCamera;
             // Check that active vcam is cmCamera. Then disable it and check that the next is now the active one.
             foreach (var cmCamera in m_CmCameras)
             {
-                yield return null;
-                
-                var activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
+                activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
                 Assert.NotNull(activeCamera);
                 Assert.That(activeCamera, Is.EqualTo(cmCamera));
                 activeCamera.enabled = false;
+                yield return null;
             }
+
+            // Re-enable all cm cameras
+            foreach (var cmCamera in m_CmCameras)
+            {
+                cmCamera.enabled = true;
+            }
+            yield return null;
+                
+            // Check that the first CmCamera in the list is the active one
+            activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
+            Assert.NotNull(activeCamera);
+            Assert.That(activeCamera, Is.EqualTo(m_CmCameras[0]));
         }
     }
 }

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Cinemachine;
+
+namespace Tests.Runtime
+{
+    [TestFixture]
+    public class PriorityTests : CinemachineRuntimeFixtureBase
+    {
+        List<CmCamera> m_CmCameras;
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            m_Brain.DefaultBlend.m_Style = CinemachineBlendDefinition.Style.Cut;
+            m_CmCameras = new List<CmCamera>();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+        
+        static IEnumerable PriorityCases
+        {
+            get
+            {
+                yield return new TestCaseData(new[] {40, 30, 20, 10, 0, -10, -20, -30, -40}).SetName("Standard").Returns(null);
+                yield return new TestCaseData(new[] {int.MaxValue, int.MaxValue / 2, 0, int.MinValue / 2, int.MinValue}).SetName("Edge-case limits").Returns(null);
+            }
+        }
+        [UnityTest, TestCaseSource(nameof(PriorityCases))]
+        public IEnumerator CheckPriorityOrder(int[] priorities)
+        {
+            // Create vcams and set priorities
+            for (var i = 0; i < priorities.Length; ++i)
+            {
+                m_CmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CmCamera)).GetComponent<CmCamera>());
+                m_CmCameras[i].PriorityAndChannel.Enabled = true;
+                m_CmCameras[i].Priority = priorities[i];
+            }
+            
+            yield return null;
+
+            // Check that active vcam is the current vcam. Then disable it and check that now the next is the active one.
+            foreach (var cmCamera in m_CmCameras)
+            {
+                var activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
+                Assert.NotNull(activeCamera);
+                Assert.That(activeCamera, Is.EqualTo(cmCamera));
+                activeCamera.enabled = false;
+                yield return null;
+            }
+        }
+        
+        
+    }
+}

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs
@@ -10,26 +10,21 @@ namespace Tests.Runtime
     [TestFixture]
     public class PriorityTests : CinemachineRuntimeFixtureBase
     {
-        List<CmCamera> m_CmCameras;
         [SetUp]
         public override void SetUp()
         {
             base.SetUp();
-            
-            m_CmCameras = new List<CmCamera>();
         }
 
         [TearDown]
         public override void TearDown()
         {
-            m_CmCameras.Clear();
-            
             base.TearDown();
         }
         
         static IEnumerable PriorityValues
         {
-            // Values must be in descending order
+            // Values must be in descending order - just so CheckPriorityOrder algorithm is simpler
             get
             {
                 yield return new TestCaseData(new[] {40, 30, 20, 10, 0, -10, -20, -30, -40}).SetName("Standard").Returns(null);
@@ -39,18 +34,19 @@ namespace Tests.Runtime
         [UnityTest, TestCaseSource(nameof(PriorityValues))]
         public IEnumerator CheckPriorityOrder(int[] priorities)
         {
+            var cmCameras = new List<CmCamera>();
             // Create vcams and set priorities
             for (var i = 0; i < priorities.Length; ++i)
             {
-                m_CmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CmCamera)).GetComponent<CmCamera>());
-                m_CmCameras[i].Priority = priorities[i];
+                cmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CmCamera)).GetComponent<CmCamera>());
+                cmCameras[i].Priority = priorities[i];
             }
             yield return null;
 
             CmCamera activeCamera;
             // Check that activeCamera is equal to cmCamera.
             // Then disable it and check that the next is now the active one.
-            foreach (var cmCamera in m_CmCameras)
+            foreach (var cmCamera in cmCameras)
             {
                 activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
                 Assert.NotNull(activeCamera);
@@ -60,16 +56,15 @@ namespace Tests.Runtime
             }
 
             // Re-enable all cm cameras
-            foreach (var cmCamera in m_CmCameras)
-            {
+            foreach (var cmCamera in cmCameras)
                 cmCamera.enabled = true;
-            }
+            
             yield return null;
                 
             // Check that the first CmCamera in the list is equal to activeCamera.
             activeCamera = m_Brain.ActiveVirtualCamera as CmCamera;
             Assert.NotNull(activeCamera);
-            Assert.That(activeCamera, Is.EqualTo(m_CmCameras[0]));
+            Assert.That(activeCamera, Is.EqualTo(cmCameras[0]));
         }
     }
 }

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs.meta
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0e49b269fbe143c1bca9d11c249bb465
+timeCreated: 1672443439


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1335](https://jira.unity3d.com/browse/CMCL-1335): Fix priority comparison bug
https://forum.unity.com/threads/bug-with-priority-in-update-loop.1379367/#post-8692113

Overflow was caused by the comparison functions subtraction. The overflow way is to use compare because it does extra checks to properly compare without overflow.

### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status
- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation