### PR TITLE
CMCL-1359: URP reset on camera cut for 2.9

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased] 
 - Bugfix: AxisState was not respecting timescale == 0
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
+- URP: add temporal effects reset on camera cut for URP 14.0.4 and up
 
 
 ## [2.9.5] - 2023-01-16

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -9,11 +9,11 @@ using Cinemachine.Utility;
 using UnityEngine.InputSystem;
 #endif
 
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
     #if CINEMACHINE_HDRP_7_3_1
         using UnityEngine.Rendering.HighDefinition;
     #else
-        #if CINEMACHINE_LWRP_7_3_1
+        #if CINEMACHINE_URP
             using UnityEngine.Rendering.Universal;
         #else
             using UnityEngine.Experimental.Rendering.HDPipeline;

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -9,7 +9,7 @@
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using UnityEngine;
     using UnityEditor;
     using UnityEngine.Rendering;
@@ -20,7 +20,7 @@
 
 namespace Cinemachine.PostFX.Editor
 {
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
     [CustomEditor(typeof(CinemachineVolumeSettings))]
     public sealed class CinemachineVolumeSettingsEditor : Cinemachine.Editor.BaseEditor<CinemachineVolumeSettings>
     {
@@ -83,7 +83,7 @@ namespace Cinemachine.PostFX.Editor
                 bool valid = false;
                 DepthOfField dof;
                 if (Target.m_Profile != null && Target.m_Profile.TryGet(out dof))
-#if CINEMACHINE_LWRP_7_3_1 && !CINEMACHINE_HDRP
+#if CINEMACHINE_URP && !CINEMACHINE_HDRP
                 {
                     valid = dof.active && dof.focusDistance.overrideState
                         && dof.mode.overrideState && dof.mode == DepthOfFieldMode.Bokeh;

--- a/com.unity.cinemachine/Editor/Utility/CinemachineLensPresets.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineLensPresets.cs
@@ -3,11 +3,11 @@ using System;
 using UnityEditor;
 using System.Collections.Generic;
 
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
     #if CINEMACHINE_HDRP_7_3_1
     using UnityEngine.Rendering.HighDefinition;
     #else
-        #if CINEMACHINE_LWRP_7_3_1
+        #if CINEMACHINE_URP
         using UnityEngine.Rendering.Universal;
         #else
         using UnityEngine.Experimental.Rendering.HDPipeline;

--- a/com.unity.cinemachine/Editor/com.unity.cinemachine.Editor.asmdef
+++ b/com.unity.cinemachine/Editor/com.unity.cinemachine.Editor.asmdef
@@ -64,7 +64,7 @@
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "7.3.1",
-            "define": "CINEMACHINE_LWRP_7_3_1"
+            "define": "CINEMACHINE_URP"
         },
         {
             "name": "com.unity.timeline",

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -10,11 +10,11 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
     #if CINEMACHINE_HDRP_7_3_1
     using UnityEngine.Rendering.HighDefinition;
     #else
-        #if CINEMACHINE_LWRP_7_3_1
+        #if CINEMACHINE_URP
         using UnityEngine.Rendering.Universal;
         #else
         using UnityEngine.Experimental.Rendering.HDPipeline;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-#if CINEMACHINE_LWRP_7_3_1 || CINEMACHINE_PIXEL_PERFECT_2_0_3
+#if CINEMACHINE_URP || CINEMACHINE_PIXEL_PERFECT_2_0_3
 
 namespace Cinemachine
 {
@@ -35,7 +35,7 @@ namespace Cinemachine
             if (brain == null || !brain.IsLive(vcam))
                 return;
 
-#if CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_URP
             UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera pixelPerfectCamera;
 #elif CINEMACHINE_PIXEL_PERFECT_2_0_3
             UnityEngine.U2D.PixelPerfectCamera pixelPerfectCamera;

--- a/com.unity.cinemachine/Runtime/Core/LensSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/LensSettings.cs
@@ -1,11 +1,11 @@
 using UnityEngine;
 using System;
 
-#if CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1
+#if CINEMACHINE_HDRP || CINEMACHINE_URP
     #if CINEMACHINE_HDRP_7_3_1
     using UnityEngine.Rendering.HighDefinition;
     #else
-        #if CINEMACHINE_LWRP_7_3_1
+        #if CINEMACHINE_URP
         using UnityEngine.Rendering.Universal;
         #else
         using UnityEngine.Experimental.Rendering.HDPipeline;

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -9,7 +9,7 @@ using UnityEngine.Serialization;
     #else
         using UnityEngine.Experimental.Rendering.HDPipeline;
     #endif
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
     using System.Collections.Generic;
     using UnityEngine.Rendering;
     using UnityEngine.Rendering.Universal;
@@ -17,7 +17,7 @@ using UnityEngine.Serialization;
 
 namespace Cinemachine.PostFX
 {
-#if !(CINEMACHINE_HDRP || CINEMACHINE_LWRP_7_3_1)
+#if !(CINEMACHINE_HDRP || CINEMACHINE_URP)
     // Workaround for Unity scripting bug
     /// <summary>
     /// This behaviour is a liaison between Cinemachine with the Post-Processing v3 module.
@@ -230,16 +230,11 @@ namespace Cinemachine.PostFX
                 hdCam.colorPyramidHistoryIsValid = false;
                 hdCam.Reset();
             }
-#elif CINEMACHINE_LDRP_7_3_1
+#elif CINEMACHINE_URP_14
             // Reset temporal effects
             var cam = brain.OutputCamera;
-            if (cam != null)
-            {
-                HDCamera hdCam = HDCamera.GetOrCreate(cam);
-                hdCam.volumetricHistoryIsValid = false;
-                hdCam.colorPyramidHistoryIsValid = false;
-                hdCam.Reset();
-            }
+            if (cam != null && cam.TryGetComponent<UniversalAdditionalCameraData>(out var data))
+                data.resetHistory = true;
 #endif
         }
 
@@ -314,7 +309,7 @@ namespace Cinemachine.PostFX
                 // Update the volume's layer so it will be seen
 #if CINEMACHINE_HDRP
                 var data = brain.gameObject.GetComponent<HDAdditionalCameraData>();
-#elif CINEMACHINE_LWRP_7_3_1
+#elif CINEMACHINE_URP
                 var data = brain.gameObject.GetComponent<UniversalAdditionalCameraData>();
 #endif
                 if (data != null)

--- a/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
+++ b/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef
@@ -41,6 +41,11 @@
             "define": "CINEMACHINE_HDRP_7_3_1"
         },
         {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "14.0.0",
+            "define": "CINEMACHINE_HDRP_14"
+        },
+        {
             "name": "com.unity.modules.physics2d",
             "expression": "1.0.0",
             "define": "CINEMACHINE_PHYSICS_2D"
@@ -58,7 +63,12 @@
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "7.3.1",
-            "define": "CINEMACHINE_LWRP_7_3_1"
+            "define": "CINEMACHINE_URP"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "14.0.4",
+            "define": "CINEMACHINE_URP_14"
         },
         {
             "name": "com.unity.2d.pixel-perfect",
@@ -79,11 +89,6 @@
             "name": "com.unity.modules.imgui",
             "expression": "1.0.0",
             "define": "CINEMACHINE_UNITY_IMGUI"
-        },
-        {
-            "name": "com.unity.render-pipelines.high-definition",
-            "expression": "14.0.0",
-            "define": "CINEMACHINE_HDRP_14"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
CMCL-1359: URP now does temporal reset on camera cuts.
Minimum URP version supported for this feature: 14.0.4 (Unity 2022.2.2f1)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation
