### PR TITLE
CMCL-0000 axis state delta time pause bugfix

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+- Bugfix: AxisState was not respecting timescale == 0
+
+
 ## [2.9.5] - 2023-01-16
 - Unity 2022.2 and up: FocusDistance added to lens settings and is pushed to the camera.
 - Optimized path gizmo drawing.  Now 3-5 times faster.

--- a/com.unity.cinemachine/Runtime/Core/AxisState.cs
+++ b/com.unity.cinemachine/Runtime/Core/AxisState.cs
@@ -211,7 +211,7 @@ namespace Cinemachine
             m_LastUpdateFrame = Time.frameCount;
 
             // Cheating: we want the render frame time, not the fixed frame time
-            if (deltaTime >= 0 && m_LastUpdateTime != 0) 
+            if (deltaTime > 0 && m_LastUpdateTime != 0) 
                 deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
             
             m_LastUpdateTime = Time.realtimeSinceStartup;
@@ -422,7 +422,7 @@ namespace Cinemachine
             public void DoRecentering(ref AxisState axis, float deltaTime, float recenterTarget)
             {
                 // Cheating: we want the render frame time, not the fixed frame time
-                if (deltaTime >= 0)
+                if (deltaTime > 0)
                     deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
                 
                 m_LastUpdateTime = Time.realtimeSinceStartup;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1344
See description and repro scene there.

Bugfix: AxisState was not respecting timescale == 0

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

