### PR TITLE
CMCL-1361: SaveDuringPlay should not follow UnityEngine.Object links

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -286,8 +286,8 @@ namespace Cinemachine.Editor
             if (m_GuidesLabel == null)
                 m_GuidesLabel = new ("Game View Guides", CinemachineCorePrefs.s_ShowInGameGuidesLabel.tooltip);
 
-            SaveDuringPlay.SaveDuringPlay.Enabled = EditorGUILayout.Toggle(
-                CinemachineCorePrefs.s_SaveDuringPlayLabel, SaveDuringPlay.SaveDuringPlay.Enabled);
+            SaveDuringPlay.Enabled = EditorGUILayout.Toggle(
+                CinemachineCorePrefs.s_SaveDuringPlayLabel, SaveDuringPlay.Enabled);
 
             int index = CinemachineCorePrefs.ShowInGameGuides.Value 
                 ? (CinemachineCorePrefs.DraggableComposerGuides.Value ? 2 : 1) : 0;
@@ -299,7 +299,7 @@ namespace Cinemachine.Editor
                 InspectorUtility.RepaintGameView();
             }
 
-            if (Application.isPlaying && SaveDuringPlay.SaveDuringPlay.Enabled)
+            if (Application.isPlaying && SaveDuringPlay.Enabled)
                 EditorGUILayout.HelpBox(
                     "CinemachineCamera settings changes made during Play Mode will be "
                         + "propagated back to the scene when Play Mode is exited.",

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -6,7 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;
 
-namespace Cinemachine.SaveDuringPlay
+namespace Cinemachine.Editor
 {
     /// <summary>A collection of tools for finding objects</summary>
     static class ObjectTreeUtil
@@ -179,13 +179,9 @@ namespace Cinemachine.SaveDuringPlay
                         var newLength = (int)length;
                         var currentLength = list.Count;
                         for (int i = 0; i < currentLength - newLength; ++i)
-                        {
                             list.RemoveAt(currentLength - i - 1); // make list shorter if needed
-                        }
                         for (int i = 0;  i < newLength - currentLength; ++i)
-                        {
                             list.Add(GetValue(type.GetGenericArguments()[0])); // make list longer if needed
-                        }
                         doneSomething = true;
                     }
 
@@ -203,9 +199,9 @@ namespace Cinemachine.SaveDuringPlay
                     if (doneSomething)
                         obj = list;
                 }
-                else
+                else if (!typeof(UnityEngine.Object).IsAssignableFrom(obj.GetType()))
                 {
-                    // Check if it's a complex type
+                    // Check if it's a complex type (but don't follow UnityEngine.Object references)
                     FieldInfo[] fields = obj.GetType().GetFields(kBindingFlags);
                     if (fields.Length > 0)
                     {

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -349,17 +349,17 @@ namespace Cinemachine.Editor
             var helpBox = ux.AddChild(new HelpBox("CinemachineCamera settings changes made during Play Mode will be "
                     + "propagated back to the scene when Play Mode is exited.", 
                 HelpBoxMessageType.Info));
-            helpBox.SetVisible(SaveDuringPlay.SaveDuringPlay.Enabled && Application.isPlaying);
+            helpBox.SetVisible(SaveDuringPlay.Enabled && Application.isPlaying);
 
             var toggle = ux.AddChild(new Toggle(CinemachineCorePrefs.s_SaveDuringPlayLabel.text) 
             { 
                 tooltip = CinemachineCorePrefs.s_SaveDuringPlayLabel.tooltip,
-                value = SaveDuringPlay.SaveDuringPlay.Enabled
+                value = SaveDuringPlay.Enabled
             });
             toggle.AddToClassList(InspectorUtility.kAlignFieldClass);
             toggle.RegisterValueChangedCallback((evt) => 
             {
-                SaveDuringPlay.SaveDuringPlay.Enabled = evt.newValue;
+                SaveDuringPlay.Enabled = evt.newValue;
                 helpBox.SetVisible(evt.newValue && Application.isPlaying);
             });
 

--- a/com.unity.cinemachine/Editor/Windows/CinemachineCorePrefs.cs
+++ b/com.unity.cinemachine/Editor/Windows/CinemachineCorePrefs.cs
@@ -49,7 +49,7 @@ namespace Cinemachine.Editor
                 ShowInGameGuides.Value = EditorGUILayout.Toggle(s_ShowInGameGuidesLabel, ShowInGameGuides.Value);
                 DraggableComposerGuides.Value = EditorGUILayout.Toggle(k_DraggableGuidesLabel, DraggableComposerGuides.Value);
                 ShowBrainIconInHierarchy.Value = EditorGUILayout.Toggle(k_ShowBrainIconsLabel, ShowBrainIconInHierarchy.Value);
-                SaveDuringPlay.SaveDuringPlay.Enabled = EditorGUILayout.Toggle(s_SaveDuringPlayLabel, SaveDuringPlay.SaveDuringPlay.Enabled);
+                SaveDuringPlay.Enabled = EditorGUILayout.Toggle(s_SaveDuringPlayLabel, SaveDuringPlay.Enabled);
 #if CINEMACHINE_UGUI
                 StoryboardGlobalMute.Value = EditorGUILayout.Toggle(s_StoryboardGlobalMuteLabel, StoryboardGlobalMute.Value);
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-1361: SaveDuringPlay was entering objects that were in saved fields, and incorrectly saving the fields within those objects.

One way to see that bug: in the ThirdPerson Shooter sample start the game, then change the value of LockCursor in Player Controller.  Stop the game.  The LockCursor state gets the SaveDuringPlay treatment, even though SimplePlayerController is not SaveDuringPlay.  It happens because CinemachineInpuutAxisController (which is SaveDuringPlay) holds a reference to the SimpleController and incorrectly goes into it to save its fields.

Also corrected the namespace of SaveDuringPlay.

