### PR TITLE
CMCL-0000: Upgrader fixes - gigaya test

### DIFF
--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -393,6 +393,8 @@ namespace Cinemachine.Editor
                 
                 foreach (var c in components)
                 {
+                    if (c == null)
+                        continue; // ignore
                     if (c.GetComponentInParent<CinemachineDoNotUpgrade>(true) != null)
                         continue; // is a backup copy
 

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
@@ -143,10 +143,7 @@ namespace Cinemachine.Editor
                 return c.UpgradeToCm3_GetTargetType();
 #endif
             var oldType = b.GetType();
-            if (ClassUpgradeMap.ContainsKey(oldType))
-                return ClassUpgradeMap[oldType];
-
-            return oldType;
+            return ClassUpgradeMap.ContainsKey(oldType) ? ClassUpgradeMap[oldType] : oldType;
         }
 
         /// <summary>
@@ -155,6 +152,9 @@ namespace Cinemachine.Editor
         /// </summary>
         public void ProcessAnimationClip(AnimationClip animationClip, Animator trackAnimator)
         {
+            if (animationClip == null || trackAnimator == null)
+                return;
+            
             var existingEditorBindings = AnimationUtility.GetCurveBindings(animationClip);
             foreach (var previousBinding in existingEditorBindings)
             {


### PR DESCRIPTION
### Purpose of this PR
Found a few missing null checks while testing gigaya.

The other errors are not related to us. They are triggered by us, because gigaya is full of corrupt prefabs. When we open them to check if need to upgrade them, they throw errors. 
The scene that we can't open is also a scene that's corrupted.
These other errors can be cleared in the console.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested with Gigaya