### PR TITLE
CMCL-1359: URP: add temporal reset on camera cut

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Confiner2D and Confiner3D support smooth stop at bounds edge.
 - CinemachineIndependentImpulseListener renamed to CinemachineExternalImpulseListener.
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
+- URP: add temporal effects reset on camera cut
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -16,7 +16,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-#if CINEMACHINE_LWRP_7_3_1 || CINEMACHINE_PIXEL_PERFECT_2_0_3
+#if CINEMACHINE_URP || CINEMACHINE_PIXEL_PERFECT_2_0_3
             m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
             m_PipelineUtility.UpdateState();
 #else

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -12,7 +12,7 @@ using UnityEngine.InputSystem;
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
@@ -15,7 +15,7 @@ namespace Cinemachine.Editor
 #if !CINEMACHINE_POST_PROCESSING_V2
         public override void OnInspectorGUI()
         {
-    #if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+    #if CINEMACHINE_HDRP || CINEMACHINE_URP
             EditorGUILayout.HelpBox(
                 "This component is not valid for HDRP and URP projects.  Use the CinemachineVolumeSettings component instead.",
                 MessageType.Warning);
@@ -76,7 +76,7 @@ namespace Cinemachine.Editor
 
         public override void OnInspectorGUI()
         {
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
             EditorGUILayout.HelpBox(
                 "This component is not valid for HDRP and URP projects.  Use the CinemachineVolumeSettings component instead.",
                 MessageType.Warning);

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -1,9 +1,10 @@
-    using UnityEngine;
-    using UnityEditor;
-    using UnityEngine.Rendering;
-    using UnityEditor.Rendering;
-    using System.Collections.Generic;
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
 
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.Rendering;
+using UnityEditor.Rendering;
+using System.Collections.Generic;
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
@@ -239,3 +240,4 @@ namespace Cinemachine.Editor
 #endif
     }
 }
+#endif

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -7,7 +7,7 @@
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 
@@ -16,7 +16,7 @@ namespace Cinemachine.Editor
     [CustomEditor(typeof(CinemachineVolumeSettings))]
     class CinemachineVolumeSettingsEditor : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
     {
-#if !(CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1)
+#if !(CINEMACHINE_HDRP || CINEMACHINE_URP)
         public override void OnInspectorGUI()
         {
             EditorGUILayout.HelpBox(
@@ -84,7 +84,7 @@ namespace Cinemachine.Editor
                 bool valid = false;
                 DepthOfField dof;
                 if (Target.Profile != null && Target.Profile.TryGet(out dof))
-#if CINEMACHINE_LWRP_7_3_1 && !CINEMACHINE_HDRP
+#if CINEMACHINE_URP && !CINEMACHINE_HDRP
                 {
                     valid = dof.active && dof.focusDistance.overrideState
                         && dof.mode.overrideState && dof.mode == DepthOfFieldMode.Bokeh;

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -7,7 +7,7 @@ using UnityEditor.UIElements;
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 

--- a/com.unity.cinemachine/Editor/com.unity.cinemachine.editor.asmdef
+++ b/com.unity.cinemachine/Editor/com.unity.cinemachine.editor.asmdef
@@ -62,7 +62,7 @@
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "7.3.1",
-            "define": "CINEMACHINE_LWRP_7_3_1"
+            "define": "CINEMACHINE_URP"
         },
         {
             "name": "com.unity.timeline",

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -11,7 +11,7 @@ using UnityEngine.Serialization;
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-#if CINEMACHINE_LWRP_7_3_1 || CINEMACHINE_PIXEL_PERFECT_2_0_3
+#if CINEMACHINE_URP || CINEMACHINE_PIXEL_PERFECT_2_0_3
 
 namespace Cinemachine
 {
@@ -35,7 +35,7 @@ namespace Cinemachine
             if (brain == null || !brain.IsLive(vcam))
                 return;
 
-#if CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_URP
             UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera pixelPerfectCamera;
 #elif CINEMACHINE_PIXEL_PERFECT_2_0_3
             UnityEngine.U2D.PixelPerfectCamera pixelPerfectCamera;

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -3,7 +3,7 @@ using System;
 
 #if CINEMACHINE_HDRP
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -1,41 +1,14 @@
-﻿using UnityEngine;
+﻿#if CINEMACHINE_POST_PROCESSING_V2
+using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
-#if CINEMACHINE_POST_PROCESSING_V2
 using System.Collections.Generic;
 using UnityEngine.Rendering.PostProcessing;
-#endif
 
 namespace Cinemachine
 {
-#if !CINEMACHINE_POST_PROCESSING_V2
     /// <summary>
-    /// This behaviour is a liaison between Cinemachine with the Post-Processing v2 module.  You must
-    /// have the Post-Processing V2 stack package installed in order to use this behaviour.
-    ///
-    /// As a component on the Virtual Camera, it holds
-    /// a Post-Processing Profile asset that will be applied to the Unity camera whenever
-    /// the Virtual camera is live.  It also has the optional functionality of animating
-    /// the Focus Distance and DepthOfField properties of the Camera State, and
-    /// applying them to the current Post-Processing profile, provided that profile has a
-    /// DepthOfField effect that is enabled.
-    /// </summary>
-    [SaveDuringPlay]
-    [AddComponentMenu("")] // Hide in menu
-    public class CinemachinePostProcessing : CinemachineExtension 
-    {
-        /// <summary>Apply PostProcessing effects</summary>
-        /// <param name="vcam">The virtual camera being processed</param>
-        /// <param name="stage">The current pipeline stage</param>
-        /// <param name="state">The current virtual camera state</param>
-        /// <param name="deltaTime">The current applicable deltaTime</param>
-        protected override void PostPipelineStageCallback(
-            CinemachineVirtualCameraBase vcam,
-            CinemachineCore.Stage stage, ref CameraState state, float deltaTime) {}
-    }
-#else
-    /// <summary>
-    /// This behaviour is a liaison between Cinemachine with the Post-Processing v2 module.  You must
+    /// This behaviour is a liaison between Cinemachine and the Post-Processing v2 module.  You must
     /// have the Post-Processing V2 stack package installed in order to use this behaviour.
     ///
     /// As a component on the Virtual Camera, it holds
@@ -382,5 +355,5 @@ namespace Cinemachine
             SceneManager.sceneUnloaded += (scene) => CleanupLookupTable();
         }
     }
-#endif
 }
+#endif

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -1,35 +1,21 @@
-﻿using UnityEngine;
+﻿#if (CINEMACHINE_HDRP || CINEMACHINE_URP)
+
+using UnityEngine;
 using UnityEngine.Serialization;
+using System.Collections.Generic;
+using UnityEngine.Rendering;
 
 #if CINEMACHINE_HDRP
-    using System.Collections.Generic;
-    using UnityEngine.Rendering;
     using UnityEngine.Rendering.HighDefinition;
-#elif CINEMACHINE_LWRP_7_3_1
-    using System.Collections.Generic;
-    using UnityEngine.Rendering;
+#elif CINEMACHINE_URP
     using UnityEngine.Rendering.Universal;
 #endif
 
 namespace Cinemachine
 {
-#if !(CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1)
-    // Workaround for Unity scripting bug
     /// <summary>
-    /// This behaviour is a liaison between Cinemachine with the Post-Processing v3 module.
-    ///
-    /// As a component on the Virtual Camera, it holds
-    /// a Post-Processing Profile asset that will be applied to the Unity camera whenever
-    /// the Virtual camera is live.  It also has the optional functionality of animating
-    /// the Focus Distance and DepthOfField properties of the Camera State, and
-    /// applying them to the current Post-Processing profile, provided that profile has a
-    /// DepthOfField effect that is enabled.
-    /// </summary>
-    [AddComponentMenu("")] // Hide in menu
-    public class CinemachineVolumeSettings : MonoBehaviour {}
-#else
-    /// <summary>
-    /// This behaviour is a liaison between Cinemachine with the Post-Processing v3 module.
+    /// This behaviour is a liaison between Cinemachine with the Post-Processing v3 module,
+    /// shipped with HDRP and URP.
     ///
     /// As a component on the Virtual Camera, it holds
     /// a Post-Processing Profile asset that will be applied to the Unity camera whenever
@@ -232,16 +218,11 @@ namespace Cinemachine
                 hdCam.colorPyramidHistoryIsValid = false;
                 hdCam.Reset();
             }
-#elif CINEMACHINE_LDRP_7_3_1
+#elif CINEMACHINE_URP
             // Reset temporal effects
             var cam = brain.OutputCamera;
-            if (cam != null)
-            {
-                HDCamera hdCam = HDCamera.GetOrCreate(cam);
-                hdCam.volumetricHistoryIsValid = false;
-                hdCam.colorPyramidHistoryIsValid = false;
-                hdCam.Reset();
-            }
+            if (cam != null && cam.TryGetComponent<UniversalAdditionalCameraData>(out var data))
+                data.resetHistory = true;
 #endif
         }
 
@@ -316,7 +297,7 @@ namespace Cinemachine
                 // Update the volume's layer so it will be seen
 #if CINEMACHINE_HDRP
                 brain.gameObject.TryGetComponent<HDAdditionalCameraData>(out var data);
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
                 brain.gameObject.TryGetComponent<UniversalAdditionalCameraData>(out var data);
 #endif
                 if (data != null)
@@ -352,5 +333,5 @@ namespace Cinemachine
             CinemachineCore.CameraCutEvent.AddListener(OnCameraCut);
         }
     }
-#endif
 }
+#endif

--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -54,8 +54,8 @@
         },
         {
             "name": "com.unity.render-pipelines.universal",
-            "expression": "7.3.1",
-            "define": "CINEMACHINE_LWRP_7_3_1"
+            "expression": "14.0.4",
+            "define": "CINEMACHINE_URP"
         },
         {
             "name": "com.unity.2d.pixel-perfect",


### PR DESCRIPTION
### Purpose of this PR

CMCL-1359: URP now does temporal reset on camera cuts.
Minimum URP version supported: 14.0.4 (Unity 2022.2.2f1)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

