### PR TITLE
CMCL-0000: extension refactor

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: AxisState was not respecting timescale == 0
 - CmCamera is now CinemachineCamera.
 - Confiner2D and Confiner3D support smooth stop at bounds edge.
+- CinemachineExtension API changes to VirtualCamera, GetAllExtraStates, OnTargetObjectWarped, and ForceCameraPosition.
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
@@ -49,20 +49,8 @@ namespace Cinemachine.Editor
             
             var oversizedCameraHelp = ux.AddChild(new HelpBox(
                 "The camera window is too big for the confiner. Enable the Oversize Window option.",
-               HelpBoxMessageType.Info));
+                HelpBoxMessageType.Info));
 
-            UpdateOversizedCameraHelpVisibility();
-            ux.schedule.Execute(UpdateOversizedCameraHelpVisibility).Every(100);
-            void UpdateOversizedCameraHelpVisibility() 
-            {
-                oversizedCameraHelp.SetVisible(false);
-                if (Target == null)
-                    return; // target deleted
-                
-                if (!Target.OversizeWindow.Enabled) 
-                    oversizedCameraHelp.SetVisible(Target.IsCameraTooBigForTheConfiner(Target.VirtualCamera));
-            }
-            
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.OversizeWindow)));
 
             var bakeProgress = ux.AddChild(new ProgressBar { lowValue = 0, highValue = 100 });
@@ -79,6 +67,7 @@ namespace Cinemachine.Editor
                 if (Target == null)
                     return; // target deleted
                 
+                oversizedCameraHelp.SetVisible(!Target.OversizeWindow.Enabled && Target.IsCameraLensOversized());
                 if (!Target.OversizeWindow.Enabled)
                 {
                     bakeTimeout.SetVisible(false);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner3DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner3DEditor.cs
@@ -48,7 +48,7 @@ namespace Cinemachine.Editor
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineConfiner3D))]
         private static void DrawColliderGizmos(CinemachineConfiner3D confiner, GizmoType type)
         {
-            CinemachineVirtualCameraBase vcam = (confiner != null) ? confiner.VirtualCamera : null;
+            CinemachineVirtualCameraBase vcam = (confiner != null) ? confiner.ComponentOwner : null;
             if (vcam != null && confiner.IsValid)
             {
                 var oldMatrix = Gizmos.matrix;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
@@ -37,7 +37,7 @@ namespace Cinemachine.Editor
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineDeoccluder))]
         static void DrawColliderGizmos(CinemachineDeoccluder collider, GizmoType type)
         {
-            CinemachineVirtualCameraBase vcam = (collider != null) ? collider.VirtualCamera : null;
+            CinemachineVirtualCameraBase vcam = (collider != null) ? collider.ComponentOwner : null;
             if (vcam != null && collider.enabled)
             {
                 Color oldColor = Gizmos.color;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -47,8 +47,8 @@ namespace Cinemachine
                 {
                     Undo.RecordObject(Target, "add modifier");
                     var m = (CinemachineFreeLookModifier.Modifier)Activator.CreateInstance(type);
-                    m.RefreshCache(Target.VirtualCamera);
-                    m.Reset(Target.VirtualCamera);
+                    m.RefreshCache(Target.ComponentOwner);
+                    m.Reset(Target.ComponentOwner);
                     Target.Modifiers.Add(m);
                 }
             }
@@ -86,7 +86,7 @@ namespace Cinemachine
                 if (GUI.Button(r, m_ResetModifierLabel))
                 {
                     Undo.RecordObject(Target, "reset modifier");
-                    m.Reset(Target.VirtualCamera);
+                    m.Reset(Target.ComponentOwner);
                 }
                 r.x += r.width;
                 if (GUI.Button(r, m_DeleteModifierLabel))

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -82,13 +82,13 @@ namespace Cinemachine.Editor
             ICinemachineTargetGroup group = null;
             for (int i = 0; group == null && i < targets.Length; ++i)
             {
-                var vcam = (targets[i] as CinemachineGroupFraming).VirtualCamera;
+                var vcam = (targets[i] as CinemachineGroupFraming).ComponentOwner;
                 if (vcam != null)
                     group = vcam.FollowTargetAsGroup;
             }
             m_GroupSizeIsZeroHelp.SetVisible(group != null && group.Sphere.radius < 0.01f);
 
-            bool ortho = Target.VirtualCamera != null && Target.VirtualCamera.State.Lens.Orthographic;
+            bool ortho = Target.ComponentOwner != null && Target.ComponentOwner.State.Lens.Orthographic;
             m_PerspectiveControls.SetVisible(!ortho);
             m_OrthoControls.SetVisible(ortho);
         }
@@ -101,7 +101,7 @@ namespace Cinemachine.Editor
             if (brain == null || (brain.OutputCamera.activeTexture != null && CinemachineCore.Instance.BrainCount > 1))
                 return;
 
-            var vcam = Target.VirtualCamera;
+            var vcam = Target.ComponentOwner;
             if (!brain.IsValidChannel(vcam))
                 return;
 
@@ -118,7 +118,7 @@ namespace Cinemachine.Editor
         static void DrawGroupComposerGizmos(CinemachineGroupFraming target, GizmoType selectionType)
         {
             // Show the group bounding box, as viewed from the camera position
-            if (target.enabled && target.VirtualCamera != null && target.VirtualCamera.FollowTargetAsGroup != null)
+            if (target.enabled && target.ComponentOwner != null && target.ComponentOwner.FollowTargetAsGroup != null)
             {
                 var oldM = Gizmos.matrix;
                 var oldC = Gizmos.color;
@@ -126,7 +126,7 @@ namespace Cinemachine.Editor
                 Gizmos.matrix = target.GroupBoundsMatrix;
                 Bounds b = target.GroupBounds;
                 Gizmos.color = Color.yellow;
-                if (target.VirtualCamera.State.Lens.Orthographic)
+                if (target.ComponentOwner.State.Lens.Orthographic)
                     Gizmos.DrawWireCube(b.center, b.size);
                 else
                 {

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineConfinerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineConfinerEditor.cs
@@ -17,7 +17,7 @@ namespace Cinemachine.Editor
         protected override void GetExcludedPropertiesInInspector(List<string> excluded)
         {
             base.GetExcludedPropertiesInInspector(excluded);
-            CinemachineBrain brain = CinemachineCore.Instance.FindPotentialTargetBrain(Target.VirtualCamera);
+            CinemachineBrain brain = CinemachineCore.Instance.FindPotentialTargetBrain(Target.ComponentOwner);
             bool ortho = brain != null ? brain.OutputCamera.orthographic : false;
             if (!ortho)
                 excluded.Add(FieldPath(x => x.m_ConfineScreenEdges));
@@ -85,7 +85,7 @@ namespace Cinemachine.Editor
         [DrawGizmo(GizmoType.Active | GizmoType.Selected, typeof(CinemachineConfiner))]
         private static void DrawColliderGizmos(CinemachineConfiner confiner, GizmoType type)
         {
-            CinemachineVirtualCameraBase vcam = (confiner != null) ? confiner.VirtualCamera : null;
+            CinemachineVirtualCameraBase vcam = (confiner != null) ? confiner.ComponentOwner : null;
             if (vcam != null && confiner.IsValid)
             {
                 Matrix4x4 oldMatrix = Gizmos.matrix;

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -69,7 +69,7 @@ namespace Cinemachine.Editor
                 else
                 {
                     var x = targets[i] as CinemachineExtension;
-                    if (x != null && x.VirtualCamera == null)
+                    if (x != null && x.ComponentOwner == null)
                         Undo.AddComponent<CinemachineCamera>(x.gameObject).AddExtension(x);
                 }
             }
@@ -99,15 +99,15 @@ namespace Cinemachine.Editor
                 else
                 {
                     var x = targets[i] as CinemachineExtension;
-                    noCamera |= x.VirtualCamera == null;
+                    noCamera |= x.ComponentOwner == null;
                     switch (m_RequiredTargets)
                     {
-                        case RequiredTargets.Follow: noTarget |= noCamera || x.VirtualCamera.Follow == null; break;
-                        case RequiredTargets.LookAt: noTarget |= noCamera || x.VirtualCamera.LookAt == null; break;
-                        case RequiredTargets.FollowGroup: noTarget |= noCamera || x.VirtualCamera.FollowTargetAsGroup == null; break;
+                        case RequiredTargets.Follow: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
+                        case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
+                        case RequiredTargets.FollowGroup: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
                         default: break;
                     }
-                    noTarget = noCamera || x.VirtualCamera.Follow == null;
+                    noTarget = noCamera || x.ComponentOwner.Follow == null;
                 }
             }
             if (m_NoCameraHelp != null)
@@ -142,15 +142,15 @@ namespace Cinemachine.Editor
                 else
                 {
                     var x = targets[i] as CinemachineExtension;
-                    noCamera |= x.VirtualCamera == null;
+                    noCamera |= x.ComponentOwner == null;
                     switch (requiredTargets)
                     {
-                        case RequiredTargets.Follow: noTarget |= noCamera || x.VirtualCamera.Follow == null; break;
-                        case RequiredTargets.LookAt: noTarget |= noCamera || x.VirtualCamera.LookAt == null; break;
-                        case RequiredTargets.FollowGroup: noTarget |= noCamera || x.VirtualCamera.FollowTargetAsGroup == null; break;
+                        case RequiredTargets.Follow: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
+                        case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
+                        case RequiredTargets.FollowGroup: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
                         default: break;
                     }
-                    noTarget = noCamera || x.VirtualCamera.Follow == null;
+                    noTarget = noCamera || x.ComponentOwner.Follow == null;
                 }
             }
             if (noCamera)

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -159,7 +159,7 @@ namespace Cinemachine
             m_extraStateCache ??= new();
             GetAllExtraStates(m_extraStateCache);
             foreach (var extra in m_extraStateCache)
-                if (extra.vcam != null && extra.vcam.Follow == target)
+                if (extra.Vcam != null && extra.Vcam.Follow == target)
                     extra.PreviousCameraPosition += positionDelta;
         }
 
@@ -174,7 +174,7 @@ namespace Cinemachine
             GetAllExtraStates(m_extraStateCache);
             foreach (var extra in m_extraStateCache)
             {
-                if (extra.vcam != null)
+                if (extra.Vcam != null)
                 {
                     extra.BakedSolution = null;
                     extra.AspectRatio = 0;
@@ -219,7 +219,6 @@ namespace Cinemachine
                     return; // invalid path
 
                 var extra = GetExtraState<VcamExtraState>(vcam);
-                extra.vcam = vcam;
                 var camPos = state.GetCorrectedPosition();
 
                 // Make sure we have a solution for our current frustum size
@@ -313,9 +312,8 @@ namespace Cinemachine
             return Mathf.Abs(frustumHeight);
         }
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
-            public CinemachineVirtualCameraBase vcam;
             public ConfinerOven.BakedSolution BakedSolution;
             
             public Vector3 PreviousDisplacement;
@@ -498,7 +496,7 @@ namespace Cinemachine
             m_extraStateCache ??= new();
             GetAllExtraStates(m_extraStateCache);
             foreach (var e in m_extraStateCache)
-                if (e.vcam != null && e.BakedSolution != null)
+                if (e.Vcam != null && e.BakedSolution != null)
                     currentPath.AddRange(e.BakedSolution.GetBakedPath());
             return originalPath != null;
         }
@@ -522,7 +520,7 @@ namespace Cinemachine
             GetAllExtraStates(m_extraStateCache);
             foreach (var extra in m_extraStateCache)
             {
-                if (extra.vcam != null && extra.BakedSolution != null)
+                if (extra.Vcam != null && extra.BakedSolution != null)
                 {
                     var solution = extra.BakedSolution.m_Solution;
                     if (solution.Count == 1 && solution[0].Count == 1)
@@ -540,9 +538,9 @@ namespace Cinemachine
             GetAllExtraStates(m_extraStateCache);
             foreach (var extra in m_extraStateCache)
             {
-                if (extra.vcam != null)
+                if (extra.Vcam != null)
                 {
-                    var state = extra.vcam.State;
+                    var state = extra.Vcam.State;
                     var lens = state.Lens;
                     var deltaW = m_ShapeCache.DeltaWorldToBaked;
                     var frustum = CalculateHalfFrustumHeight(lens, deltaW.MultiplyPoint3x4(state.GetCorrectedPosition()).z);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner3D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner3D.cs
@@ -49,9 +49,8 @@ namespace Cinemachine
             SlowingDistance = Mathf.Max(0, SlowingDistance);
         }
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
-            public CinemachineVirtualCameraBase vcam;
             public Vector3 PreviousDisplacement;
             public Vector3 PreviousCameraPosition;
         };
@@ -79,7 +78,7 @@ namespace Cinemachine
             m_extraStateCache ??= new();
             GetAllExtraStates(m_extraStateCache);
             foreach (var extra in m_extraStateCache)
-                if (extra.vcam != null && extra.vcam.Follow == target)
+                if (extra.Vcam != null && extra.Vcam.Follow == target)
                     extra.PreviousCameraPosition += positionDelta;
         }
         
@@ -97,7 +96,6 @@ namespace Cinemachine
             if (stage == CinemachineCore.Stage.Body && IsValid)
             {
                 var extra = GetExtraState<VcamExtraState>(vcam);
-                extra.vcam = vcam;
                 var camPos = state.GetCorrectedPosition();
 
                 // Snap the point inside the bounds

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -289,16 +289,20 @@ namespace Cinemachine
             }
         };
 
+        List<VcamExtraState> m_extraStateCache;
+
         /// <summary>Inspector API for debugging collision resolution path</summary>
-        public List<List<Vector3>> DebugPaths
+        internal List<List<Vector3>> DebugPaths
         {
             get
             {
                 List<List<Vector3>> list = new List<List<Vector3>>();
-                List<VcamExtraState> extraStates = GetAllExtraStates<VcamExtraState>();
-                foreach (var v in extraStates)
-                    if (v.DebugResolutionPath != null && v.DebugResolutionPath.Count > 0)
-                        list.Add(v.DebugResolutionPath);
+
+                m_extraStateCache ??= new();
+                GetAllExtraStates(m_extraStateCache);
+                foreach (var e in m_extraStateCache)
+                    if (e.DebugResolutionPath != null && e.DebugResolutionPath.Count > 0)
+                        list.Add(e.DebugResolutionPath);
                 return list;
             }
         }
@@ -383,7 +387,7 @@ namespace Cinemachine
 
                     // Apply damping
                     float dampTime = AvoidObstacles.DampingWhenOccluded;
-                    if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid && AvoidObstacles.DampingWhenOccluded + AvoidObstacles.Damping > Epsilon)
+                    if (deltaTime >= 0 && vcam.PreviousStateIsValid && AvoidObstacles.DampingWhenOccluded + AvoidObstacles.Damping > Epsilon)
                     {
                         // To ease the transition between damped and undamped regions, we damp the damp time
                         var dispSqrMag = displacement.sqrMagnitude;
@@ -399,7 +403,7 @@ namespace Cinemachine
                     cameraPos = state.GetCorrectedPosition();
 
                     // Adjust the damping bypass to account for the displacement
-                    if (state.HasLookAt() && VirtualCamera.PreviousStateIsValid)
+                    if (state.HasLookAt() && vcam.PreviousStateIsValid)
                     {
                         var dir0 = extra.PreviousCameraPosition - state.ReferenceLookAt;
                         var dir1 = cameraPos - state.ReferenceLookAt;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -177,29 +177,29 @@ namespace Cinemachine
 
         /// <summary>See whether an object is blocking the camera's view of the target</summary>
         /// <param name="vcam">The virtual camera in question.  This might be different from the
-        /// virtual camera that owns the collider, in the event that the camera has children</param>
+        /// virtual camera that owns the deoccluder, in the event that the camera has children</param>
         /// <returns>True if something is blocking the view</returns>
-        public bool IsTargetObscured(ICinemachineCamera vcam)
+        public bool IsTargetObscured(CinemachineVirtualCameraBase vcam)
         {
             return GetExtraState<VcamExtraState>(vcam).TargetObscured;
         }
 
         /// <summary>See whether the virtual camera has been moved nby the collider</summary>
         /// <param name="vcam">The virtual camera in question.  This might be different from the
-        /// virtual camera that owns the collider, in the event that the camera has children</param>
+        /// virtual camera that owns the deoccluder, in the event that the camera has children</param>
         /// <returns>True if the virtual camera has been displaced due to collision or
         /// target obstruction</returns>
-        public bool CameraWasDisplaced(ICinemachineCamera vcam)
+        public bool CameraWasDisplaced(CinemachineVirtualCameraBase vcam)
         {
             return GetCameraDisplacementDistance(vcam) > 0;
         }
 
         /// <summary>See how far the virtual camera wa moved nby the collider</summary>
         /// <param name="vcam">The virtual camera in question.  This might be different from the
-        /// virtual camera that owns the collider, in the event that the camera has children</param>
+        /// virtual camera that owns the deoccluder, in the event that the camera has children</param>
         /// <returns>True if the virtual camera has been displaced due to collision or
         /// target obstruction</returns>
-        public float GetCameraDisplacementDistance(ICinemachineCamera vcam)
+        public float GetCameraDisplacementDistance(CinemachineVirtualCameraBase vcam)
         {
             return GetExtraState<VcamExtraState>(vcam).PreviousDisplacement.magnitude;
         }
@@ -241,7 +241,7 @@ namespace Cinemachine
         /// <summary>
         /// Per-vcam extra state info
         /// </summary>
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public Vector3 PreviousDisplacement;
             public bool TargetObscured;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
@@ -50,7 +50,7 @@ namespace Cinemachine
             FovRange.x = Mathf.Clamp(FovRange.x, 1, FovRange.y);
         }
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public float m_PreviousFrameZoom = 0;
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFollowZoom.cs
@@ -71,7 +71,7 @@ namespace Cinemachine
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             var extra = GetExtraState<VcamExtraState>(vcam);
-            if (deltaTime < 0 || !VirtualCamera.PreviousStateIsValid)
+            if (deltaTime < 0 || !vcam.PreviousStateIsValid)
                 extra.m_PreviousFrameZoom = state.Lens.FieldOfView;
 
             // Set the zoom after the body has been positioned, but before the aim,
@@ -90,11 +90,11 @@ namespace Cinemachine
                     targetWidth = Mathf.Clamp(targetWidth, minW, maxW);
 
                     // Apply damping
-                    if (deltaTime >= 0 && Damping > 0 && VirtualCamera.PreviousStateIsValid)
+                    if (deltaTime >= 0 && Damping > 0 && vcam.PreviousStateIsValid)
                     {
                         var currentWidth = d * 2f * Mathf.Tan(extra.m_PreviousFrameZoom * Mathf.Deg2Rad / 2f);
                         var delta = targetWidth - currentWidth;
-                        delta = VirtualCamera.DetachedLookAtTargetDamp(delta, Damping, deltaTime);
+                        delta = vcam.DetachedLookAtTargetDamp(delta, Damping, deltaTime);
                         targetWidth = currentWidth + delta;
                     }
                     fov = 2f * Mathf.Atan(targetWidth / (2 * d)) * Mathf.Rad2Deg;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
@@ -575,7 +575,7 @@ namespace Cinemachine
 
         void OnValidate()
         {
-            var vcam = VirtualCamera;
+            var vcam = ComponentOwner;
             for (int i = 0; i < Modifiers.Count; ++i)
                 Modifiers[i].Validate(vcam);
         }
@@ -590,22 +590,13 @@ namespace Cinemachine
         // GML todo: clean this up
         static void TryGetVcamComponent<T>(CinemachineVirtualCameraBase vcam, out T component)
         {
-    #pragma warning disable 618
-            var legacyVcam = vcam as CinemachineVirtualCamera;
-            if (legacyVcam != null)
-            {
-                if (!legacyVcam.GetComponentOwner().TryGetComponent(out component))
-                    component = default;
-                return;
-            }
-    #pragma warning restore 618
             if (vcam == null || !vcam.TryGetComponent(out component))
                 component = default;
         }
 
         void RefreshComponentCache()
         {
-            var vcam = VirtualCamera;
+            var vcam = ComponentOwner;
             TryGetVcamComponent(vcam, out m_ValueSource);
             for (int i = 0; i < Modifiers.Count; ++i)
                 Modifiers[i].RefreshCache(vcam);
@@ -622,7 +613,7 @@ namespace Cinemachine
         public override void PrePipelineMutateCameraStateCallback(
             CinemachineVirtualCameraBase vcam, ref CameraState curState, float deltaTime) 
         {
-            if (m_ValueSource != null)
+            if (m_ValueSource != null && vcam == ComponentOwner)
             {
                 // Apply easing
                 if (s_EasingCurve == null)
@@ -656,7 +647,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            if (m_ValueSource != null && stage == CinemachineCore.Stage.Finalize)
+            if (m_ValueSource != null && stage == CinemachineCore.Stage.Finalize && vcam == ComponentOwner)
             {
                 for (int i = 0; i < Modifiers.Count; ++i)
                     Modifiers[i].AfterPipeline(vcam, ref state, deltaTime, m_CurrentValue);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -123,7 +123,7 @@ namespace Cinemachine
         /// <summary>For editor visualization of the calculated bounding box of the group</summary>
         internal Matrix4x4 GroupBoundsMatrix;
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public Vector3 PosAdjustment;
             public Vector2 RotAdjustment;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -145,7 +145,7 @@ namespace Cinemachine
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             // Apply to this vcam only, not the children
-            if (vcam != VirtualCamera || stage != CinemachineCore.Stage.Finalize)
+            if (vcam != ComponentOwner || stage != CinemachineCore.Stage.Finalize)
                 return;
 
             UpdateRenderCanvas();
@@ -205,8 +205,8 @@ namespace Cinemachine
 
         void CameraUpdatedCallback(CinemachineBrain brain)
         {
-            var showIt = enabled && ShowImage && CinemachineCore.Instance.IsLive(VirtualCamera);
-            var channel = (uint)VirtualCamera.GetChannel();
+            var showIt = enabled && ShowImage && CinemachineCore.Instance.IsLive(ComponentOwner);
+            var channel = (uint)ComponentOwner.GetChannel();
             if (s_StoryboardGlobalMute || ((uint)brain.ChannelMask & channel) == 0)
                 showIt = false;
             var ci = LocateMyCanvas(brain, showIt);
@@ -368,10 +368,10 @@ namespace Cinemachine
             {
                 var b = state.GetCustomBlendable(i);
                 var src = b.Custom as CinemachineStoryboard;
-                if (src != null && src.VirtualCamera != null) // in case it was deleted
+                if (src != null && src.ComponentOwner != null) // in case it was deleted
                 {
                     bool showIt = true;
-                    var channel = (uint)src.VirtualCamera.GetChannel();
+                    var channel = (uint)src.ComponentOwner.GetChannel();
                     if (s_StoryboardGlobalMute || ((uint)brain.ChannelMask & channel) == 0)
                         showIt = false;
                     var ci = src.LocateMyCanvas(brain, showIt);

--- a/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
@@ -224,9 +224,7 @@ namespace Cinemachine
         {
             base.OnTargetObjectWarped(target, positionDelta);
             if (target == FollowTarget)
-            {
                 m_PreviousFollowTargetPosition += positionDelta;
-            }
         }
         
         void PositionCamera(ref CameraState curState, float deltaTime)

--- a/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
@@ -10,8 +10,18 @@ namespace Cinemachine
     /// </summary>
     public abstract class CinemachineExtension : MonoBehaviour
     {
+        /// <summary>
+        /// Extensions that need to save per-vcam state should inherit from this class and add
+        /// appropriate member variables.  Use GetExtraState() to access.
+        /// </summary>
+        protected class VcamExtraStateBase
+        {
+            /// <summary>The virtual camera being modified by the extension</summary>
+            public CinemachineVirtualCameraBase Vcam;
+        }
+
         CinemachineVirtualCameraBase m_VcamOwner;
-        Dictionary<ICinemachineCamera, System.Object> m_ExtraState;
+        Dictionary<CinemachineVirtualCameraBase, VcamExtraStateBase> m_ExtraState;
 
         /// <summary>Useful constant for very small floats</summary>
         protected const float Epsilon = Utility.UnityVectorExtensions.Epsilon;
@@ -145,19 +155,19 @@ namespace Cinemachine
         /// /// <typeparam name="T">The type of the extra state class</typeparam>
         /// <param name="vcam">The virtual camera being processed</param>
         /// <returns>The extra state, cast as type T</returns>
-        protected T GetExtraState<T>(ICinemachineCamera vcam) where T : class, new()
+        protected T GetExtraState<T>(CinemachineVirtualCameraBase vcam) where T : VcamExtraStateBase, new()
         {
             if (m_ExtraState == null)
-                m_ExtraState = new Dictionary<ICinemachineCamera, System.Object>();
+                m_ExtraState = new ();
             if (!m_ExtraState.TryGetValue(vcam, out var extra))
-                extra = m_ExtraState[vcam] = new T();
+                extra = m_ExtraState[vcam] = new T { Vcam = vcam};
             return extra as T;
         }
 
         /// <summary>Get all extra state info for all vcams.</summary>
         /// <typeparam name="T">The extra state type</typeparam>
         /// <param name="list">The list that will get populated with the extra states.</param>
-        protected void GetAllExtraStates<T>(List<T> list) where T : class, new()
+        protected void GetAllExtraStates<T>(List<T> list) where T : VcamExtraStateBase, new()
         {
             list.Clear();
             if (m_ExtraState != null)

--- a/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
@@ -16,8 +16,10 @@ namespace Cinemachine
         /// <summary>Useful constant for very small floats</summary>
         protected const float Epsilon = Utility.UnityVectorExtensions.Epsilon;
 
-        /// <summary>Get the CinemachineVirtualCamera to which this extension is attached</summary>
-        public CinemachineVirtualCameraBase VirtualCamera
+        /// <summary>Get the CinemachineVirtualCamera to which this extension is attached.
+        /// This is distinct from the CinemachineCameras that the extension will modify,
+        /// as extensions owned by manager cameras will be applied to all the CinemachineCamewra children.</summary>
+        public CinemachineVirtualCameraBase ComponentOwner
         {
             get
             {
@@ -58,12 +60,12 @@ namespace Cinemachine
         /// <param name="connect">True if connecting, false if disconnecting</param>
         protected virtual void ConnectToVcam(bool connect)
         {
-            if (VirtualCamera != null)
+            if (ComponentOwner != null)
             {
                 if (connect)
-                    VirtualCamera.AddExtension(this);
+                    ComponentOwner.AddExtension(this);
                 else
-                    VirtualCamera.RemoveExtension(this);
+                    ComponentOwner.RemoveExtension(this);
             }
             m_ExtraState = null;
         }
@@ -105,16 +107,20 @@ namespace Cinemachine
         /// <summary>This is called to notify the extension that a target got warped,
         /// so that the extension can update its internal state to make the camera
         /// also warp seamlessly.  Base class implementation does nothing.</summary>
+        /// <param name="vcam">Virtual camera to warp</param>
         /// <param name="target">The object that was warped</param>
         /// <param name="positionDelta">The amount the target's position changed</param>
-        public virtual void OnTargetObjectWarped(Transform target, Vector3 positionDelta) {}
+        public virtual void OnTargetObjectWarped(
+            CinemachineVirtualCameraBase vcam, Transform target, Vector3 positionDelta) {}
 
         /// <summary>
         /// Force the virtual camera to assume a given position and orientation
         /// </summary>
+        /// <param name="vcam">Virtual camera to reposition</param>
         /// <param name="pos">Worldspace position to take</param>
         /// <param name="rot">Worldspace orientation to take</param>
-        public virtual void ForceCameraPosition(Vector3 pos, Quaternion rot) {}
+        public virtual void ForceCameraPosition(
+            CinemachineVirtualCameraBase vcam, Vector3 pos, Quaternion rot) {}
         
         /// <summary>Notification that this virtual camera is going live.
         /// Base class implementation must be called by any overridden method.</summary>
@@ -148,18 +154,15 @@ namespace Cinemachine
             return extra as T;
         }
 
-        /// <summary>Inefficient method to get all extra state info for all vcams.
-        /// Intended for Editor use only, not runtime!
-        /// </summary>
+        /// <summary>Get all extra state info for all vcams.</summary>
         /// <typeparam name="T">The extra state type</typeparam>
-        /// <returns>A dynamically-allocated list with all the extra states</returns>
-        protected List<T> GetAllExtraStates<T>() where T : class, new()
+        /// <param name="list">The list that will get populated with the extra states.</param>
+        protected void GetAllExtraStates<T>(List<T> list) where T : class, new()
         {
-            var list = new List<T>();
+            list.Clear();
             if (m_ExtraState != null)
                 foreach (var v in m_ExtraState)
                     list.Add(v.Value as T);
-            return list;
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Cinemachine.Utility;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -323,7 +322,7 @@ namespace Cinemachine
                         e.InvokePostPipelineStageCallback(vcam, stage, ref newState, deltaTime);
                 }
             }
-            CinemachineVirtualCameraBase parent = ParentCamera as CinemachineVirtualCameraBase;
+            var parent = ParentCamera as CinemachineVirtualCameraBase;
             if (parent != null)
                 parent.InvokePostPipelineStageCallback(vcam, stage, ref newState, deltaTime);
         }
@@ -356,7 +355,7 @@ namespace Cinemachine
                         e.PrePipelineMutateCameraStateCallback(vcam, ref newState, deltaTime);
                 }
             }
-            CinemachineVirtualCameraBase parent = ParentCamera as CinemachineVirtualCameraBase;
+            var parent = ParentCamera as CinemachineVirtualCameraBase;
             if (parent != null)
                 parent.InvokePrePipelineMutateCameraStateCallback(vcam, ref newState, deltaTime);
         }
@@ -731,14 +730,20 @@ namespace Cinemachine
         /// also warp seamlessly.</summary>
         /// <param name="target">The object that was warped</param>
         /// <param name="positionDelta">The amount the target's position changed</param>
-        public virtual void OnTargetObjectWarped(Transform target, Vector3 positionDelta)
+        public virtual void OnTargetObjectWarped(Transform target, Vector3 positionDelta) 
+            => OnTargetObjectWarped(this, target, positionDelta);
+
+        void OnTargetObjectWarped(CinemachineVirtualCameraBase vcam, Transform target, Vector3 positionDelta)
         {
             // inform the extensions
             if (Extensions != null)
             {
                 for (int i = 0; i < Extensions.Count; ++i)
-                    Extensions[i].OnTargetObjectWarped(target, positionDelta);
+                    Extensions[i].OnTargetObjectWarped(vcam, target, positionDelta);
             }
+            var parent = ParentCamera as CinemachineVirtualCameraBase;
+            if (parent != null)
+                parent.OnTargetObjectWarped(vcam, target, positionDelta);
         }
 
         /// <summary>
@@ -746,14 +751,20 @@ namespace Cinemachine
         /// </summary>
         /// <param name="pos">Worldspace position to take</param>
         /// <param name="rot">Worldspace orientation to take</param>
-        public virtual void ForceCameraPosition(Vector3 pos, Quaternion rot)
+        public virtual void ForceCameraPosition(Vector3 pos, Quaternion rot) 
+            => ForceCameraPosition(this, pos, rot);
+
+        void ForceCameraPosition(CinemachineVirtualCameraBase vcam, Vector3 pos, Quaternion rot)
         {
             // inform the extensions
             if (Extensions != null)
             {
                 for (int i = 0; i < Extensions.Count; ++i)
-                    Extensions[i].ForceCameraPosition(pos, rot);
+                    Extensions[i].ForceCameraPosition(vcam, pos, rot);
             }
+            var parent = ParentCamera as CinemachineVirtualCameraBase;
+            if (parent != null)
+                parent.ForceCameraPosition(vcam, pos, rot);
         }
 
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Deprecated/Cinemachine3rdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/Cinemachine3rdPersonFollow.cs
@@ -201,9 +201,7 @@ namespace Cinemachine
         {
             base.OnTargetObjectWarped(target, positionDelta);
             if (target == FollowTarget)
-            {
                 m_PreviousFollowTargetPosition += positionDelta;
-            }
         }
         
         void PositionCamera(ref CameraState curState, float deltaTime)

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
@@ -228,16 +228,20 @@ namespace Cinemachine
             }
         };
 
+        List<VcamExtraState> m_extraStateCache;
+
         /// <summary>Inspector API for debugging collision resolution path</summary>
-        public List<List<Vector3>> DebugPaths
+        internal List<List<Vector3>> DebugPaths
         {
             get
             {
                 List<List<Vector3>> list = new List<List<Vector3>>();
-                List<VcamExtraState> extraStates = GetAllExtraStates<VcamExtraState>();
-                foreach (var v in extraStates)
-                    if (v.debugResolutionPath != null && v.debugResolutionPath.Count > 0)
-                        list.Add(v.debugResolutionPath);
+
+                m_extraStateCache ??= new();
+                GetAllExtraStates(m_extraStateCache);
+                foreach (var e in m_extraStateCache)
+                    if (e.debugResolutionPath != null && e.debugResolutionPath.Count > 0)
+                        list.Add(e.debugResolutionPath);
                 return list;
             }
         }
@@ -319,7 +323,7 @@ namespace Cinemachine
 
                     // Apply damping
                     float dampTime = m_DampingWhenOccluded;
-                    if (deltaTime >= 0 && VirtualCamera.PreviousStateIsValid && m_DampingWhenOccluded + m_Damping > Epsilon)
+                    if (deltaTime >= 0 && vcam.PreviousStateIsValid && m_DampingWhenOccluded + m_Damping > Epsilon)
                     {
                         // To ease the transition between damped and undamped regions, we damp the damp time
                         var dispSqrMag = displacement.sqrMagnitude;
@@ -345,7 +349,7 @@ namespace Cinemachine
                     cameraPos = state.GetCorrectedPosition();
 
                     // Adjust the damping bypass to account for the displacement
-                    if (state.HasLookAt() && VirtualCamera.PreviousStateIsValid)
+                    if (state.HasLookAt() && vcam.PreviousStateIsValid)
                     {
                         var dir0 = extra.previousCameraPosition - state.ReferenceLookAt;
                         var dir1 = cameraPos - state.ReferenceLookAt;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
@@ -131,7 +131,7 @@ namespace Cinemachine
         /// <param name="vcam">The virtual camera in question.  This might be different from the
         /// virtual camera that owns the collider, in the event that the camera has children</param>
         /// <returns>True if something is blocking the view</returns>
-        public bool IsTargetObscured(ICinemachineCamera vcam)
+        public bool IsTargetObscured(CinemachineVirtualCameraBase vcam)
         {
             return GetExtraState<VcamExtraState>(vcam).targetObscured;
         }
@@ -141,7 +141,7 @@ namespace Cinemachine
         /// virtual camera that owns the collider, in the event that the camera has children</param>
         /// <returns>True if the virtual camera has been displaced due to collision or
         /// target obstruction</returns>
-        public bool CameraWasDisplaced(ICinemachineCamera vcam)
+        public bool CameraWasDisplaced(CinemachineVirtualCameraBase vcam)
         {
             return GetCameraDisplacementDistance(vcam) > 0;
         }
@@ -151,7 +151,7 @@ namespace Cinemachine
         /// virtual camera that owns the collider, in the event that the camera has children</param>
         /// <returns>True if the virtual camera has been displaced due to collision or
         /// target obstruction</returns>
-        public float GetCameraDisplacementDistance(ICinemachineCamera vcam)
+        public float GetCameraDisplacementDistance(CinemachineVirtualCameraBase vcam)
         {
             return GetExtraState<VcamExtraState>(vcam).previousDisplacement.magnitude;
         }
@@ -180,7 +180,7 @@ namespace Cinemachine
         /// <summary>
         /// Per-vcam extra state info
         /// </summary>
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public Vector3 previousDisplacement;
             public Vector3 previousCameraOffset;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineConfiner.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineConfiner.cs
@@ -107,7 +107,7 @@ namespace Cinemachine
             base.ConnectToVcam(connect);
         }
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public Vector3 PreviousDisplacement;
             public float ConfinerDisplacement;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineConfiner.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineConfiner.cs
@@ -157,7 +157,7 @@ namespace Cinemachine
                 else
                     displacement = ConfinePoint(state.GetCorrectedPosition());
 
-                if (m_Damping > 0 && deltaTime >= 0 && VirtualCamera.PreviousStateIsValid)
+                if (m_Damping > 0 && deltaTime >= 0 && vcam.PreviousStateIsValid)
                 {
                     var delta = displacement - extra.PreviousDisplacement;
                     delta = Damper.Damp(delta, m_Damping, deltaTime);

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
@@ -135,10 +135,10 @@ namespace Cinemachine
                         if (state.HasLookAt())
                             focusDistance =  (state.GetFinalPosition() - state.ReferenceLookAt).magnitude;
                         else 
-                            focusTarget = VirtualCamera.LookAt; // probably null, but doesn't hurt
+                            focusTarget = vcam.LookAt; // probably null, but doesn't hurt
                         break;
                     case FocusTrackingMode.FollowTarget: 
-                        focusTarget = VirtualCamera.Follow; 
+                        focusTarget = vcam.Follow; 
                         break;
                     case FocusTrackingMode.CustomTarget: 
                         focusTarget = CustomTarget; 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineAutoFocus.cs
@@ -87,7 +87,7 @@ namespace Cinemachine
         }
 #endif
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public float CurrentFocusDistance;
         }

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -107,10 +107,6 @@ namespace Cinemachine
         [FormerlySerializedAs("m_Profile")]
         public PostProcessProfile Profile;
 
-        /// <summary>Legacy support for obsolete format</summary>
-        [HideInInspector, SerializeField, FormerlySerializedAs("m_FocusTracksTarget")]
-        bool m_LegacyFocusTracksTarget;
-       
         class VcamExtraState
         {
             public PostProcessProfile ProfileCopy;
@@ -138,28 +134,19 @@ namespace Cinemachine
             }
         }
 
+        List<VcamExtraState> m_extraStateCache;
+
         /// <summary>True if the profile is enabled and nontrivial</summary>
         public bool IsValid => Profile != null && Profile.settings.Count > 0;
 
+
         /// <summary>Called by the editor when the shared asset has been edited</summary>
-        public void InvalidateCachedProfile()
+        internal void InvalidateCachedProfile()
         {
-            var list = GetAllExtraStates<VcamExtraState>();
-            for (int i = 0; i < list.Count; ++i)
-                list[i].DestroyProfileCopy();
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-
-            // Map legacy m_FocusTracksTarget to focus mode
-            if (m_LegacyFocusTracksTarget)
-            {
-                FocusTracking = VirtualCamera.LookAt != null 
-                    ? FocusTrackingMode.LookAtTarget : FocusTrackingMode.Camera;
-            }
-            m_LegacyFocusTracksTarget = false;
+            m_extraStateCache ??= new();
+            GetAllExtraStates(m_extraStateCache);
+            foreach (var e in m_extraStateCache)
+                e.DestroyProfileCopy();
         }
 
         protected override void OnDestroy()
@@ -207,7 +194,7 @@ namespace Cinemachine
                                 switch (FocusTracking)
                                 {
                                     default: break;
-                                    case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
+                                    case FocusTrackingMode.FollowTarget: focusTarget = vcam.Follow; break;
                                     case FocusTrackingMode.CustomTarget: focusTarget = FocusTarget; break;
                                 }
                                 if (focusTarget != null)

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -107,7 +107,7 @@ namespace Cinemachine
         [FormerlySerializedAs("m_Profile")]
         public PostProcessProfile Profile;
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public PostProcessProfile ProfileCopy;
 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -100,10 +100,6 @@ namespace Cinemachine
         [FormerlySerializedAs("m_Profile")]
         public VolumeProfile Profile;
 
-        /// <summary>This is obsolete, please use m_FocusTracking</summary>
-        [HideInInspector, SerializeField, FormerlySerializedAs("m_FocusTracksTarget")]
-        bool m_LegacyFocusTracksTarget;
-
         class VcamExtraState
         {
             public VolumeProfile ProfileCopy;
@@ -132,28 +128,18 @@ namespace Cinemachine
             }
         }
 
+        List<VcamExtraState> m_extraStateCache;
+
         /// <summary>True if the profile is enabled and nontrivial</summary>
         public bool IsValid => Profile != null && Profile.components.Count > 0;
 
         /// <summary>Called by the editor when the shared asset has been edited</summary>
-        public void InvalidateCachedProfile()
+        internal void InvalidateCachedProfile()
         {
-            var list = GetAllExtraStates<VcamExtraState>();
-            for (int i = 0; i < list.Count; ++i)
-                list[i].DestroyProfileCopy();
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-
-            // Map legacy m_FocusTracksTarget to focus mode
-            if (m_LegacyFocusTracksTarget)
-            {
-                FocusTracking = VirtualCamera.LookAt != null 
-                    ? FocusTrackingMode.LookAtTarget : FocusTrackingMode.Camera;
-            }
-            m_LegacyFocusTracksTarget = false;
+            m_extraStateCache ??= new();
+            GetAllExtraStates(m_extraStateCache);
+            foreach (var e in m_extraStateCache)
+                e.DestroyProfileCopy();
         }
 
         protected override void OnDestroy()
@@ -200,7 +186,7 @@ namespace Cinemachine
                                 switch (FocusTracking)
                                 {
                                     default: break;
-                                    case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
+                                    case FocusTrackingMode.FollowTarget: focusTarget = vcam.Follow; break;
                                     case FocusTrackingMode.CustomTarget: focusTarget = FocusTarget; break;
                                 }
                                 if (focusTarget != null)

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -100,7 +100,7 @@ namespace Cinemachine
         [FormerlySerializedAs("m_Profile")]
         public VolumeProfile Profile;
 
-        class VcamExtraState
+        class VcamExtraState : VcamExtraStateBase
         {
             public VolumeProfile ProfileCopy;
 

--- a/com.unity.cinemachine/Samples~/2D Samples/CameraMagnets.unity
+++ b/com.unity.cinemachine/Samples~/2D Samples/CameraMagnets.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -67,6 +67,9 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 0
@@ -147,7 +150,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 129940154}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -13.05, y: 2.3, z: -10}
+  m_LocalPosition: {x: -12, y: 2.2501001, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -168,7 +171,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   BoundingShape2D: {fileID: 773640721}
   Damping: 0.5
-  SlowingDistance: 0
+  SlowingDistance: 5
   OversizeWindow:
     Enabled: 0
     MaxWindowSize: 0
@@ -1144,12 +1147,9 @@ MonoBehaviour:
   RotationMode: 0
   UpdateMethod: 2
   Targets:
-  - Object: {fileID: 0}
+  - Object: {fileID: 1679282207}
     Weight: 1
     Radius: 0.5
-  - Object: {fileID: 0}
-    Weight: 1
-    Radius: 1
   - Object: {fileID: 436036891}
     Weight: 0
     Radius: 0
@@ -1168,7 +1168,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 838270487}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -13.05, y: 1.3, z: 0}
+  m_LocalPosition: {x: -12, y: 1.2501, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1825,6 +1825,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ZPosiion: 0
+--- !u!4 &1679282207 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_PrefabInstance: {fileID: 1679282204}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1691503748
 GameObject:
   m_ObjectHideFlags: 0
@@ -2373,7 +2378,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7726835707821803386}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -9.026683, y: 3.249998, z: -10}
+  m_LocalPosition: {x: -11.046989, y: 3.249998, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
Refactored CinemachineExtension API a little:

- CinemachineExtension.OnTargetObjectWarped and CinemachineExtension.ForceCameraPosition were not defined in such a way that multi-vcam support was possible.  We did not notice this because until recently they were never used.
- Also fixed a number of places where extension.VirtualCamera was incorrectly being used (again, breaking multi-vcam support).
- Renamed CinemachineExtension.VirtualCamera to CinemachineExtension.ComponentOwner to help prevent this mistake from being made.
- CinemachineExtension.GetAllExtraStates refactored for improved performance.
- Refactored CinemachineConfiner2D a little in consequence of this change.
- Fixed HelpBox refresh issues in Confiner2DEditor