### PR TITLE
CMCL-1315: damping stability for uneven framerates

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CinemachinePathBase search radius fixed for not looped paths.
 - Bugfix: priority ordering was wrong when the difference between any priority values were smaller than integer min or bigger than integer max values.
 - Regression fix: POV and PanTilt handle ReferenceUp correctly.
+- Improved performance of CINEMACHINE_EXPERIMENTAL_DAMPING algorithm.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Core/Predictor.cs
+++ b/com.unity.cinemachine/Runtime/Core/Predictor.cs
@@ -139,7 +139,7 @@ namespace Cinemachine.Utility
         /// <returns>The damped amount.  This will be the original amount scaled by
         /// a value between 0 and 1.</returns>
         // Internal for testing
-        public static float StandardDamp(float initial, float dampTime, float deltaTime)
+        internal static float StandardDamp(float initial, float dampTime, float deltaTime)
         {
             if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
                 return initial;
@@ -164,7 +164,7 @@ namespace Cinemachine.Utility
         /// <returns>The damped amount.  This will be the original amount scaled by
         /// a value between 0 and 1.</returns>
         // Internal for testing
-        public static float StableDamp(float initial, float dampTime, float deltaTime)
+        internal static float StableDamp(float initial, float dampTime, float deltaTime)
         {
             if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
                 return initial;

--- a/com.unity.cinemachine/Runtime/Core/Predictor.cs
+++ b/com.unity.cinemachine/Runtime/Core/Predictor.cs
@@ -97,25 +97,7 @@ namespace Cinemachine.Utility
             if (deltaTime < Epsilon)
                 return 0;
             float k = -kLogNegligibleResidual / dampTime; //DecayConstant(dampTime, kNegligibleResidual);
-
-#if CINEMACHINE_EXPERIMENTAL_DAMPING
-            // Try to reduce damage caused by frametime variability
-            float step = Time.fixedDeltaTime;
-            if (deltaTime != step)
-                step /= 5;
-            int numSteps = Mathf.FloorToInt(deltaTime / step);
-            float vel = initial * step / deltaTime;
-            float decayConstant = Mathf.Exp(-k * step);
-            float r = 0;
-            for (int i = 0; i < numSteps; ++i)
-                r = (r + vel) * decayConstant;
-            float d = deltaTime - (step * numSteps);
-            if (d > Epsilon)
-                r = Mathf.Lerp(r, (r + vel) * decayConstant, d / step);
-            return initial - r;
-#else
             return initial * (1 - Mathf.Exp(-k * deltaTime));
-#endif
         }
 
         /// <summary>Get a damped version of a quantity.  This is the portion of the
@@ -142,6 +124,87 @@ namespace Cinemachine.Utility
         /// <returns>The damped amount.  This will be the original amount scaled by
         /// a value between 0 and 1.</returns>
         public static Vector3 Damp(Vector3 initial, float dampTime, float deltaTime)
+        {
+            for (int i = 0; i < 3; ++i)
+                initial[i] = Damp(initial[i], dampTime, deltaTime);
+            return initial;
+        }
+
+        /// <summary>Get a damped version of a quantity.  This is the portion of the
+        /// quantity that will take effect over the given time.
+        /// 
+        /// This is a special implementation designed to compensate for the effects of a 
+        /// variable timestep, for use in cases where the amount to be damped is proportional
+        /// to deltaTime.
+        /// </summary>
+        /// <param name="initial">The amount that will be damped</param>
+        /// <param name="dampTime">The rate of damping.  This is the time it would
+        /// take to reduce the original amount to a negligible percentage</param>
+        /// <param name="deltaTime">The time over which to damp</param>
+        /// <returns>The damped amount.  This will be the original amount scaled by
+        /// a value between 0 and 1.</returns>
+        public static float SteppedDamp(float initial, float dampTime, float deltaTime)
+        {
+            if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
+                return initial;
+            if (deltaTime < Epsilon)
+                return 0;
+            float k = -kLogNegligibleResidual / dampTime; //DecayConstant(dampTime, kNegligibleResidual);
+
+#if CINEMACHINE_EXPERIMENTAL_DAMPING
+            // Try to reduce damage caused by frametime variability
+            float step = Time.fixedDeltaTime;
+            if (deltaTime != step)
+                step /= 5;
+            int numSteps = Mathf.FloorToInt(deltaTime / step);
+            float vel = initial * step / deltaTime;
+            float decayConstant = Mathf.Exp(-k * step);
+            float r = 0;
+            for (int i = 0; i < numSteps; ++i)
+                r = (r + vel) * decayConstant;
+            float d = deltaTime - (step * numSteps);
+            if (d > Epsilon)
+                r = Mathf.Lerp(r, (r + vel) * decayConstant, d / step);
+            return initial - r;
+#else
+            return initial * (1 - Mathf.Exp(-k * deltaTime));
+#endif
+        }
+
+        /// <summary>Get a damped version of a quantity.  This is the portion of the
+        /// quantity that will take effect over the given time.
+        /// 
+        /// This is a special implementation designed to compensate for the effects of a 
+        /// variable timestep, for use in cases where the amount to be damped is proportional
+        /// to deltaTime.
+        /// </summary>
+        /// <param name="initial">The amount that will be damped</param>
+        /// <param name="dampTime">The rate of damping.  This is the time it would
+        /// take to reduce the original amount to a negligible percentage</param>
+        /// <param name="deltaTime">The time over which to damp</param>
+        /// <returns>The damped amount.  This will be the original amount scaled by
+        /// a value between 0 and 1.</returns>
+        public static Vector3 SteppedDamp(Vector3 initial, Vector3 dampTime, float deltaTime)
+        {
+            for (int i = 0; i < 3; ++i)
+                initial[i] = SteppedDamp(initial[i], dampTime[i], deltaTime);
+            return initial;
+        }
+
+        /// <summary>Get a damped version of a quantity.  This is the portion of the
+        /// quantity that will take effect over the given time.
+        /// 
+        /// This is a special implementation designed to compensate for the effects of a 
+        /// variable timestep, for use in cases where the amount to be damped is proportional
+        /// to deltaTime.
+        /// </summary>
+        /// <param name="initial">The amount that will be damped</param>
+        /// <param name="dampTime">The rate of damping.  This is the time it would
+        /// take to reduce the original amount to a negligible percentage</param>
+        /// <param name="deltaTime">The time over which to damp</param>
+        /// <returns>The damped amount.  This will be the original amount scaled by
+        /// a value between 0 and 1.</returns>
+        public static Vector3 SteppedDamp(Vector3 initial, float dampTime, float deltaTime)
         {
             for (int i = 0; i < 3; ++i)
                 initial[i] = Damp(initial[i], dampTime, deltaTime);

--- a/com.unity.cinemachine/Runtime/Core/Predictor.cs
+++ b/com.unity.cinemachine/Runtime/Core/Predictor.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Cinemachine.Utility
 {
@@ -92,43 +93,11 @@ namespace Cinemachine.Utility
         /// a value between 0 and 1.</returns>
         public static float Damp(float initial, float dampTime, float deltaTime)
         {
-            if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
-                return initial;
-            if (deltaTime < Epsilon)
-                return 0;
-
-#if true || CINEMACHINE_EXPERIMENTAL_DAMPING
-            // Try to reduce damage caused by frametime variability, by pretending
-            // that the value to decay has accumulated steadily over many constant-time subframes.
-            // We simulate being called each subframe.
-            // This does result in a longer damping time.
-            float step = Mathf.Min(deltaTime, Time.fixedDeltaTime / 16);
-            int numSteps = Mathf.FloorToInt(deltaTime / step);
-            float vel = initial * step / deltaTime; // the amount that accumulates each subframe
-            float k = -kLogNegligibleResidual / dampTime; //DecayConstant(dampTime, kNegligibleResidual);
-            k = Mathf.Exp(-k * step);
-
-            // ====================================
-            // This code is equivalent to:
-            //     float r = 0;
-            //     for (int i = 0; i < numSteps; ++i)
-            //         r = (r + vel) * k;
-            float r = vel;
-            if (Mathf.Abs(k - 1) < Epsilon)
-                r *= k * numSteps;
-            else
-            {
-                r *= k - Mathf.Pow(k, numSteps + 1);
-                r /= 1 - k;
-            }
-            // ====================================
-
-            r = Mathf.Lerp(r, (r + vel) * k, (deltaTime - (step * numSteps)) / step);
-            return initial - r;
-#else
-            float k = -kLogNegligibleResidual / dampTime; //DecayConstant(dampTime, kNegligibleResidual);
-            return initial * (1 - Mathf.Exp(-k * deltaTime));
+#if CINEMACHINE_EXPERIMENTAL_DAMPING
+            if (!Time.inFixedTimeStep)
+                return StableDamp(initial, dampTime, deltaTime);
 #endif
+            return StandardDamp(initial, dampTime, deltaTime);
         }
 
         /// <summary>Get a damped version of a quantity.  This is the portion of the
@@ -159,6 +128,162 @@ namespace Cinemachine.Utility
             for (int i = 0; i < 3; ++i)
                 initial[i] = Damp(initial[i], dampTime, deltaTime);
             return initial;
+        }
+
+        /// <summary>Get a damped version of a quantity.  This is the portion of the
+        /// quantity that will take effect over the given time.</summary>
+        /// <param name="initial">The amount that will be damped</param>
+        /// <param name="dampTime">The rate of damping.  This is the time it would
+        /// take to reduce the original amount to a negligible percentage</param>
+        /// <param name="deltaTime">The time over which to damp</param>
+        /// <returns>The damped amount.  This will be the original amount scaled by
+        /// a value between 0 and 1.</returns>
+        // Internal for testing
+        public static float StandardDamp(float initial, float dampTime, float deltaTime)
+        {
+            if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
+                return initial;
+            if (deltaTime < Epsilon)
+                return 0;
+            return initial * (1 - Mathf.Exp(kLogNegligibleResidual * deltaTime / dampTime));
+        }
+
+        /// <summary>
+        /// Get a damped version of a quantity.  This is the portion of the
+        /// quantity that will take effect over the given time.
+        /// 
+        /// This is a special implementation that attempts to increase visual stability 
+        /// in the context of an unstable framerate.
+        /// 
+        /// It relies on AverageFrameRateTracker to track the average framerate.
+        /// </summary>
+        /// <param name="initial">The amount that will be damped</param>
+        /// <param name="dampTime">The rate of damping.  This is the time it would
+        /// take to reduce the original amount to a negligible percentage</param>
+        /// <param name="deltaTime">The time over which to damp</param>
+        /// <returns>The damped amount.  This will be the original amount scaled by
+        /// a value between 0 and 1.</returns>
+        // Internal for testing
+        public static float StableDamp(float initial, float dampTime, float deltaTime)
+        {
+            if (dampTime < Epsilon || Mathf.Abs(initial) < Epsilon)
+                return initial;
+            if (deltaTime < Epsilon)
+                return 0;
+
+            // Try to reduce damage caused by frametime variability, by pretending
+            // that the value to decay has accumulated steadily over many constant-time subframes.
+            // We simulate being called for each subframe.  This does result in a longer damping time,
+            // so we compensate with AverageFrameRateTracker.DampTimeScale, which is calculated
+            // every frame based on the average framerate over the past number of frames.
+            float step = Mathf.Min(deltaTime, AverageFrameRateTracker.kSubframeTime);
+            int numSteps = Mathf.FloorToInt(deltaTime / step);
+            float vel = initial * step / deltaTime; // the amount that accumulates each subframe
+            float k = Mathf.Exp(kLogNegligibleResidual * AverageFrameRateTracker.DampTimeScale * step / dampTime);
+
+            // ====================================
+            // This code is equivalent to:
+            //     float r = 0;
+            //     for (int i = 0; i < numSteps; ++i)
+            //         r = (r + vel) * k;
+            // (partial sum of geometric series)
+            float r = vel;
+            if (Mathf.Abs(k - 1) < Epsilon)
+                r *= k * numSteps;
+            else
+            {
+                r *= k - Mathf.Pow(k, numSteps + 1);
+                r /= 1 - k;
+            }
+            // ====================================
+
+            // Handle any remaining quantity after the last step
+            r = Mathf.Lerp(r, (r + vel) * k, (deltaTime - (step * numSteps)) / step);
+
+            return initial - r;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoad]
+#endif
+        // Internal for testing.
+        // This class keeps a running calculation of the average framerate over a fixed
+        // time window.  Used to smooth out framerate fluctuations for determining the
+        // correct damping constant.
+        internal static class AverageFrameRateTracker
+        {
+            const int kBufferSize = 100;
+
+            static float[] s_Buffer = new float[kBufferSize];
+            static int s_NumItems = 0;
+            static int s_Head = 0;
+            static float s_Sum = 0;
+
+            public const float kSubframeTime = 1.0f / 1024.0f; // Do not change this without also changing SetDampTimeScale()
+
+            public static float FPS { get; private set; }
+            public static float DampTimeScale { get; private set; }
+
+#if UNITY_EDITOR
+            static AverageFrameRateTracker() => Reset();
+#endif
+
+            [RuntimeInitializeOnLoadMethod]
+            static void Initialize()
+            {
+#if CINEMACHINE_EXPERIMENTAL_DAMPING
+                // GML TODO: use a different hook
+                Application.onBeforeRender -= Append;
+                Application.onBeforeRender += Append;
+
+                SceneManager.sceneLoaded -= OnSceneLoaded;
+                SceneManager.sceneLoaded += OnSceneLoaded;
+#endif
+                Reset();
+            }
+
+            static void OnSceneLoaded(Scene scene, LoadSceneMode mode) => Reset();
+
+            // Internal for testing
+            internal static void Reset()
+            {
+                s_NumItems = 0;
+                s_Head = 0;
+                s_Sum = 0;
+                FPS = 60;
+                SetDampTimeScale(FPS);
+            }
+
+            static void Append()
+            {
+#if UNITY_EDITOR
+                if (!Application.isPlaying)
+                {
+                    Reset();
+                    return;
+                }
+#endif
+                var dt = Time.unscaledDeltaTime;
+                if (++s_Head == kBufferSize)
+                    s_Head = 0;
+                if (s_NumItems == kBufferSize)
+                    s_Sum -= s_Buffer[s_Head];
+                else
+                    ++s_NumItems;
+                s_Sum += dt;
+                s_Buffer[s_Head] = dt;
+
+                FPS = s_NumItems / s_Sum;
+                SetDampTimeScale(FPS);
+            }
+
+            // Internal for testing
+            internal static void SetDampTimeScale(float fps) 
+            {
+                // Approximation computed heuristically, and curve-fitted to sampled data.
+                // Valid only for kSubframeTime = 1.0f / 1024.0f
+                DampTimeScale = 2.0f - 1.81e-3f * fps + 7.9e-07f * fps * fps;
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1315: CM's damping is highly sensitive to uneven frame rates, and this can lead to jitter. CINEMACHINE_EXPERIMENTAL_DAMPING is there to address this, and it works, but at an unacceptable performance cost. 
- This PR significantly improves the performance of the stable damping algorithm (replaces a loop with a fixed calculation).  
- Also, the stable algorithm took longer to damp, so its behaviour was noticeably different from the standard algorithm.  Researched a solution for this and added some code to compensate for it, resulting in the same damping time for both algorithms.
- Added StableDampFloat test, to ensure that behaviour is consistent across both methods.

The code is still opt-in, based on the CINEMACHINE_EXPERIMENTAL_DAMPING define.  We might consider changing that.

Smoothing isn't perfect, but it's noticeably better with the stable version - especially when following fast-moving objects.  

Standard damping, with wildly fluctuating framerate:
![UnstableDamping](https://user-images.githubusercontent.com/6424658/213726798-94fc5e5f-914b-4e88-9f58-7a4c42dfd37f.gif)

Stable damping, with wildly fluctuating framerate:
![StableDamping](https://user-images.githubusercontent.com/6424658/213726851-f293b56c-ad07-436e-a0b6-4fccd0fbf04c.gif)

For the damp time compensation, I sampled it and used google sheets to fit a curve.
![image](https://user-images.githubusercontent.com/6424658/213748242-dc4ec469-8b33-4c9c-aa85-9705cca84fc6.png)

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

