### PR TITLE
CMCL-0000: Old samples SaveDuring play script fixed

### DIFF
--- a/com.unity.cinemachine/Samples~/Old Samples from CM2/Scenes/2D/MouseScrollZoom2D.cs
+++ b/com.unity.cinemachine/Samples~/Old Samples from CM2/Scenes/2D/MouseScrollZoom2D.cs
@@ -24,15 +24,15 @@ namespace Cinemachine.Examples
 
 #if UNITY_EDITOR
             // This code shows how to play nicely with the VirtualCamera's SaveDuringPlay functionality
-            SaveDuringPlay.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
-            SaveDuringPlay.SaveDuringPlay.OnHotSave += RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave += RestoreOriginalOrthographicSize;
 #endif
         }
 
 #if UNITY_EDITOR
         void OnDestroy()
         {
-            SaveDuringPlay.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
+            Editor.SaveDuringPlay.OnHotSave -= RestoreOriginalOrthographicSize;
         }
         
         void RestoreOriginalOrthographicSize()


### PR DESCRIPTION
### Purpose of this PR
Old samples gave an error because one script was using bad Api for SaveDuringPlay - fixed.