### PR TITLE
CMCL-1324: Sort extensions on domain reload.

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CinemachinePathBase search radius fixed for not looped paths.
 - Bugfix: priority ordering was wrong when the difference between any priority values were smaller than integer min or bigger than integer max values.
 - Regression fix: POV and PanTilt handle ReferenceUp correctly.
+- Bugfix: Extensions were not respecting execution order on domain reload.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
@@ -42,8 +42,11 @@ namespace Cinemachine
         [UnityEditor.Callbacks.DidReloadScripts]
         static void OnScriptReload()
         {
-            var extensions = Resources.FindObjectsOfTypeAll(
-                typeof(CinemachineExtension)) as CinemachineExtension[];
+            var extensions = Resources.FindObjectsOfTypeAll<CinemachineExtension>();
+            // Sort by execution order
+            System.Array.Sort(extensions, (x, y) => 
+                UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(y)) 
+                    - UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(x)));
             foreach (var e in extensions)
                 e.ConnectToVcam(true);
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1324: Extensions were not respecting execution order on domain reload.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

