### PR TITLE
CMCL-0000: C# syntax fixes in 2019 and 2020 - cm 2.9

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -336,7 +336,7 @@ namespace Cinemachine
         internal void ValidateInstructions()
         {
             if (m_Instructions == null)
-                m_Instructions = new Instruction[0];
+                m_Instructions = Array.Empty<Instruction>();
             for (int i = 0; i < m_Instructions.Length; ++i)
             {
                 if (m_Instructions[i].m_VirtualCamera != null

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePath.cs
@@ -43,7 +43,7 @@ namespace Cinemachine
         /// <summary>The waypoints that define the path.
         /// They will be interpolated using a bezier curve</summary>
         [Tooltip("The waypoints that define the path.  They will be interpolated using a bezier curve.")]
-        public Waypoint[] m_Waypoints = new Waypoint[0];
+        public Waypoint[] m_Waypoints = Array.Empty<Waypoint>();
 
         /// <summary>The minimum value for the path position</summary>
         public override float MinPos => 0;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -51,7 +51,7 @@ namespace Cinemachine
         /// <summary>The waypoints that define the path.
         /// They will be interpolated using a bezier curve</summary>
         [Tooltip("The waypoints that define the path.  They will be interpolated using a bezier curve.")]
-        public Waypoint[] m_Waypoints = new Waypoint[0];
+        public Waypoint[] m_Waypoints = Array.Empty<Waypoint>();
 
         /// <summary>The minimum value for the path position</summary>
         public override float MinPos => 0;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -400,7 +400,7 @@ namespace Cinemachine
         internal void ValidateInstructions()
         {
             if (m_Instructions == null)
-                m_Instructions = new Instruction[0];
+                m_Instructions = Array.Empty<Instruction>();
             mInstructionDictionary = new Dictionary<int, int>();
             for (int i = 0; i < m_Instructions.Length; ++i)
             {

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -130,7 +130,7 @@ namespace Cinemachine
         [NoSaveDuringPlay]
         [Tooltip("The target objects, together with their weights and radii, that will contribute to the "
             + "group's average position, orientation, and size.")]
-        public Target[] m_Targets = new Target[0];
+        public Target[] m_Targets = Array.Empty<Target>();
 
         float m_MaxWeight;
         Vector3 m_AveragePos;
@@ -139,8 +139,8 @@ namespace Cinemachine
         int m_LastUpdateFrame = -1;
 
         // Caches of valid members so we don't keep checking activeInHierarchy
-        List<int> m_ValidMembers = new ();
-        List<bool> m_MemberValidity = new ();
+        List<int> m_ValidMembers = new List<int>();
+        List<bool> m_MemberValidity = new List<bool>();
         
         void OnValidate()
         {
@@ -157,7 +157,7 @@ namespace Cinemachine
             m_PositionMode = PositionMode.GroupCenter;
             m_RotationMode = RotationMode.Manual;
             m_UpdateMethod = UpdateMethod.LateUpdate;
-            m_Targets = new Target[0];
+            m_Targets = Array.Empty<Target>();
         }
 
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Core/NoiseSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/NoiseSettings.cs
@@ -85,13 +85,13 @@ namespace Cinemachine
         [Tooltip("These are the noise channels for the virtual camera's position. Convincing noise setups "
             + "typically mix low, medium and high frequencies together, so start with a size of 3")]
         [FormerlySerializedAs("m_Position")]
-        public TransformNoiseParams[] PositionNoise = new TransformNoiseParams[0];
+        public TransformNoiseParams[] PositionNoise = Array.Empty<TransformNoiseParams>();
 
         /// <summary>The array of orientation noise channels for this <c>NoiseSettings</c></summary>
         [Tooltip("These are the noise channels for the virtual camera's orientation. Convincing noise "
             + "setups typically mix low, medium and high frequencies together, so start with a size of 3")]
         [FormerlySerializedAs("m_Orientation")]
-        public TransformNoiseParams[] OrientationNoise = new TransformNoiseParams[0];
+        public TransformNoiseParams[] OrientationNoise = Array.Empty<TransformNoiseParams>();
 
         /// <summary>Get the noise signal value at a specific time</summary>
         /// <param name="noiseParams">The parameters that define the noise function</param>


### PR DESCRIPTION
### Purpose of this PR
Fixes some C# syntax that was invalid in unity editor 2019 and 2020