### PR TITLE
CMCL-1324: sort extensions on domain reload for 2.9

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - TargetGroup now ignores members whose gameObjects are inactive.
 - Bugfix: CinemachinePathBase search radius fixed for not looped paths.
 - Bugfix: priority ordering was wrong when the difference between any priority values were smaller than integer min or bigger than integer max values.
+- Bugfix: Extensions were not respecting execution order on domain reload.
 
 
 ## [2.9.4] - 2022-11-18

--- a/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
@@ -40,8 +40,11 @@ namespace Cinemachine
         [UnityEditor.Callbacks.DidReloadScripts]
         static void OnScriptReload()
         {
-            var extensions = Resources.FindObjectsOfTypeAll(
-                typeof(CinemachineExtension)) as CinemachineExtension[];
+            var extensions = Resources.FindObjectsOfTypeAll<CinemachineExtension>();
+            // Sort by execution order
+            System.Array.Sort(extensions, (x, y) => 
+                UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(x)) 
+                    - UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(y)));
             foreach (var e in extensions)
                 e.ConnectToVcam(true);
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1324: sort extensions by execution order on domain reload

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

