### PR TITLE
CMCL-1345: fix for 3.0 axis state respects timescale=0

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Path gizmo drawing was optimized.
 - Confiner2D provides API to adjust the confiner to the current window size when the lens or aspect changes.
 - Confiner2D does less gc alloc.
+## [Unreleased] 
+- Bugfix: AxisState was not respecting timescale == 0
+
+
+## [2.9.5] - 2023-01-16
+- Unity 2022.2 and up: FocusDistance added to lens settings and is pushed to the camera.
+- Optimized path gizmo drawing.  Now 3-5 times faster.
 - TargetGroup now ignores members whose gameObjects are inactive.
 - CinemachineConfiner is deprecated.  New behaviour CinemachineConfiner3D to handle 3D confining.  Use CinemachineConfiner2D for 2D confining.
 - Cinemachine Samples can import their package dependencies.

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -15,13 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Path gizmo drawing was optimized.
 - Confiner2D provides API to adjust the confiner to the current window size when the lens or aspect changes.
 - Confiner2D does less gc alloc.
-## [Unreleased] 
-- Bugfix: AxisState was not respecting timescale == 0
-
-
-## [2.9.5] - 2023-01-16
-- Unity 2022.2 and up: FocusDistance added to lens settings and is pushed to the camera.
-- Optimized path gizmo drawing.  Now 3-5 times faster.
 - TargetGroup now ignores members whose gameObjects are inactive.
 - CinemachineConfiner is deprecated.  New behaviour CinemachineConfiner3D to handle 3D confining.  Use CinemachineConfiner2D for 2D confining.
 - Cinemachine Samples can import their package dependencies.
@@ -31,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Regression fix: POV and PanTilt handle ReferenceUp correctly.
 - Bugfix: Extensions were not respecting execution order on domain reload.
 - Add SplineAutoDolly.ISplineAutoDolly.Reset() method and SplineAutoDolly.Enabled flag.
+- Bugfix: AxisState was not respecting timescale == 0
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Deprecated/AxisState.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/AxisState.cs
@@ -221,7 +221,7 @@ namespace Cinemachine
             m_LastUpdateFrame = Time.frameCount;
 
             // Cheating: we want the render frame time, not the fixed frame time
-            if (deltaTime >= 0 && m_LastUpdateTime != 0) 
+            if (deltaTime > 0 && m_LastUpdateTime != 0) 
                 deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
             
             m_LastUpdateTime = Time.realtimeSinceStartup;
@@ -437,7 +437,7 @@ namespace Cinemachine
             public void DoRecentering(ref AxisState axis, float deltaTime, float recenterTarget)
             {
                 // Cheating: we want the render frame time, not the fixed frame time
-                if (deltaTime >= 0)
+                if (deltaTime > 0)
                     deltaTime = Time.realtimeSinceStartup - m_LastUpdateTime;
                 
                 m_LastUpdateTime = Time.realtimeSinceStartup;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1345

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

