### PR TITLE
CMCL-0000: Add LockCursor to Shooter sample

### DIFF
--- a/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
@@ -998,8 +998,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ButtonText: Help
-  Position: {x: 0.9, y: 0.05}
-  Displayed: 0
+  Position: {x: 1.1, y: 0.05}
+  Displayed: 1
   HelpText: "This scene shows a third person shooter game.  Use WASD to move, Spacebar
     to jump, Shift to sprint.  Mouse left click to fire projectiles. The mouse rotates
     the Player Aiming Core object, which controls the player direction and aim. 
@@ -1022,6 +1022,21 @@ MonoBehaviour:
     target the player when the player moves close to them. To visualize the trigger
     zone, you can enable the Mesh Renderers on the enemies'  ProximityTrigger child
     objects."
+  OnHelpDismissed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1802572052}
+        m_TargetAssemblyTypeName: Cinemachine.Examples.SimplePlayerController, Assembly-CSharp
+        m_MethodName: EnableLockCursor
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!4 &1040083249
 Transform:
   m_ObjectHideFlags: 0
@@ -2359,6 +2374,17 @@ Animator:
   m_CorrespondingSourceObject: {fileID: 7887234737240387235, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
   m_PrefabInstance: {fileID: 1802572047}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1802572052 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8077383552022060413, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_PrefabInstance: {fileID: 1802572047}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 297aaca66939f724fbbc8f0c485168bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1972898889
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SamplesHelpGUI.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SamplesHelpGUI.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
 namespace Cinemachine.Examples
@@ -19,6 +20,9 @@ namespace Cinemachine.Examples
 
         [TextArea(minLines: 10, maxLines: 50)]
         public string HelpText;
+
+        [Tooltip("Event sent when the help window is dismissed")]
+        public UnityEvent OnHelpDismissed = new UnityEvent();
 
         Vector2 m_Size = Vector2.zero;
 
@@ -45,7 +49,10 @@ namespace Cinemachine.Examples
                     GUILayout.Label(HelpText);
                     GUILayout.EndVertical();
                     if (GUILayout.Button("Got it!"))
+                    {
                         Displayed = false;
+                        OnHelpDismissed.Invoke();
+                    }
                 }, title);
             }
             else

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -59,6 +59,9 @@ namespace Cinemachine.Examples
         public bool IsJumping => m_IsJumping;
         public bool IsMoving => m_LastInput.sqrMagnitude > 0.01f;
 
+        public void EnableLockCursor() => LockCursor = true;
+        public void DisableLockCursor() => LockCursor = false;
+
         /// Report the available input axes to the input axis controller.
         /// We use the Input Axis Controller because it works with both the Input package
         /// and the Legacy input system.  This is sample code and we
@@ -81,12 +84,12 @@ namespace Cinemachine.Examples
             m_CurrentVelocityY = 0;
             m_IsSprinting = false;
             m_IsJumping = false;
-            if (LockCursor)
-                Cursor.lockState = CursorLockMode.Locked;
         }
 
         void Update()
         {
+            Cursor.lockState = LockCursor ? CursorLockMode.Locked : CursorLockMode.None;
+
             PreUpdate?.Invoke();
 
             // Process Jump and gravity


### PR DESCRIPTION
Add LockCursor to the shooter sample.  It gets turned on via an event when the help text is dismissed.
This PR depends on https://github.com/Unity-Technologies/com.unity.cinemachine/pull/767 (SaveDuringPlay bugfix)

