### PR TITLE
CMCL-1362: groupframing works on lookat target also

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
 - URP: add temporal effects reset on camera cut
 - Add Weight setting to CinemachinePostProcessing and CinemachineVolumeSettings
+- GroupFraming also works on LookAt target
 
 
 ## [3.0.0-pre.3] - 2022-10-28

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -159,7 +159,8 @@ namespace Cinemachine
             if (stage != CinemachineCore.Stage.Noise)
                 return;
             
-            var group = vcam.FollowTargetAsGroup;
+            var group = vcam.LookAtTargetAsGroup;
+            group ??= vcam.FollowTargetAsGroup;
             if (group == null)
                 return;
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1362: GroupFraming must consider LookAt target if different from Tracking Target

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

