### PR TITLE
CMCL-1364: Progress bar for Upgrader

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- Progress bar added to Cinemachine Upgrader.
 
-## [3.0.0-pre.4] - 2022-11-01
+## [3.0.0-pre.4] - 2022-02-09
+- Progress bar added to Cinemachine Upgrader.
 - Bugfix: Physical lens settings were not being properly applied.
 - 3rdPersonFollow and 3rdPersonAim are deprecated and replaced by ThirdPersonFollow and ThirdPersonAim respectively.
 - Bugfix: Lens blending was wrong.

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [3.0.0-pre.4] - 2022-02-09
+## [3.0.0-pre.4] - 2023-02-09
 - Progress bar added to Cinemachine Upgrader.
 - Bugfix: Physical lens settings were not being properly applied.
 - 3rdPersonFollow and 3rdPersonAim are deprecated and replaced by ThirdPersonFollow and ThirdPersonAim respectively.

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Progress bar added to Cinemachine Upgrader.
+
 ## [3.0.0-pre.4] - 2022-11-01
 - Bugfix: Physical lens settings were not being properly applied.
 - 3rdPersonFollow and 3rdPersonAim are deprecated and replaced by ThirdPersonFollow and ThirdPersonAim respectively.

--- a/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
+++ b/com.unity.cinemachine/Editor/Samples/SampleDependencyImporter.cs
@@ -62,7 +62,6 @@ namespace Cinemachine.Editor
             return false;
         }
         
-        const string k_SampleName = "Samples/Cinemachine/";
         AddRequest m_PackageAddRequest;
         int m_PackageDependencyIndex;
         List<string> m_PackageDependencies = new ();

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -68,17 +68,22 @@ namespace Cinemachine.Editor
                 + "Upgrade scene?",
                 "Upgrade", "Cancel"))
             {
+                Thread.Sleep(1); // this is needed so the Display Dialog closes, and lets the progress bar open
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Initializing...", 0);
                 var manager = new CinemachineUpgradeManager(false);
                 var scene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
                 var rootObjects = scene.GetRootGameObjects();
                 var upgradable = manager.GetUpgradables(
                     rootObjects, manager.m_ObjectUpgrader.RootUpgradeComponentTypes, true);
                 var upgradedObjects = new HashSet<GameObject>();
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Scene...", 0.5f);
                 manager.UpgradeNonPrefabs(upgradable, upgradedObjects, null);
                 UpgradeObjectReferences(rootObjects);
 
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Cleaning up...", 1f);
                 foreach (var go in upgradedObjects)
                     manager.m_ObjectUpgrader.DeleteObsoleteComponents(go);
+                EditorUtility.ClearProgressBar();
             }
         }
 
@@ -114,11 +119,10 @@ namespace Cinemachine.Editor
                 manager.UpgradeReferencablePrefabInstances(conversionLinksPerScene);
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.5f);
                 manager.UpgradePrefabAssets(false);
-                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.7f);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Scenes...", 0.7f);
                 manager.UpgradeRemaining(conversionLinksPerScene, timelineRenames);
-                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading scenes...", 0.9f);
-                manager.CleanupPrefabAssets();
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Cleaning up...", 1);
+                manager.CleanupPrefabAssets();
                 EditorUtility.ClearProgressBar();
             }
         }

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Cinemachine.Utility;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -81,6 +82,7 @@ namespace Cinemachine.Editor
             }
         }
 
+        const string k_ProgressBarTitle = "Upgrade Progress";
         /// <summary>
         /// Upgrades all objects in all scenes and prefabs
         /// </summary>
@@ -102,14 +104,22 @@ namespace Cinemachine.Editor
                 + "Upgrade project?",
                 "I made a backup, go ahead", "Cancel"))
             {
+                Thread.Sleep(1); // this is needed so the Display Dialog closes, and lets the progress bar open
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Initializing...", 0);
                 var manager = new CinemachineUpgradeManager(true);
-
                 manager.PrepareUpgrades(out var conversionLinksPerScene, out var timelineRenames);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.2f);
                 manager.UpgradePrefabAssets(true);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.3f);
                 manager.UpgradeReferencablePrefabInstances(conversionLinksPerScene);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.5f);
                 manager.UpgradePrefabAssets(false);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.7f);
                 manager.UpgradeRemaining(conversionLinksPerScene, timelineRenames);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading scenes...", 0.9f);
                 manager.CleanupPrefabAssets();
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Cleaning up...", 1);
+                EditorUtility.ClearProgressBar();
             }
         }
 

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -30,6 +30,7 @@ namespace Cinemachine.Editor
 
         // This gets set to help with more informative warning messages about objects
         string m_CurrentSceneOrPrefab;
+        const string k_ProgressBarTitle = "Upgrade Progress";
 
         /// <summary>
         /// GML Temporary helper method for testing.
@@ -87,7 +88,6 @@ namespace Cinemachine.Editor
             }
         }
 
-        const string k_ProgressBarTitle = "Upgrade Progress";
         /// <summary>
         /// Upgrades all objects in all scenes and prefabs
         /// </summary>
@@ -113,13 +113,13 @@ namespace Cinemachine.Editor
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Initializing...", 0);
                 var manager = new CinemachineUpgradeManager(true);
                 manager.PrepareUpgrades(out var conversionLinksPerScene, out var timelineRenames);
-                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.2f);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.1f);
                 manager.UpgradePrefabAssets(true);
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.3f);
                 manager.UpgradeReferencablePrefabInstances(conversionLinksPerScene);
-                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.5f);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Prefabs...", 0.6f);
                 manager.UpgradePrefabAssets(false);
-                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Scenes...", 0.7f);
+                EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Upgrading Scenes...", 0.8f);
                 manager.UpgradeRemaining(conversionLinksPerScene, timelineRenames);
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Cleaning up...", 1);
                 manager.CleanupPrefabAssets();

--- a/com.unity.cinemachine/Samples~/Old Samples from CM2/Scenes/2D/MouseScrollZoom2D.cs
+++ b/com.unity.cinemachine/Samples~/Old Samples from CM2/Scenes/2D/MouseScrollZoom2D.cs
@@ -24,15 +24,15 @@ namespace Cinemachine.Examples
 
 #if UNITY_EDITOR
             // This code shows how to play nicely with the VirtualCamera's SaveDuringPlay functionality
-            SaveDuringPlay.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
-            SaveDuringPlay.SaveDuringPlay.OnHotSave += RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave += RestoreOriginalOrthographicSize;
 #endif
         }
 
 #if UNITY_EDITOR
         void OnDestroy()
         {
-            SaveDuringPlay.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
         }
         
         void RestoreOriginalOrthographicSize()


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1364](https://jira.unity3d.com/browse/CMCL-1364): Adds a progress bar to upgrader, so users don't think that their large project is frozen while upgrading.

Also fixed SaveDuringPlay api in one script in the old samples.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation