### PR TITLE
CMCL-1356: Improved fix for axis drift for CM3

### DIFF
--- a/com.unity.cinemachine/Runtime/Core/TargetTracking.cs
+++ b/com.unity.cinemachine/Runtime/Core/TargetTracking.cs
@@ -276,7 +276,7 @@ namespace Cinemachine.TargetTracking
                     dampedOrientation = Quaternion.Slerp(
                         PreviousReferenceOrientation, targetOrientation, t);
                 }
-                else
+                else if (settings.BindingMode != BindingMode.SimpleFollowWithWorldUp)
                 {
                     var relative = (Quaternion.Inverse(PreviousReferenceOrientation)
                         * targetOrientation).eulerAngles;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1356: Improved fix.  We can bypass rotation damping altogether in SimpleFollow because angular damping is always 0 in this mode.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 