### PR TITLE
CMCL-1341: Fix InstructionList - Blendlist and StateDriven

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlendListCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlendListCameraEditor.cs
@@ -59,6 +59,8 @@ namespace Cinemachine.Editor
                 EditorGUILayout.Separator();
                 if (m_ChildListHelper.OnInspectorGUI(FindProperty(x => x.m_ChildCameras)))
                     Target.ValidateInstructions();
+                if (EditorGUI.EndChangeCheck()) 
+                    serializedObject.ApplyModifiedProperties();
             }
             else
             {

--- a/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -105,6 +105,8 @@ namespace Cinemachine.Editor
             EditorGUILayout.Separator();
             if (m_ChildListHelper.OnInspectorGUI(FindProperty(x => x.m_ChildCameras)))
                 Target.ValidateInstructions();
+            if (EditorGUI.EndChangeCheck()) 
+                serializedObject.ApplyModifiedProperties();
 
             // Extensions
             DrawExtensionsWidgetInInspector();


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1341](https://jira.unity3d.com/browse/CMCL-1341): Instruction lists were not reacting to interaction in the inspector (changing order, or modifying values).

The bug was not yet released. It was introduced by https://github.com/Unity-Technologies/com.unity.cinemachine/pull/716. 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 