### PR TITLE
CMCL-1324: Sort extensions on domain reload for 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: VirtualCameras did not set the focal length property of physical cameras.
 - CinemachinePathBase search radius fixed for not looped paths.
 - Regression fix: POV was not handling ReferenceUp correctly
+- Bugfix: Extensions were not respecting execution order on domain reload.
 
 
 ## [2.8.9] - 2022-08-24

--- a/Runtime/Core/CinemachineExtension.cs
+++ b/Runtime/Core/CinemachineExtension.cs
@@ -40,8 +40,11 @@ namespace Cinemachine
         [UnityEditor.Callbacks.DidReloadScripts]
         static void OnScriptReload()
         {
-            var extensions = Resources.FindObjectsOfTypeAll(
-                typeof(CinemachineExtension)) as CinemachineExtension[];
+            var extensions = Resources.FindObjectsOfTypeAll<CinemachineExtension>();
+            // Sort by execution order
+            System.Array.Sort(extensions, (x, y) => 
+                UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(x)) 
+                    - UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(y)));
             foreach (var e in extensions)
                 e.ConnectToVcam(true);
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1324: Extensions were not respecting execution order on domain reload.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low