### PR TITLE
CMCL-CMCL-1356: Improved fix for axis drift

### DIFF
--- a/com.unity.cinemachine/Runtime/Components/CinemachineTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineTransposer.cs
@@ -272,7 +272,7 @@ namespace Cinemachine
                     dampedOrientation = Quaternion.Slerp(
                         m_PreviousReferenceOrientation, targetOrientation, t);
                 }
-                else
+                else if (m_BindingMode != BindingMode.SimpleFollowWithWorldUp)
                 {
                     var relative = (Quaternion.Inverse(m_PreviousReferenceOrientation)
                         * targetOrientation).eulerAngles;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1356: Improved fix.  We can bypass rotation damping altogether in SimpleFollow because angular damping is always 0 in this mode.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

