### PR TITLE
CMCL-1380: Cleanup of UITK refresh callbacks

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBasicMultiChannelPerlinEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBasicMultiChannelPerlinEditor.cs
@@ -18,7 +18,7 @@ namespace Cinemachine.Editor
         {
             serializedObject.Update();
 
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this);
+            this.IMGUI_DrawMissingCmCameraHelpBox();
             bool needWarning = false;
             for (int i = 0; !needWarning && i < targets.Length; ++i)
                 needWarning = (targets[i] as CinemachineBasicMultiChannelPerlin).NoiseProfile == null;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -68,13 +68,13 @@ namespace Cinemachine.Editor
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraCutEvent)));
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
 
-            ux.schedule.Execute(() =>
+            ux.ContinuousUpdate(() =>
             {
                 if (target == null || liveCamera == null)
                     return;
                 liveCamera.value = Target.ActiveVirtualCamera as CinemachineVirtualCameraBase;
                 liveBlend.value = Target.ActiveBlend != null ? Target.ActiveBlend.Description : string.Empty;
-            }).Every(100);
+            });
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -15,22 +15,10 @@ namespace Cinemachine.Editor
         CinemachineBrain Target => target as CinemachineBrain;
 
         EmbeddeAssetEditor<CinemachineBlenderSettings> m_BlendsEditor;
-        ObjectField m_LiveCamera;
-        TextField m_LiveBlend;
         bool m_EventsExpanded = false;
 
-        void OnEnable()
-        {
-            m_BlendsEditor = new EmbeddeAssetEditor<CinemachineBlenderSettings>();
-            EditorApplication.update += UpdateVisibility;
-        }
-
-        void OnDisable()
-        {
-            if (m_BlendsEditor != null)
-                m_BlendsEditor.OnDisable();
-            EditorApplication.update -= UpdateVisibility;
-        }
+        void OnEnable() => m_BlendsEditor = new EmbeddeAssetEditor<CinemachineBlenderSettings>();
+        void OnDisable() => m_BlendsEditor?.OnDisable();
 
         public override VisualElement CreateInspectorGUI()
         {
@@ -40,14 +28,14 @@ namespace Cinemachine.Editor
             var row = ux.AddChild(new InspectorUtility.LeftRightContainer());
             row.Left.Add(new Label("Live Camera")
                 { tooltip = "The Cm Camera that is currently active", style = { alignSelf = Align.Center, flexGrow = 1 }});
-            m_LiveCamera = row.Right.AddChild(new ObjectField("") 
+            var liveCamera = row.Right.AddChild(new ObjectField("") 
                 { objectType = typeof(CinemachineVirtualCameraBase), style = { flexGrow = 1 }});
             row.SetEnabled(false);
 
             row = ux.AddChild(new InspectorUtility.LeftRightContainer());
             row.Left.Add(new Label("Live Blend")
                 { tooltip = "The state of currently active blend, if any", style = { alignSelf = Align.Center, flexGrow = 1 }});
-            m_LiveBlend = row.Right.AddChild(new TextField("") { style = { flexGrow = 1 }});
+            var liveBlend = row.Right.AddChild(new TextField("") { style = { flexGrow = 1 }});
             row.SetEnabled(false);
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ShowDebugText)));
@@ -80,15 +68,15 @@ namespace Cinemachine.Editor
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraCutEvent)));
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
 
-            return ux;
-        }
+            ux.schedule.Execute(() =>
+            {
+                if (target == null || liveCamera == null)
+                    return;
+                liveCamera.value = Target.ActiveVirtualCamera as CinemachineVirtualCameraBase;
+                liveBlend.value = Target.ActiveBlend != null ? Target.ActiveBlend.Description : string.Empty;
+            }).Every(100);
 
-        void UpdateVisibility()
-        {
-            if (Target == null || m_LiveCamera == null)
-                return;
-            m_LiveCamera.value = Target.ActiveVirtualCamera as CinemachineVirtualCameraBase;
-            m_LiveBlend.value = Target.ActiveBlend != null ? Target.ActiveBlend.Description : string.Empty;
+            return ux;
         }
 
         [DrawGizmo(GizmoType.Selected | GizmoType.NonSelected, typeof(CinemachineBrain))]

--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraOffsetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraOffsetEditor.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            CmPipelineComponentInspectorUtility.AddMissingCmCameraHelpBox(this, ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Offset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ApplyAfter)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PreserveComposition)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraOffsetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraOffsetEditor.cs
@@ -10,21 +10,15 @@ namespace Cinemachine.Editor
     {
         CinemachineCameraOffset Target => target as CinemachineCameraOffset;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            CmPipelineComponentInspectorUtility.AddMissingCmCameraHelpBox(this, ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Offset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ApplyAfter)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PreserveComposition)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
@@ -55,14 +55,14 @@ namespace Cinemachine.Editor
                 + "\n\nTo fix this, reduce the number of points in the confining shape, "
                 + "or set the MaxWindowSize parameter to limit skeleton computation.",
                 HelpBoxMessageType.Warning));
-
+            
             UpdateBakingProgress();
             ux.schedule.Execute(UpdateBakingProgress).Every(250); // GML todo: is there a better way to do this?
             void UpdateBakingProgress() 
             {
                 if (Target == null)
                     return; // target deleted
-                
+
                 oversizedCameraHelp.SetVisible(!Target.OversizeWindow.Enabled && Target.IsCameraLensOversized());
                 if (!Target.OversizeWindow.Enabled)
                 {

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
@@ -13,16 +13,12 @@ namespace Cinemachine.Editor
     class CinemachineConfiner2DEditor : UnityEditor.Editor
     {
         CinemachineConfiner2D Target => target as CinemachineConfiner2D;
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
 
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
 
             var boundsHelp = ux.AddChild(new HelpBox(
                 "Bounding Shape must be a PolygonCollider2D, BoxCollider2D, or CompositeCollider2D.", 
@@ -93,8 +89,6 @@ namespace Cinemachine.Editor
                     + "Call this when the input bounding shape changes " 
                     + "(non-uniform scale, rotation, or points are moved, added or deleted)."
             });
-
-            m_PipelineUtility.UpdateState();
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner3DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner3DEditor.cs
@@ -13,16 +13,11 @@ namespace Cinemachine.Editor
     {
         CinemachineConfiner3D Target => target as CinemachineConfiner3D;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
 
             var boundsHelp = ux.AddChild(new HelpBox(
                 "Bounding Volume must be a BoxCollider, SphereCollider, CapsuleCollider, or convex MeshCollider.", 
@@ -31,7 +26,6 @@ namespace Cinemachine.Editor
             var volumeProp = serializedObject.FindProperty(() => Target.BoundingVolume);
             ux.Add(new PropertyField(volumeProp));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.SlowingDistance)));
-            m_PipelineUtility.UpdateState();
 
             TrackVolume(volumeProp);
             ux.TrackPropertyValue(volumeProp, TrackVolume);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
@@ -14,23 +14,18 @@ namespace Cinemachine.Editor
     {
         CinemachineDeoccluder Target => target as CinemachineDeoccluder;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CollideAgainst)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.IgnoreTag)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TransparentLayers)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.MinimumDistanceFromTarget)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.AvoidObstacles)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ShotQualityEvaluation)));
-            m_PipelineUtility.UpdateState();
+
             return ux;
         }
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
@@ -9,23 +9,12 @@ namespace Cinemachine.Editor
     class CinemachineExternalCameraEditor : UnityEditor.Editor
     {
         CinemachineExternalCamera Target => target as CinemachineExternalCamera;
-        CmCameraInspectorUtility m_CameraUtility = new();
-
-        void OnEnable()
-        {
-            m_CameraUtility.OnEnable(targets);
-        }
-
-        void OnDisable()
-        {
-            m_CameraUtility.OnDisable();
-        }
 
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_CameraUtility.AddCameraStatus(ux);
+            this.AddCameraStatus(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TransitionHint)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFollowEditor.cs
@@ -24,7 +24,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackerSettings)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FollowOffset)));
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFollowEditor.cs
@@ -10,17 +10,13 @@ namespace Cinemachine.Editor
     {
         CinemachineFollow Target => target as CinemachineFollow;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
         void OnEnable()
         {
-            m_PipelineUtility = new (this);
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
         }
         
         void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
         }
 
@@ -28,11 +24,10 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackerSettings)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FollowOffset)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFollowZoomEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFollowZoomEditor.cs
@@ -10,21 +10,15 @@ namespace Cinemachine.Editor
     {
         CinemachineFollowZoom Target => target as CinemachineFollowZoom;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Width)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FovRange)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFollowZoomEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFollowZoomEditor.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Width)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FovRange)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -68,15 +68,13 @@ namespace Cinemachine
             button.AddManipulator(manipulator);
             button.clickable = null;
 
-            TrackSourceValidity();
-            ux.schedule.Execute(TrackSourceValidity).Every(250); // GML todo: is there a better way to do this?
-            void TrackSourceValidity() => invalidSrcMsg.SetVisible(Target != null && !Target.HasValueSource());
+            ux.TrackAnyUserActivity(() => invalidSrcMsg.SetVisible(Target != null && !Target.HasValueSource()));
 
             return ux;
         }
 
         [CustomPropertyDrawer(typeof(CinemachineFreeLookModifier.Modifier), true)]
-        class InputAxisControllerItemPropertyDrawer : PropertyDrawer
+        class FreeLookModifierItemPropertyDrawer : PropertyDrawer
         {
             public override VisualElement CreatePropertyGUI(SerializedProperty property)
             {
@@ -114,14 +112,12 @@ namespace Cinemachine
                     childProperty.NextVisible(false);
                 }
 
-                TrackSourceValidity();
-                foldout.schedule.Execute(TrackSourceValidity).Every(250); // GML todo: is there a better way to do this?
-                void TrackSourceValidity() 
+                foldout.TrackAnyUserActivity(() => 
                 {
                     var showWarning = m != null && !m.HasRequiredComponent;
                     noComponentsMsg.SetVisible(showWarning);
                     warningSymbol.SetVisible(showWarning);
-                };
+                });
 
                 return new InspectorUtility.FoldoutWithOverlay(foldout, overlay, null);
             }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -12,14 +12,8 @@ namespace Cinemachine.Editor
     {
         CinemachineGroupFraming Target => target as CinemachineGroupFraming;
 
-        VisualElement m_GroupSizeIsZeroHelp;
-        VisualElement m_PerspectiveControls;
-        VisualElement m_OrthoControls;
-
         void OnEnable() 
         {
-            EditorApplication.update += UpdateVisibility;
-
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             CinemachineDebug.OnGUIHandlers += OnGuiHandler;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
@@ -30,8 +24,6 @@ namespace Cinemachine.Editor
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
                 InspectorUtility.RepaintGameView();
-
-            EditorApplication.update -= UpdateVisibility;
         }
 
         public override VisualElement CreateInspectorGUI()
@@ -40,22 +32,22 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.FollowGroup);
-            m_GroupSizeIsZeroHelp = ux.AddChild(new HelpBox("Group size is zero, cannot frame.", HelpBoxMessageType.Warning));
+            var groupSizeIsZeroHelp = ux.AddChild(new HelpBox("Group size is zero, cannot frame.", HelpBoxMessageType.Warning));
 
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingMode)));
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingSize)));
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.Damping)));
 
-            m_PerspectiveControls = ux.AddChild(new VisualElement());
+            var perspectiveControls = ux.AddChild(new VisualElement());
 
             var sizeAdjustmentProperty = serializedTarget.FindProperty(() => Target.SizeAdjustment);
-            m_PerspectiveControls.Add(new PropertyField(sizeAdjustmentProperty));
-            m_PerspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.LateralAdjustment)));
-            var fovRange = m_PerspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.FovRange)));
-            var dollyRange = m_PerspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.DollyRange)));
+            perspectiveControls.Add(new PropertyField(sizeAdjustmentProperty));
+            perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.LateralAdjustment)));
+            var fovRange = perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.FovRange)));
+            var dollyRange = perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.DollyRange)));
 
-            m_OrthoControls = ux.AddChild(new VisualElement());
-            m_OrthoControls.Add(new PropertyField(serializedTarget.FindProperty(() => Target.OrthoSizeRange)));
+            var orthoControls = ux.AddChild(new VisualElement());
+            orthoControls.Add(new PropertyField(serializedTarget.FindProperty(() => Target.OrthoSizeRange)));
 
             ux.TrackPropertyValue(sizeAdjustmentProperty, (prop) =>
             {
@@ -66,27 +58,26 @@ namespace Cinemachine.Editor
                 dollyRange.SetVisible(haveDolly);
             });
             
-            UpdateVisibility();
-            return ux;
-        }
-
-        void UpdateVisibility()
-        {
-            if (target == null || m_GroupSizeIsZeroHelp == null)
-                return; 
-
-            ICinemachineTargetGroup group = null;
-            for (int i = 0; group == null && i < targets.Length; ++i)
+            ux.TrackAnyUserActivity(() =>
             {
-                var vcam = (targets[i] as CinemachineGroupFraming).ComponentOwner;
-                if (vcam != null)
-                    group = vcam.FollowTargetAsGroup;
-            }
-            m_GroupSizeIsZeroHelp.SetVisible(group != null && group.Sphere.radius < 0.01f);
+                if (target == null || groupSizeIsZeroHelp == null)
+                    return; 
 
-            bool ortho = Target.ComponentOwner != null && Target.ComponentOwner.State.Lens.Orthographic;
-            m_PerspectiveControls.SetVisible(!ortho);
-            m_OrthoControls.SetVisible(ortho);
+                ICinemachineTargetGroup group = null;
+                for (int i = 0; group == null && i < targets.Length; ++i)
+                {
+                    var vcam = (targets[i] as CinemachineGroupFraming).ComponentOwner;
+                    if (vcam != null)
+                        group = vcam.FollowTargetAsGroup;
+                }
+                groupSizeIsZeroHelp.SetVisible(group != null && group.Sphere.radius < 0.01f);
+
+                bool ortho = Target.ComponentOwner != null && Target.ComponentOwner.State.Lens.Orthographic;
+                perspectiveControls.SetVisible(!ortho);
+                orthoControls.SetVisible(ortho);
+            });
+
+            return ux;
         }
 
         protected virtual void OnGuiHandler(CinemachineBrain brain)

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -31,7 +31,7 @@ namespace Cinemachine.Editor
             var serializedTarget = new SerializedObject(Target);
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.FollowGroup);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Group);
             var groupSizeIsZeroHelp = ux.AddChild(new HelpBox("Group size is zero, cannot frame.", HelpBoxMessageType.Warning));
 
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingMode)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -12,14 +12,12 @@ namespace Cinemachine.Editor
     {
         CinemachineGroupFraming Target => target as CinemachineGroupFraming;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         VisualElement m_GroupSizeIsZeroHelp;
         VisualElement m_PerspectiveControls;
         VisualElement m_OrthoControls;
 
         void OnEnable() 
         {
-            m_PipelineUtility = new(this);
             EditorApplication.update += UpdateVisibility;
 
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
@@ -34,7 +32,6 @@ namespace Cinemachine.Editor
                 InspectorUtility.RepaintGameView();
 
             EditorApplication.update -= UpdateVisibility;
-            m_PipelineUtility.OnDisable();
         }
 
         public override VisualElement CreateInspectorGUI()
@@ -42,7 +39,7 @@ namespace Cinemachine.Editor
             var serializedTarget = new SerializedObject(Target);
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.FollowGroup);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.FollowGroup);
             m_GroupSizeIsZeroHelp = ux.AddChild(new HelpBox("Group size is zero, cannot frame.", HelpBoxMessageType.Warning));
 
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingMode)));
@@ -69,7 +66,6 @@ namespace Cinemachine.Editor
                 dollyRange.SetVisible(haveDolly);
             });
             
-            m_PipelineUtility.UpdateState();
             UpdateVisibility();
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLockToTargetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLockToTargetEditor.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
             return ux;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLockToTargetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLockToTargetEditor.cs
@@ -10,19 +10,13 @@ namespace Cinemachine.Editor
     {
         CinemachineHardLockToTarget Target => target as CinemachineHardLockToTarget;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
@@ -7,16 +7,10 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachineHardLookAtEditor : UnityEditor.Editor
     {
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
-            m_PipelineUtility.UpdateState();
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
@@ -10,7 +10,7 @@ namespace Cinemachine.Editor
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -11,18 +11,14 @@ namespace Cinemachine.Editor
     {
         CinemachineOrbitalFollow Target => target as CinemachineOrbitalFollow;
 
-        VisualElement m_NoControllerHelp;
-
         void OnEnable()
         {
-            EditorApplication.update += UpdateHelpBoxes;
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
             CinemachineSceneToolUtility.RegisterTool(typeof(OrbitalFollowOrbitSelection));
         }
         
         void OnDisable()
         {
-            EditorApplication.update -= UpdateHelpBoxes;
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
             CinemachineSceneToolUtility.UnregisterTool(typeof(OrbitalFollowOrbitSelection));
         }
@@ -41,7 +37,7 @@ namespace Cinemachine.Editor
             var m_Orbits = ux.AddChild(new PropertyField(serializedObject.FindProperty(() => Target.Orbits)));
 
             ux.AddSpace();
-            m_NoControllerHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
+            var noControllerHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
                 "Orbital Follow has no input axis controller behaviour.", HelpBoxMessageType.Info,
                 "Add Input Controller", () =>
             {
@@ -75,24 +71,20 @@ namespace Cinemachine.Editor
                 m_Orbits.SetVisible(mode == CinemachineOrbitalFollow.OrbitStyles.ThreeRing);
             }
 
-            UpdateHelpBoxes();
+            ux.TrackAnyUserActivity(() =>
+            {
+                if (target == null || noControllerHelp == null)
+                    return;  // target was deleted
+
+                bool noHandler = false;
+                for (int i = 0; i < targets.Length; ++i)
+                    noHandler |= !(targets[i] as CinemachineOrbitalFollow).HasInputHandler;
+                noControllerHelp.SetVisible(noHandler);
+            });
+
             return ux;
         }
 
-        void UpdateHelpBoxes()
-        {
-            if (target == null || m_NoControllerHelp == null)
-                return;  // target was deleted
-            bool noHandler = false;
-            for (int i = 0; i < targets.Length; ++i)
-            {
-                var t = (CinemachineOrbitalFollow)targets[i];
-                noHandler |= !t.HasInputHandler;
-            }
-            if (m_NoControllerHelp != null)
-                m_NoControllerHelp.SetVisible(noHandler);
-        }
-  
         static GUIContent[] s_OrbitNames = 
         {
             new GUIContent("Top"), 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -27,7 +27,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackerSettings)));
             ux.AddSpace();
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineOrbitalFollowEditor.cs
@@ -11,12 +11,10 @@ namespace Cinemachine.Editor
     {
         CinemachineOrbitalFollow Target => target as CinemachineOrbitalFollow;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         VisualElement m_NoControllerHelp;
 
         void OnEnable()
         {
-            m_PipelineUtility = new (this);
             EditorApplication.update += UpdateHelpBoxes;
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
             CinemachineSceneToolUtility.RegisterTool(typeof(OrbitalFollowOrbitSelection));
@@ -24,7 +22,6 @@ namespace Cinemachine.Editor
         
         void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             EditorApplication.update -= UpdateHelpBoxes;
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
             CinemachineSceneToolUtility.UnregisterTool(typeof(OrbitalFollowOrbitSelection));
@@ -34,7 +31,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackerSettings)));
             ux.AddSpace();
 
@@ -78,7 +75,6 @@ namespace Cinemachine.Editor
                 m_Orbits.SetVisible(mode == CinemachineOrbitalFollow.OrbitStyles.ThreeRing);
             }
 
-            m_PipelineUtility.UpdateState();
             UpdateHelpBoxes();
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePanTiltEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePanTiltEditor.cs
@@ -10,17 +10,6 @@ namespace Cinemachine.Editor
     {
         CinemachinePanTilt Target => target as CinemachinePanTilt;
 
-        VisualElement m_NoControllerHelp;
-
-        void OnEnable()
-        {
-            EditorApplication.update += UpdateHelpBox;
-        }
-        void OnDisable()
-        {
-            EditorApplication.update -= UpdateHelpBox;
-        }
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
@@ -31,7 +20,7 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TiltAxis)));
 
             ux.AddSpace();
-            m_NoControllerHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
+            var noControllerHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
                 "PanTilt has no input axis controller behaviour.", HelpBoxMessageType.Info,
                 "Add Input Controller", () =>
             {
@@ -52,19 +41,18 @@ namespace Cinemachine.Editor
                 }
             }));
 
-            UpdateHelpBox();
-            return ux;
-        }
+            ux.TrackAnyUserActivity(() =>
+            {
+                if (target == null || noControllerHelp == null)
+                    return;  // target was deleted
 
-        void UpdateHelpBox()
-        {
-            if (target == null || m_NoControllerHelp == null)
-                return;  // target was deleted
-            bool noHandler = false;
-            for (int i = 0; !noHandler && i < targets.Length; ++i)
-                noHandler |= !(targets[i] as CinemachinePanTilt).HasInputHandler;
-            if (m_NoControllerHelp != null)
-                m_NoControllerHelp.SetVisible(noHandler);
+                bool noHandler = false;
+                for (int i = 0; !noHandler && i < targets.Length; ++i)
+                    noHandler |= !(targets[i] as CinemachinePanTilt).HasInputHandler;
+                noControllerHelp?.SetVisible(noHandler);
+            });
+
+            return ux;
         }
     }
 }

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePanTiltEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePanTiltEditor.cs
@@ -10,17 +10,14 @@ namespace Cinemachine.Editor
     {
         CinemachinePanTilt Target => target as CinemachinePanTilt;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         VisualElement m_NoControllerHelp;
 
         void OnEnable()
         {
-            m_PipelineUtility = new (this);
             EditorApplication.update += UpdateHelpBox;
         }
         void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             EditorApplication.update -= UpdateHelpBox;
         }
 
@@ -28,7 +25,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ReferenceFrame)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PanAxis)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TiltAxis)));
@@ -55,7 +52,6 @@ namespace Cinemachine.Editor
                 }
             }));
 
-            m_PipelineUtility.UpdateState();
             UpdateHelpBox();
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -7,18 +7,12 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachinePixelPerfectEditor : UnityEditor.Editor
     {
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
 #if CINEMACHINE_URP || CINEMACHINE_PIXEL_PERFECT_2_0_3
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
-            m_PipelineUtility.UpdateState();
+            this.AddMissingCmCameraHelpBox(ux);
 #else
             ux.Add(new HelpBox("This component is only valid within URP projects", HelpBoxMessageType.Warning));
 #endif

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -10,14 +10,12 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachinePositionComposerEditor : UnityEditor.Editor
     {
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         GameViewComposerGuides m_GameViewGuides = new();
 
         CinemachinePositionComposer Target => target as CinemachinePositionComposer;
 
         protected virtual void OnEnable()
         {
-            m_PipelineUtility = new (this);
             m_GameViewGuides.GetComposition = () => Target.Composition;
             m_GameViewGuides.SetComposition = (s) => Target.Composition = s;
             m_GameViewGuides.Target = () => serializedObject;
@@ -34,7 +32,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             m_GameViewGuides.OnDisable();
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
@@ -48,7 +45,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackedObjectOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDistance)));
@@ -57,7 +54,6 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -45,7 +45,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackedObjectOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDistance)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineRecomposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineRecomposerEditor.cs
@@ -10,16 +10,11 @@ namespace Cinemachine.Editor
     {
         CinemachineRecomposer Target => target as CinemachineRecomposer;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ApplyAfter)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Tilt)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Pan)));
@@ -28,7 +23,6 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FollowAttachment)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.LookAtAttachment)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
@@ -9,15 +9,12 @@ namespace Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachineRotationComposerEditor : UnityEditor.Editor
     {
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         GameViewComposerGuides m_GameViewGuides = new();
 
         CinemachineRotationComposer Target => target as CinemachineRotationComposer;
 
         protected virtual void OnEnable()
         {
-            m_PipelineUtility = new (this);
-
             m_GameViewGuides.GetComposition = () => Target.Composition;
             m_GameViewGuides.SetComposition = (s) => Target.Composition = s;
             m_GameViewGuides.Target = () => serializedObject;
@@ -33,7 +30,6 @@ namespace Cinemachine.Editor
 
         protected virtual void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             m_GameViewGuides.OnDisable();
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
             if (CinemachineCorePrefs.ShowInGameGuides.Value)
@@ -46,13 +42,13 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TrackedObjectOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CenterOnActivate)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Composition)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lookahead)));
-            m_PipelineUtility.UpdateState();
+
             return ux;
         }
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSameAsFollowTargetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSameAsFollowTargetEditor.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
             return ux;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSameAsFollowTargetEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSameAsFollowTargetEditor.cs
@@ -10,19 +10,13 @@ namespace Cinemachine.Editor
     {
         CinemachineSameAsFollowTarget Target => target as CinemachineSameAsFollowTarget;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSplineDollyEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSplineDollyEditor.cs
@@ -10,16 +10,11 @@ namespace Cinemachine.Editor
     {
         CinemachineSplineDolly Target => target as CinemachineSplineDolly;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             var noSplineHelp = ux.AddChild(new HelpBox("A Spline is required.", HelpBoxMessageType.Warning));
 
             var splineProp = serializedObject.FindProperty(() => Target.Spline);
@@ -44,7 +39,7 @@ namespace Cinemachine.Editor
                     noSpline = targets[i] != null && ((CinemachineSplineDolly)targets[i]).Spline == null;
                 noSplineHelp.SetVisible(noSpline);
             }
-            m_PipelineUtility.UpdateState();
+
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -36,7 +36,7 @@ namespace Cinemachine.Editor
             if (now - m_LastSplitScreenEventTime > k_FastWaveformUpdateInterval * 5)
                 WaveformWindow.SetDefaultUpdateInterval();
 
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this);
+            this.IMGUI_DrawMissingCmCameraHelpBox();
 
             CinemachineCorePrefs.StoryboardGlobalMute.Value = EditorGUILayout.Toggle(
                 CinemachineCorePrefs.s_StoryboardGlobalMuteLabel, CinemachineCorePrefs.StoryboardGlobalMute.Value);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonAimEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonAimEditor.cs
@@ -11,22 +11,16 @@ namespace Cinemachine.Editor
     {
         CinemachineThirdPersonAim Target => target as CinemachineThirdPersonAim;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.AimCollisionFilter)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.IgnoreTag)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.AimDistance)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.NoiseCancellation)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonFollowEditor.cs
@@ -25,7 +25,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ShoulderOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.VerticalArmLength)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineThirdPersonFollowEditor.cs
@@ -10,17 +10,14 @@ namespace Cinemachine.Editor
     class CinemachineThirdPersonFollowEditor : UnityEditor.Editor
     {
         CinemachineThirdPersonFollow Target => target as CinemachineThirdPersonFollow;
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
         
         protected virtual void OnEnable()
         {
-            m_PipelineUtility = new CmPipelineComponentInspectorUtility(this);
             CinemachineSceneToolUtility.RegisterTool(typeof(FollowOffsetTool));
         }
 
         protected virtual void OnDisable()
         {
-            m_PipelineUtility.OnDisable();
             CinemachineSceneToolUtility.UnregisterTool(typeof(FollowOffsetTool));
         }
         
@@ -28,7 +25,7 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ShoulderOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.VerticalArmLength)));
@@ -37,8 +34,6 @@ namespace Cinemachine.Editor
 #if CINEMACHINE_PHYSICS
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.AvoidObstacles)));
 #endif
-
-            m_PipelineUtility.UpdateState();
             return ux;
         }
         

--- a/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -88,22 +88,6 @@ namespace Cinemachine.Editor
             DrawGlobalControlsInInspector();
         }
         
-/* GML DO NOT COMMIT
-        /// <summary>Create the contents of the inspector panel.
-        /// This implementation draws header and Extensions widget, and uses default algorithms 
-        /// to draw the properties in the inspector</summary>
-        public override void OnInspectorGUI()
-        {
-            serializedObject.Update();
-            UpgradeManagerInspectorHelpers.DrawUpgradeControls(this, "CinemachineCamera");
-            DrawCameraStatusInInspector();
-            DrawGlobalControlsInInspector();
-            DrawInputProviderButtonInInspector();
-            DrawRemainingPropertiesInInspector();
-            DrawExtensionsWidgetInInspector();
-        }
-*/
-
 #if CINEMACHINE_UNITY_INPUTSYSTEM
         /// <summary>
         /// Draw a message prompting the user to add a CinemachineInputProvider.  

--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -9,7 +9,6 @@ namespace Cinemachine.Editor
     class CmCameraEditor : UnityEditor.Editor 
     {
         CinemachineCamera Target => target as CinemachineCamera;
-        CmCameraInspectorUtility m_CameraUtility = new CmCameraInspectorUtility();
 
         [MenuItem("CONTEXT/CinemachineCamera/Adopt Game View Camera Settings")]
         static void AdoptGameViewCameraSettings(MenuCommand command)
@@ -32,7 +31,6 @@ namespace Cinemachine.Editor
 
         void OnEnable()
         {
-            m_CameraUtility.OnEnable(targets);
             Undo.undoRedoPerformed += ResetTarget;
 
             CinemachineSceneToolUtility.RegisterTool(typeof(FoVTool));
@@ -41,9 +39,8 @@ namespace Cinemachine.Editor
 
         void OnDisable()
         {
-            m_CameraUtility.OnDisable();
             Undo.undoRedoPerformed -= ResetTarget;
-            
+
             CinemachineSceneToolUtility.UnregisterTool(typeof(FoVTool));
             CinemachineSceneToolUtility.UnregisterTool(typeof(FarNearClipTool));
         }
@@ -52,23 +49,23 @@ namespace Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            m_CameraUtility.AddCameraStatus(ux);
+            this.AddCameraStatus(ux);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Transitions)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lens)));
 
             ux.AddHeader("Global Settings");
-            m_CameraUtility.AddGlobalControls(ux);
+            this.AddGlobalControls(ux);
 
             ux.AddHeader("Procedural Motion");
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Target)));
-            m_CameraUtility.AddPipelineDropdowns(ux);
+            this.AddPipelineDropdowns(ux);
 
             ux.AddSpace();
-            m_CameraUtility.AddExtensionsDropdown(ux);
+            this.AddExtensionsDropdown(ux);
 
-            ux.TrackAnyUserActivity(m_CameraUtility.SortComponents);
+            ux.TrackAnyUserActivity(() => CmCameraInspectorUtility.SortComponents(target as CinemachineVirtualCameraBase));
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -33,7 +33,6 @@ namespace Cinemachine.Editor
         void OnEnable()
         {
             m_CameraUtility.OnEnable(targets);
-            EditorApplication.update += m_CameraUtility.SortComponents;
             Undo.undoRedoPerformed += ResetTarget;
 
             CinemachineSceneToolUtility.RegisterTool(typeof(FoVTool));
@@ -42,7 +41,6 @@ namespace Cinemachine.Editor
 
         void OnDisable()
         {
-            EditorApplication.update -= m_CameraUtility.SortComponents;
             m_CameraUtility.OnDisable();
             Undo.undoRedoPerformed -= ResetTarget;
             
@@ -69,6 +67,8 @@ namespace Cinemachine.Editor
 
             ux.AddSpace();
             m_CameraUtility.AddExtensionsDropdown(ux);
+
+            ux.TrackAnyUserActivity(m_CameraUtility.SortComponents);
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Impulse/CinemachineImpulseListenerEditor.cs
+++ b/com.unity.cinemachine/Editor/Impulse/CinemachineImpulseListenerEditor.cs
@@ -10,16 +10,11 @@ namespace Cinemachine.Editor
     {
         CinemachineImpulseListener Target => target as CinemachineImpulseListener;
 
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
-
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
 
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
             ux.Add(new HelpBox("The Impulse Listener will respond to signals broadcast by any CinemachineImpulseSource.", HelpBoxMessageType.Info));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ApplyAfter)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ChannelMask)));
@@ -28,7 +23,6 @@ namespace Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.UseCameraSpace)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ReactionSettings)));
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Obsolete/Cinemachine3rdPersonFollowEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/Cinemachine3rdPersonFollowEditor.cs
@@ -53,7 +53,7 @@ namespace Cinemachine.Editor
         public override void OnInspectorGUI()
         {
             BeginInspector();
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this, CmPipelineComponentInspectorUtility.RequiredTargets.Follow);
+            this.IMGUI_DrawMissingCmCameraHelpBox(CmPipelineComponentInspectorUtility.RequiredTargets.Tracking);
             DrawRemainingPropertiesInInspector();
         }
 

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineConfinerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineConfinerEditor.cs
@@ -32,7 +32,7 @@ namespace Cinemachine.Editor
         public override void OnInspectorGUI()
         {
             BeginInspector();
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this);
+            this.IMGUI_DrawMissingCmCameraHelpBox();
 
 #if CINEMACHINE_PHYSICS && CINEMACHINE_PHYSICS_2D
             if (Target.m_ConfineMode == CinemachineConfiner.Mode.Confine2D)

--- a/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
+++ b/com.unity.cinemachine/Editor/Overlays/CinemachineToolbarOverlay.cs
@@ -205,7 +205,7 @@ namespace Cinemachine.Editor
             EditorApplication.update -= DisplayAndUpdateOrbitIfRequired;
         }
         
-        Type m_OrbitalFollowSelectionType = typeof(OrbitalFollowOrbitSelection);
+        readonly Type m_OrbitalFollowSelectionType = typeof(OrbitalFollowOrbitSelection);
         void DisplayAndUpdateOrbitIfRequired()
         {
             var active = Selection.activeObject as GameObject;

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineAutoFocusEditor.cs
@@ -13,15 +13,11 @@ namespace Cinemachine.Editor
 #if CINEMACHINE_HDRP
         const string k_ComputeShaderName = "CinemachineFocusDistanceCompute";
 #endif
-        CmPipelineComponentInspectorUtility m_PipelineUtility;
-
-        void OnEnable() => m_PipelineUtility = new (this);
-        void OnDisable() => m_PipelineUtility.OnDisable();
 
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
-            m_PipelineUtility.AddMissingCmCameraHelpBox(ux);
+            this.AddMissingCmCameraHelpBox(ux);
 #if CINEMACHINE_HDRP
             ux.AddChild(new HelpBox(
                 "Note: focus control requires an active Volume containing a Depth Of Field override "
@@ -109,7 +105,6 @@ namespace Cinemachine.Editor
             });
 #endif
 
-            m_PipelineUtility.UpdateState();
             return ux;
         }
 

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
@@ -50,7 +50,7 @@ namespace Cinemachine.Editor
                 MessageType.Warning);
 #endif
 
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this);
+            this.IMGUI_DrawMissingCmCameraHelpBox();
 
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -51,7 +51,7 @@ namespace Cinemachine.Editor
         {
             serializedObject.Update();
 
-            CmPipelineComponentInspectorUtility.IMGUI_DrawMissingCmCameraHelpBox(this);
+            this.IMGUI_DrawMissingCmCameraHelpBox();
 
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -165,10 +165,7 @@ namespace Cinemachine.Editor
                 foldout.Add(new PropertyField(modeOverrideProperty));
             }
 
-            // GML: This is rather evil.  Is there a better (event-driven) way?
-            DoUpdate();
-            ux.schedule.Execute(DoUpdate).Every(250);
-            void DoUpdate()
+            ux.TrackAnyUserActivity(() =>
             {
                 if (property.serializedObject.targetObject == null)
                     return; // target deleted
@@ -184,7 +181,7 @@ namespace Cinemachine.Editor
                     modeHelp.SetVisible(!brainHasModeOverride
                         && modeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None);
                 }
-            }
+            });
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -165,10 +165,14 @@ namespace Cinemachine.Editor
                 foldout.Add(new PropertyField(modeOverrideProperty));
             }
 
-            ux.TrackAnyUserActivity(() =>
+            // GML: This is rather evil.  Is there a better (event-driven) way?
+            DoUpdate();
+            ux.schedule.Execute(DoUpdate).Every(250);
+            void DoUpdate()
             {
                 if (property.serializedObject.targetObject == null)
                     return; // target deleted
+
                 bool isPhysical = IsPhysical(property);
                 physical.SetVisible(isPhysical);
                 outerFovControl.Update(true);
@@ -181,7 +185,7 @@ namespace Cinemachine.Editor
                     modeHelp.SetVisible(!brainHasModeOverride
                         && modeOverrideProperty.intValue != (int)LensSettings.OverrideModes.None);
                 }
-            });
+            };
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -486,15 +486,9 @@ namespace Cinemachine.Editor
         static SaveDuringPlay()
         {
             // Install our callbacks
-#if UNITY_2017_2_OR_NEWER
             EditorApplication.playModeStateChanged += OnPlayStateChanged;
-#else
-            EditorApplication.update += OnEditorUpdate;
-            EditorApplication.playmodeStateChanged += OnPlayStateChanged;
-#endif
         }
 
-#if UNITY_2017_2_OR_NEWER
         static void OnPlayStateChanged(PlayModeStateChange pmsc)
         {
             if (Enabled)
@@ -511,35 +505,6 @@ namespace Cinemachine.Editor
                 }
             }
         }
-#else
-        static void OnPlayStateChanged()
-        {
-            // If exiting playmode, collect the state of all interesting objects
-            if (Enabled)
-            {
-                if (!EditorApplication.isPlayingOrWillChangePlaymode && EditorApplication.isPlaying)
-                    SaveAllInterestingStates();
-            }
-        }
-
-        static float sWaitStartTime = 0;
-        static void OnEditorUpdate()
-        {
-            if (Enabled && sSavedStates != null && !Application.isPlaying)
-            {
-                // Wait a bit for things to settle before applying the saved state
-                const float WaitTime = 1f; // GML todo: is there a better way to do this?
-                float time = Time.realtimeSinceStartup;
-                if (sWaitStartTime == 0)
-                    sWaitStartTime = time;
-                else if (time - sWaitStartTime > WaitTime)
-                {
-                    RestoreAllInterestingStates();
-                    sWaitStartTime = 0;
-                }
-            }
-        }
-#endif
 
         /// <summary>
         /// If you need to get notified before state is collected for hotsave, this is the place

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -161,8 +161,9 @@ namespace Cinemachine.Editor
             m_ParentElement.Add(new PropertyField(serializedObject.FindProperty(() => Target.DisplayName)));
             m_ParentElement.AddSpace();
 
-            // Component editors
-            m_ParentElement.TrackAnyUserActivity(UpdateComponentEditors);
+            // Component editors.  We delay the initial update because otherwise we get
+            // infinite loops (something to do with UITK throttling Bind calls)
+            m_ParentElement.TrackAnyUserActivity(UpdateComponentEditors, true);
 
             return m_ParentElement;
         }

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -88,16 +88,7 @@ namespace Cinemachine.Editor
             m_Subeditors.Clear();
         }
 
-        void OnEnable()
-        {
-            InspectorUtility.UserDidSomething += UpdateComponentEditors;
-        }
-
-        void OnDisable()
-        {
-            InspectorUtility.UserDidSomething -= UpdateComponentEditors;
-            DestroySubeditors();
-        }
+        void OnDisable() => DestroySubeditors();
 
         public override VisualElement CreateInspectorGUI()
         {
@@ -170,9 +161,8 @@ namespace Cinemachine.Editor
             m_ParentElement.Add(new PropertyField(serializedObject.FindProperty(() => Target.DisplayName)));
             m_ParentElement.AddSpace();
 
-            // We perform an initial subeditor update with a delay call because it goes into an infinite
-            // loop if we do it immediately. Something to do with the UITK's throttling of Bind calls.
-            EditorApplication.delayCall += UpdateComponentEditors;
+            // Component editors
+            m_ParentElement.TrackAnyUserActivity(UpdateComponentEditors);
 
             return m_ParentElement;
         }

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -37,7 +37,6 @@ namespace Cinemachine.Editor
 #if CINEMACHINE_TIMELINE_1_8_2
         VisualElement m_ParentElement;
         VisualElement m_CreateButton;
-        SerializedProperty m_vcamProperty;
         CinemachineVirtualCameraBase m_CachedReferenceObject;
         readonly List<MonoBehaviour> m_ComponentsCache = new ();
         readonly List<Subeditor> m_Subeditors = new ();
@@ -132,7 +131,7 @@ namespace Cinemachine.Editor
 
             // Camera Reference - we do it in IMGUI until the ExposedReference UITK bugs are fixed
             m_ParentElement.AddSpace();
-            m_vcamProperty = serializedObject.FindProperty(() => Target.VirtualCamera);
+            var vcamProperty = serializedObject.FindProperty(() => Target.VirtualCamera);
             row = m_ParentElement.AddChild(new InspectorUtility.LeftRightContainer());
             row.Left.AddChild(new Label("Cinemachine Camera") 
             { 
@@ -142,14 +141,14 @@ namespace Cinemachine.Editor
             row.Right.Add(new IMGUIContainer(() =>
             {
                 EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(m_vcamProperty, GUIContent.none);
+                EditorGUILayout.PropertyField(vcamProperty, GUIContent.none);
                 if (EditorGUI.EndChangeCheck())
                     serializedObject.ApplyModifiedProperties();
             }) { style = { flexGrow = 1, marginBottom = 2 }} );
             m_CreateButton = row.Right.AddChild(new Button(() => 
             {
-                m_vcamProperty.exposedReferenceValue = CreatePassiveVcamFromSceneView();
-                m_vcamProperty.serializedObject.ApplyModifiedProperties();
+                vcamProperty.exposedReferenceValue = CreatePassiveVcamFromSceneView();
+                vcamProperty.serializedObject.ApplyModifiedProperties();
             })
             {
                 text = "Create",
@@ -173,8 +172,9 @@ namespace Cinemachine.Editor
             if (m_ParentElement == null || serializedObject == null)
                 return;
 
-            m_CreateButton.SetVisible(m_vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase == null);
-            var vcam = m_vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase;
+            var vcamProperty = serializedObject.FindProperty(() => Target.VirtualCamera);
+            m_CreateButton.SetVisible(vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase == null);
+            var vcam = vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase;
 
             m_ComponentsCache.Clear();
             if (vcam != null)

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -33,7 +33,6 @@ namespace Cinemachine.Editor
         const string k_ProgressBarTitle = "Upgrade Progress";
 
         /// <summary>
-        /// GML Temporary helper method for testing.
         /// Upgrades the input gameObject.  Referenced objects (e.g. paths) may also get upgraded.
         /// Obsolete components are deleted.  Timeline references are not patched.
         /// Undo is supported.
@@ -54,8 +53,7 @@ namespace Cinemachine.Editor
         }
 
         /// <summary>
-        /// GML Temporary helper method for testing.
-        /// Upgrades the input gameObject.  Referenced objects (e.g. paths) may also get upgraded.
+        /// Upgrades all the gameObjects in the current scene.  
         /// Obsolete components are deleted.  Timeline references are not patched.
         /// Undo is supported.
         /// </summary>
@@ -692,7 +690,7 @@ namespace Cinemachine.Editor
         // Hack: ignore nested rigs of a freeLook (GML todo: how to remove this?)
         static bool IsHiddenFreeLookRig(Component c)
         {
-            return !(c is CinemachineFreeLook) && c.GetComponentInParent<CinemachineFreeLook>(true) != null;
+            return c is not CinemachineFreeLook && c.GetComponentInParent<CinemachineFreeLook>(true) != null;
         }
         
         class SceneManager

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -72,12 +72,8 @@ namespace Cinemachine.Editor
             });
 
             // Capture "normal" colors
-            ux.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
-            void OnGeometryChanged(GeometryChangedEvent e)
+            ux.OnInitialGeometryChanged(() =>
             {
-                // Only once
-                ux.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
-
                 var normalColor = statusText.resolvedStyle.color;
                 var normalBkgColor = soloButton.resolvedStyle.backgroundColor;
 
@@ -116,7 +112,7 @@ namespace Cinemachine.Editor
                         InspectorUtility.RepaintGameView();
                     }
                 });
-            }
+            });
 
             // Kill solo when inspector shuts down
             ux.RegisterCallback<DetachFromPanelEvent>((e) => 

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -11,132 +11,128 @@ namespace Cinemachine.Editor
     /// <summary>
     /// Helpers for drawing CinemachineCamera inspectors.
     /// </summary>
-    class CmCameraInspectorUtility
+    static class CmCameraInspectorUtility
     {
-        public UnityEngine.Object[] Targets { get; private set; }
-        CinemachineVirtualCameraBase Target => Targets.Length == 0 ? null : Targets[0] as CinemachineVirtualCameraBase;
-
-        VisualElement m_NavelGazeMessage;
-        Label m_StatusText;
-        Button m_SoloButton;
-        Label m_UpdateMode;
-
-        public bool IsPrefab { get; private set; }
-
-        /// <summary>Call from Inspector's OnEnable</summary>
-        public void OnEnable(UnityEngine.Object[] targets)
+        struct PipelineStageItem
         {
-            Targets = targets;
-            Undo.undoRedoPerformed += UpdateCameraState;
-            IsPrefab = Target != null && Target.gameObject.scene.name == null; // causes a small GC alloc
+            public CinemachineCore.Stage Stage;
+            public DropdownField Dropdown;
+            public Label WarningIcon;
         }
 
-        /// <summary>Call from Inspector's OnDisable</summary>
-        public void OnDisable()
+        static bool IsPrefab(UnityEngine.Object target)
         {
-            EditorApplication.update -= UpdateCameraStatus;
-            EditorApplication.update -= RefreshPipelinDropdowns;
-            Undo.undoRedoPerformed -= UpdateCameraState;
-            if (Target != null && CinemachineBrain.SoloCamera == Target)
-            {
-                CinemachineBrain.SoloCamera = null;
-                InspectorUtility.RepaintGameView();
-            }
+            var t = target as CinemachineVirtualCameraBase;
+            return t != null && t.gameObject.scene.name == null; // causes a small GC alloc
         }
-        
-        public void AddCameraStatus(VisualElement ux)
+
+        /// <summary>Add the camera ststos controls and indicators in the inspector</summary>
+        public static void AddCameraStatus(this UnityEditor.Editor editor, VisualElement ux)
         {
             // No status and Solo for prefabs or multi-select
-            if (Selection.objects.Length > 1 || IsPrefab)
+            if (Selection.objects.Length > 1 || IsPrefab(editor.target))
                 return;
 
-            EditorApplication.update -= UpdateCameraStatus;
-            EditorApplication.update += UpdateCameraStatus;
+            var navelGazeMessage = ux.AddChild(new HelpBox("The camera is trying to look at itself.", HelpBoxMessageType.Warning));
 
-            m_NavelGazeMessage = ux.AddChild(new HelpBox("The camera is trying to look at itself.", HelpBoxMessageType.Warning));
-
-            var row = new InspectorUtility.LabeledContainer("Status");
-            m_StatusText = row.labelElement;
-            m_SoloButton = row.AddInput(new Button() 
+            var row = ux.AddChild(new InspectorUtility.LabeledContainer("Status"));
+            var statusText = row.labelElement;
+            var soloButton = row.AddInput(new Button() 
             { 
                 text = "Solo", 
                 style = { flexGrow = 1, paddingLeft = 0, paddingRight = 0, 
                     marginLeft = 0, marginRight = 0, borderLeftWidth = 0, borderRightWidth = 0 } 
             });
-            m_UpdateMode = row.AddInput(new Label("(Update Mode)") { style = { flexGrow = 0, alignSelf = Align.Center }});
-            m_UpdateMode.SetEnabled(false);
-            m_UpdateMode.style.display = DisplayStyle.None;
-            ux.Add(row);
+            var updateMode = row.AddInput(new Label("(Update Mode)") { style = { flexGrow = 0, alignSelf = Align.Center }});
+            updateMode.SetEnabled(false);
+            updateMode.style.display = DisplayStyle.None;
 
-            var target = Target; // capture for lambda
-            m_SoloButton.RegisterCallback<ClickEvent>((evt) => 
+            var target = editor.target as CinemachineVirtualCameraBase; // capture for lambda
+            soloButton.RegisterCallback<ClickEvent>((evt) => 
             {
                 var isSolo = CinemachineBrain.SoloCamera != target;
-                CinemachineBrain.SoloCamera = isSolo ? Target : null;
+                CinemachineBrain.SoloCamera = isSolo ? target : null;
                 InspectorUtility.RepaintGameView();
             });
 
-            UpdateCameraStatus(); // avoid initial flicker
-        }
+            ux.TrackAnyUserActivity(() =>
+            { 
+                if (target == null)
+                    return;
 
-        void UpdateCameraState() { if (Target != null) Target.InternalUpdateCameraState(Vector3.up, -1); }
-
-        void UpdateCameraStatus() 
-        { 
-            if (Target == null)
-                return;
-
-            // Is the camera navel-gazing?
-            if (m_NavelGazeMessage != null)
-            {
-                CameraState state = Target.State;
-                bool isNavelGazing = Target.PreviousStateIsValid && state.HasLookAt() &&
-                    (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero() &&
-                    Target.GetCinemachineComponent(CinemachineCore.Stage.Aim) != null;
-                m_NavelGazeMessage.style.display = isNavelGazing ? DisplayStyle.Flex : DisplayStyle.None;
-            }
-
-            bool isSolo = CinemachineBrain.SoloCamera == Target;
-            var color = isSolo ? CinemachineBrain.GetSoloGUIColor() : GUI.color; // GML fixme: what is the right way to get default color?
-            if (m_StatusText != null)
-            {
-                bool isLive = CinemachineCore.Instance.IsLive(Target);
-                m_StatusText.text = isLive ? "Status: Live"
-                    : (Target.isActiveAndEnabled ? "Status: Standby" : "Status: Disabled");
-                m_StatusText.SetEnabled(isLive);
-                m_StatusText.style.color = color;
-            }
-
-            if (m_UpdateMode != null)
-            {
-                if (!Application.isPlaying)
-                    m_UpdateMode.style.display = DisplayStyle.None;
-                else
+                // Is the camera navel-gazing?
+                if (navelGazeMessage != null)
                 {
-                    UpdateTracker.UpdateClock updateMode = CinemachineCore.Instance.GetVcamUpdateStatus(Target);
-                    m_UpdateMode.text = updateMode == UpdateTracker.UpdateClock.Fixed ? " Fixed Update" : " Late Update";
-                    m_UpdateMode.style.display = DisplayStyle.Flex;
+                    CameraState state = target.State;
+                    bool isNavelGazing = target.PreviousStateIsValid && state.HasLookAt() &&
+                        (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero() &&
+                        target.GetCinemachineComponent(CinemachineCore.Stage.Aim) != null;
+                    navelGazeMessage.SetVisible(isNavelGazing);
                 }
-            }
+            });
 
-            if (m_SoloButton != null)
-                m_SoloButton.style.color = color;
+            // Refresh camera state
+            ux.ContinuousUpdate(() =>
+            { 
+                if (target == null)
+                    return;
 
-            // Refresh the game view if solo and not playing
-            if (isSolo && !Application.isPlaying)
-                InspectorUtility.RepaintGameView();
+                bool isSolo = CinemachineBrain.SoloCamera == target;
+                var color = isSolo ? CinemachineBrain.GetSoloGUIColor() : GUI.color; // GML fixme: what is the right way to get default color?
+                if (statusText != null)
+                {
+                    bool isLive = CinemachineCore.Instance.IsLive(target);
+                    statusText.text = isLive ? "Status: Live"
+                        : (target.isActiveAndEnabled ? "Status: Standby" : "Status: Disabled");
+                    statusText.SetEnabled(isLive);
+                    statusText.style.color = color;
+                }
+
+                if (updateMode != null)
+                {
+                    if (!Application.isPlaying)
+                        updateMode.SetVisible(false);
+                    else
+                    {
+                        var mode = CinemachineCore.Instance.GetVcamUpdateStatus(target);
+                        updateMode.text = mode == UpdateTracker.UpdateClock.Fixed ? " Fixed Update" : " Late Update";
+                        updateMode.SetVisible(true);
+                    }
+                }
+
+                if (soloButton != null)
+                    soloButton.style.color = color;
+
+                // Refresh the game view if solo and not playing
+                if (isSolo && !Application.isPlaying)
+                {
+                    target.InternalUpdateCameraState(Vector3.up, -1);
+                    InspectorUtility.RepaintGameView();
+                }
+            });
+
+            // Kill solo when inspector shuts down
+            ux.RegisterCallback<DetachFromPanelEvent>((e) => 
+            {
+                if (target != null && CinemachineBrain.SoloCamera == target)
+                {
+                    CinemachineBrain.SoloCamera = null;
+                    InspectorUtility.RepaintGameView();
+                }
+            });
         }
-        
-        public void AddPipelineDropdowns(VisualElement ux)
+
+        /// <summary>Add the pipeline control dropdowns in the inspector</summary>
+        public static void AddPipelineDropdowns(this UnityEditor.Editor editor, VisualElement ux)
         {
-            var cmCam = Target as CinemachineCamera;
-            if (cmCam == null)
+            var target = editor.target as CinemachineCamera;
+            if (target == null)
                 return;
 
-            var targets = Targets; // capture for lambda
+            var targets = editor.targets; // capture for lambda
 
             // Add a dropdown for each pipeline stage
-            m_PipelineItems = new List<PipelineStageItem>();
+            var pipelineItems = new List<PipelineStageItem>();
             for (int i = 0; i < PipelineStageMenu.s_StageData.Length; ++i)
             {
                 // Skip empty categories
@@ -145,7 +141,7 @@ namespace Cinemachine.Editor
 
                 var row = ux.AddChild(new InspectorUtility.LeftRightContainer());
                 int currentSelection = PipelineStageMenu.GetSelectedComponent(
-                    i, cmCam.GetCinemachineComponent((CinemachineCore.Stage)i));
+                    i, target.GetCinemachineComponent((CinemachineCore.Stage)i));
                 var stage = i; // capture for lambda
                 var dropdown = new DropdownField
                 {
@@ -174,8 +170,9 @@ namespace Cinemachine.Editor
                             if (newType != null)
                                 Undo.AddComponent(t.gameObject, newType);
                         }
-                    }            
-                    int GetTypeIndexFromSelection(string selection, int stage)
+                    }
+
+                    static int GetTypeIndexFromSelection(string selection, int stage)
                     {
                         for (var j = 0; j < PipelineStageMenu.s_StageData[stage].Choices.Count; ++j)
                             if (PipelineStageMenu.s_StageData[stage].Choices[j].Equals(selection))
@@ -199,44 +196,33 @@ namespace Cinemachine.Editor
                 warningIcon.SetVisible(false);
                 row.Right.Add(dropdown);
 
-                m_PipelineItems.Add(new PipelineStageItem
+                pipelineItems.Add(new PipelineStageItem
                 {
                     Stage = (CinemachineCore.Stage)i,
                     Dropdown = dropdown,
                     WarningIcon = warningIcon
                 });
             }
-            EditorApplication.update += RefreshPipelinDropdowns;
-        }
 
-        struct PipelineStageItem
-        {
-            public CinemachineCore.Stage Stage;
-            public DropdownField Dropdown;
-            public Label WarningIcon;
-        }
-        List<PipelineStageItem> m_PipelineItems;
-
-        void RefreshPipelinDropdowns()
-        {
-            var cmCam = Target as CinemachineCamera;
-            if (cmCam == null)
-                return;
-            for (int i = 0; i < m_PipelineItems.Count; ++i)
+            ux.TrackAnyUserActivity(() =>
             {
-                var item = m_PipelineItems[i];
-                var c = cmCam.GetCinemachineComponent(item.Stage);
-                int selection = PipelineStageMenu.GetSelectedComponent((int)item.Stage, c);
-                item.Dropdown.value = PipelineStageMenu.s_StageData[(int)item.Stage].Choices[selection];
-                
-                item.WarningIcon.SetVisible(c != null && !c.IsValid);
-            }
+                if (target == null)
+                    return; // deleted
+                for (int i = 0; i < pipelineItems.Count; ++i)
+                {
+                    var item = pipelineItems[i];
+                    var c = target.GetCinemachineComponent(item.Stage);
+                    int selection = PipelineStageMenu.GetSelectedComponent((int)item.Stage, c);
+                    item.Dropdown.value = PipelineStageMenu.s_StageData[(int)item.Stage].Choices[selection];
+                    item.WarningIcon.SetVisible(c != null && !c.IsValid);
+                }
+            });
         }
 
         /// <summary>Draw the Extensions dropdown in the inspector</summary>
-        public void AddExtensionsDropdown(VisualElement ux)
+        public static void AddExtensionsDropdown(this UnityEditor.Editor editor, VisualElement ux)
         {
-            var cmCam = Target;
+            var targets = editor.targets;
             var dropdown = new DropdownField
             {
                 name = "extensions selector",
@@ -248,14 +234,14 @@ namespace Cinemachine.Editor
             dropdown.RegisterValueChangedCallback((evt) => 
             {
                 Type extType = PipelineStageMenu.s_ExtentionTypes[GetTypeIndexFromSelection(evt.newValue)];
-                for (int i = 0; i < Targets.Length; i++)
+                for (int i = 0; i < targets.Length; i++)
                 {
-                    var targetGO = (Targets[i] as CinemachineVirtualCameraBase).gameObject;
+                    var targetGO = (targets[i] as CinemachineVirtualCameraBase).gameObject;
                     if (targetGO != null && targetGO.GetComponent(extType) == null)
                         Undo.AddComponent(targetGO, extType);
                 }
             
-                int GetTypeIndexFromSelection(string selection)
+                static int GetTypeIndexFromSelection(string selection)
                 {
                     for (var j = 0; j < PipelineStageMenu.s_ExtentionNames.Count; ++j)
                         if (PipelineStageMenu.s_ExtentionNames[j].Equals(selection))
@@ -341,10 +327,8 @@ namespace Cinemachine.Editor
             }
         }
         
-        /// <summary>
-        /// Draw the global settings controls in the inspector
-        /// </summary>
-        public void AddGlobalControls(VisualElement ux)
+        /// <summary>Draw the global settings controls in the inspector</summary>
+        public static void AddGlobalControls(this UnityEditor.Editor editor, VisualElement ux)
         {
             var helpBox = ux.AddChild(new HelpBox("CinemachineCamera settings changes made during Play Mode will be "
                     + "propagated back to the scene when Play Mode is exited.", 
@@ -382,7 +366,7 @@ namespace Cinemachine.Editor
             });
         }
 
-        static List<MonoBehaviour> s_componentCache = new List<MonoBehaviour>();
+        static List<MonoBehaviour> s_componentCache = new ();
         enum SortOrder { None, Camera, Pipeline, Extensions = CinemachineCore.Stage.Finalize + 1, Other };
 
         /// <summary>
@@ -390,14 +374,14 @@ namespace Cinemachine.Editor
         /// Behaviours should be sorted like this:
         /// CinemachineCamera, Body, Aim, Noise, Finalize, Extensions, everything else.
         /// </summary>
-        public void SortComponents()
+        public static void SortComponents(CinemachineVirtualCameraBase target)
         {
-            if (Target == null || PrefabUtility.IsPartOfNonAssetPrefabInstance(Target))
+            if (target == null || PrefabUtility.IsPartOfNonAssetPrefabInstance(target))
                 return; // target was deleted or is part of a prefab instance
 
             SortOrder lastItem = SortOrder.None;
             bool sortNeeded = false;
-            Target.gameObject.GetComponents(s_componentCache);
+            target.gameObject.GetComponents(s_componentCache);
             for (int i = 0; i < s_componentCache.Count && !sortNeeded; ++i)
             {
                 var current = GetSortOrderForComponent(s_componentCache[i]);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -26,7 +26,7 @@ namespace Cinemachine.Editor
             return t != null && t.gameObject.scene.name == null; // causes a small GC alloc
         }
 
-        /// <summary>Add the camera ststos controls and indicators in the inspector</summary>
+        /// <summary>Add the camera status controls and indicators in the inspector</summary>
         public static void AddCameraStatus(this UnityEditor.Editor editor, VisualElement ux)
         {
             // No status and Solo for prefabs or multi-select
@@ -48,7 +48,7 @@ namespace Cinemachine.Editor
             updateMode.style.display = DisplayStyle.None;
 
             var target = editor.target as CinemachineVirtualCameraBase; // capture for lambda
-            soloButton.RegisterCallback<ClickEvent>((evt) => 
+            soloButton.RegisterCallback<ClickEvent>(_ => 
             {
                 var isSolo = CinemachineBrain.SoloCamera != target;
                 CinemachineBrain.SoloCamera = isSolo ? target : null;
@@ -88,7 +88,7 @@ namespace Cinemachine.Editor
 
                     bool isLive = CinemachineCore.Instance.IsLive(target);
                     statusText.text = isLive ? "Status: Live"
-                        : (target.isActiveAndEnabled ? "Status: Standby" : "Status: Disabled");
+                        : target.isActiveAndEnabled ? "Status: Standby" : "Status: Disabled";
                     statusText.SetEnabled(isLive);
                     statusText.style.color = color;
 
@@ -115,7 +115,7 @@ namespace Cinemachine.Editor
             });
 
             // Kill solo when inspector shuts down
-            ux.RegisterCallback<DetachFromPanelEvent>((e) => 
+            ux.RegisterCallback<DetachFromPanelEvent>(_ => 
             {
                 if (target != null && CinemachineBrain.SoloCamera == target)
                 {
@@ -155,12 +155,12 @@ namespace Cinemachine.Editor
                     style = { flexGrow = 1 }
                 };
                 dropdown.AddToClassList(InspectorUtility.kAlignFieldClass);
-                dropdown.RegisterValueChangedCallback((evt) => 
+                dropdown.RegisterValueChangedCallback(evt => 
                 {
                     var newType = PipelineStageMenu.s_StageData[stage].Types[GetTypeIndexFromSelection(evt.newValue, stage)];
-                    for (int i = 0; i < targets.Length; i++)
+                    for (int j = 0; j < targets.Length; j++)
                     {
-                        var t = targets[i] as CinemachineCamera;
+                        var t = targets[j] as CinemachineCamera;
                         if (t == null)
                             continue;
                         var oldComponent = t.GetCinemachineComponent((CinemachineCore.Stage)stage);
@@ -234,7 +234,7 @@ namespace Cinemachine.Editor
                 index = 0,
             };
             dropdown.AddToClassList(InspectorUtility.kAlignFieldClass);
-            dropdown.RegisterValueChangedCallback((evt) => 
+            dropdown.RegisterValueChangedCallback(evt => 
             {
                 Type extType = PipelineStageMenu.s_ExtentionTypes[GetTypeIndexFromSelection(evt.newValue)];
                 for (int i = 0; i < targets.Length; i++)

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -12,11 +12,11 @@ namespace Cinemachine.Editor
     {
         public enum RequiredTargets { None, Tracking, LookAt, Group };
 
-        const string s_NeedTarget = "A Tracking Target is required in the CinemachineCamera.";
-        const string s_NeedLookAt = "A LookAt Tracking Target is required in the CinemachineCamera.";
-        const string s_NeedGroup = "The Tracking Target in the CinemachineCamera must be a Target Group.";
-        const string s_NeedCamera = "This component is intended to be used only with a CinemachineCamera.";
-        const string s_AddCamera = "Add\nCinemachineCamera";
+        const string k_NeedTarget = "A Tracking Target is required in the CinemachineCamera.";
+        const string k_NeedLookAt = "A LookAt Tracking Target is required in the CinemachineCamera.";
+        const string k_NeedGroup = "The Tracking Target in the CinemachineCamera must be a Target Group.";
+        const string k_NeedCamera = "This component is intended to be used only with a CinemachineCamera.";
+        const string k_AddCamera = "Add\nCinemachineCamera";
 
         /// <summary>
         /// Add help box for CinemachineComponentBase or CinemachineExtension editors, 
@@ -27,16 +27,15 @@ namespace Cinemachine.Editor
         {
             var targets = editor.targets;
             var noCameraHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
-                s_NeedCamera, HelpBoxMessageType.Warning,
-                s_AddCamera, () => AddCmCameraToTargets(targets)));
+                k_NeedCamera, HelpBoxMessageType.Warning,
+                k_AddCamera, () => AddCmCameraToTargets(targets)));
 
-            string text = string.Empty;
+            var text = string.Empty;
             switch (requiredTargets)
             {
-                case RequiredTargets.Tracking: text = s_NeedTarget; break;
-                case RequiredTargets.LookAt: text = s_NeedLookAt; break;
-                case RequiredTargets.Group: text = s_NeedGroup; break;
-                default: break;
+                case RequiredTargets.Tracking: text = k_NeedTarget; break;
+                case RequiredTargets.LookAt: text = k_NeedLookAt; break;
+                case RequiredTargets.Group: text = k_NeedGroup; break;
             }
             VisualElement noTargetHelp = null;
             if (text.Length > 0)
@@ -48,8 +47,8 @@ namespace Cinemachine.Editor
                 if (editor == null || editor.target == null)
                     return;  // target was deleted
 
-                bool noCamera = false;
-                bool noTarget = false;
+                var noCamera = false;
+                var noTarget = false;
                 for (int i = 0; i < targets.Length && !noCamera; ++i)
                 {
                     var t = targets[i] as CinemachineComponentBase;
@@ -61,7 +60,6 @@ namespace Cinemachine.Editor
                             case RequiredTargets.Tracking: noTarget |= t.FollowTarget == null; break;
                             case RequiredTargets.LookAt: noTarget |= t.LookAtTarget == null; break;
                             case RequiredTargets.Group: noTarget |= t.FollowTargetAsGroup == null; break;
-                            default: break;
                         }
                     }
                     else
@@ -73,7 +71,6 @@ namespace Cinemachine.Editor
                             case RequiredTargets.Tracking: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
                             case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
                             case RequiredTargets.Group: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
-                            default: break;
                         }
                     }
                 }
@@ -143,8 +140,8 @@ namespace Cinemachine.Editor
                 // Oh gawd there has to be a nicer way to do this
                 const int size = 128;
                 const float th = 1f;
+                const float radius = size / 2 - th;
                 var pix = new Color32[size * size];
-                float radius = size / 2 - th;
                 var center = new Vector2(size-1, size-1) / 2;
                 for (int y = 0; y < size; ++y)
                 {
@@ -181,7 +178,6 @@ namespace Cinemachine.Editor
                         case RequiredTargets.Tracking: noTarget |= t.FollowTarget == null; break;
                         case RequiredTargets.LookAt: noTarget |= t.LookAtTarget == null; break;
                         case RequiredTargets.Group: noTarget |= t.FollowTargetAsGroup == null; break;
-                        default: break;
                     }
                 }
                 else
@@ -193,26 +189,24 @@ namespace Cinemachine.Editor
                         case RequiredTargets.Tracking: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
                         case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
                         case RequiredTargets.Group: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
-                        default: break;
                     }
                 }
             }
             if (noCamera)
             {
                 InspectorUtility.HelpBoxWithButton(
-                    s_NeedCamera, MessageType.Warning,
-                    new GUIContent(s_AddCamera), () => AddCmCameraToTargets(targets));
+                    k_NeedCamera, MessageType.Warning,
+                    new GUIContent(k_AddCamera), () => AddCmCameraToTargets(targets));
                 EditorGUILayout.Space();
             }
             else if (noTarget)
             {
-                string text = string.Empty;
+                var text = string.Empty;
                 switch (requiredTargets)
                 {
-                    case RequiredTargets.Tracking: text = s_NeedTarget; break;
-                    case RequiredTargets.LookAt: text = s_NeedLookAt; break;
-                    case RequiredTargets.Group: text = s_NeedGroup; break;
-                    default: break;
+                    case RequiredTargets.Tracking: text = k_NeedTarget; break;
+                    case RequiredTargets.LookAt: text = k_NeedLookAt; break;
+                    case RequiredTargets.Group: text = k_NeedGroup; break;
                 }
                 if (text.Length > 0)
                     EditorGUILayout.HelpBox(text, MessageType.Warning);

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -12,6 +12,12 @@ namespace Cinemachine.Editor
     {
         public enum RequiredTargets { None, Tracking, LookAt, Group };
 
+        const string s_NeedTarget = "A Tracking Target is required in the CinemachineCamera.";
+        const string s_NeedLookAt = "A LookAt Tracking Target is required in the CinemachineCamera.";
+        const string s_NeedGroup = "The Tracking Target in the CinemachineCamera must be a Target Group.";
+        const string s_NeedCamera = "This component is intended to be used only with a CinemachineCamera.";
+        const string s_AddCamera = "Add\nCinemachineCamera";
+
         /// <summary>
         /// Add help box for CinemachineComponentBase or CinemachineExtension editors, 
         /// prompting to solve a missing CinemachineCamera component or a missing tracking target
@@ -21,15 +27,15 @@ namespace Cinemachine.Editor
         {
             var targets = editor.targets;
             var noCameraHelp = ux.AddChild(InspectorUtility.CreateHelpBoxWithButton(
-                "This component is intended to be used only with a CinemachineCamera.", HelpBoxMessageType.Warning,
-                "Add\nCinemachineCamera", () => AddCmCameraToTargets(targets)));
+                s_NeedCamera, HelpBoxMessageType.Warning,
+                s_AddCamera, () => AddCmCameraToTargets(targets)));
 
             string text = string.Empty;
             switch (requiredTargets)
             {
-                case RequiredTargets.Tracking: text = "A Tracking Target is required in the CinemachineCamera."; break;
-                case RequiredTargets.LookAt: text = "A LookAt Tracking Target is required in the CinemachineCamera."; break;
-                case RequiredTargets.Group: text = "The Tracking Target in the CinemachineCamera must be a Target Group."; break;
+                case RequiredTargets.Tracking: text = s_NeedTarget; break;
+                case RequiredTargets.LookAt: text = s_NeedLookAt; break;
+                case RequiredTargets.Group: text = s_NeedGroup; break;
                 default: break;
             }
             VisualElement noTargetHelp = null;
@@ -194,8 +200,8 @@ namespace Cinemachine.Editor
             if (noCamera)
             {
                 InspectorUtility.HelpBoxWithButton(
-                    "This component is intended to be used only with a CinemachineCamera.", MessageType.Warning,
-                    new GUIContent("Add\nCinemachineCamera"), () => AddCmCameraToTargets(targets));
+                    s_NeedCamera, MessageType.Warning,
+                    new GUIContent(s_AddCamera), () => AddCmCameraToTargets(targets));
                 EditorGUILayout.Space();
             }
             else if (noTarget)
@@ -203,9 +209,9 @@ namespace Cinemachine.Editor
                 string text = string.Empty;
                 switch (requiredTargets)
                 {
-                    case RequiredTargets.Tracking: text = "A Tracking Target is required in the CinemachineCamera."; break;
-                    case RequiredTargets.LookAt: text = "A LookAt Tracking Target is required in the CinemachineCamera."; break;
-                    case RequiredTargets.Group: text = "The Tracking Target in the CinemachineCamera must be a Target Group."; break;
+                    case RequiredTargets.Tracking: text = s_NeedTarget; break;
+                    case RequiredTargets.LookAt: text = s_NeedLookAt; break;
+                    case RequiredTargets.Group: text = s_NeedGroup; break;
                     default: break;
                 }
                 if (text.Length > 0)

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -10,7 +10,7 @@ namespace Cinemachine.Editor
     /// </summary>
     static class CmPipelineComponentInspectorUtility
     {
-        public enum RequiredTargets { None, Follow, LookAt, FollowGroup };
+        public enum RequiredTargets { None, Tracking, LookAt, Group };
 
         /// <summary>
         /// Add help box for CinemachineComponentBase or CinemachineExtension editors, 
@@ -27,9 +27,9 @@ namespace Cinemachine.Editor
             string text = string.Empty;
             switch (requiredTargets)
             {
-                case RequiredTargets.Follow: text = "A Tracking Target is required in the CinemachineCamera."; break;
+                case RequiredTargets.Tracking: text = "A Tracking Target is required in the CinemachineCamera."; break;
                 case RequiredTargets.LookAt: text = "A LookAt Tracking Target is required in the CinemachineCamera."; break;
-                case RequiredTargets.FollowGroup: text = "Tracking Target in the CinemachineCamera must be a Target Group."; break;
+                case RequiredTargets.Group: text = "The Tracking Target in the CinemachineCamera must be a Target Group."; break;
                 default: break;
             }
             VisualElement noTargetHelp = null;
@@ -52,9 +52,9 @@ namespace Cinemachine.Editor
                         noCamera |= t.VirtualCamera == null || t.VirtualCamera is CinemachineCameraManagerBase;
                         switch (requiredTargets)
                         {
-                            case RequiredTargets.Follow: noTarget |= t.FollowTarget == null; break;
+                            case RequiredTargets.Tracking: noTarget |= t.FollowTarget == null; break;
                             case RequiredTargets.LookAt: noTarget |= t.LookAtTarget == null; break;
-                            case RequiredTargets.FollowGroup: noTarget |= t.FollowTargetAsGroup == null; break;
+                            case RequiredTargets.Group: noTarget |= t.FollowTargetAsGroup == null; break;
                             default: break;
                         }
                     }
@@ -64,12 +64,11 @@ namespace Cinemachine.Editor
                         noCamera |= x.ComponentOwner == null;
                         switch (requiredTargets)
                         {
-                            case RequiredTargets.Follow: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
+                            case RequiredTargets.Tracking: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
                             case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
-                            case RequiredTargets.FollowGroup: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
+                            case RequiredTargets.Group: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
                             default: break;
                         }
-                        noTarget = noCamera || x.ComponentOwner.Follow == null;
                     }
                 }
                 noCameraHelp?.SetVisible(noCamera);
@@ -77,7 +76,7 @@ namespace Cinemachine.Editor
             });
         }
 
-        static void AddCmCameraToTargets(UnityEngine.Object[] targets)
+        static void AddCmCameraToTargets(Object[] targets)
         {
             for (int i = 0; i < targets.Length; ++i)
             {
@@ -160,7 +159,7 @@ namespace Cinemachine.Editor
 
         /// IMGUI support - to be removed when IMGUI is gone
         public static void IMGUI_DrawMissingCmCameraHelpBox(
-            UnityEditor.Editor editor, RequiredTargets requiredTargets = RequiredTargets.None)
+            this UnityEditor.Editor editor, RequiredTargets requiredTargets = RequiredTargets.None)
         {
             bool noCamera = false;
             bool noTarget = false;
@@ -173,9 +172,9 @@ namespace Cinemachine.Editor
                     noCamera |= t.VirtualCamera == null || t.VirtualCamera is CinemachineCameraManagerBase;
                     switch (requiredTargets)
                     {
-                        case RequiredTargets.Follow: noTarget |= t.FollowTarget == null; break;
+                        case RequiredTargets.Tracking: noTarget |= t.FollowTarget == null; break;
                         case RequiredTargets.LookAt: noTarget |= t.LookAtTarget == null; break;
-                        case RequiredTargets.FollowGroup: noTarget |= t.FollowTargetAsGroup == null; break;
+                        case RequiredTargets.Group: noTarget |= t.FollowTargetAsGroup == null; break;
                         default: break;
                     }
                 }
@@ -185,18 +184,17 @@ namespace Cinemachine.Editor
                     noCamera |= x.ComponentOwner == null;
                     switch (requiredTargets)
                     {
-                        case RequiredTargets.Follow: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
+                        case RequiredTargets.Tracking: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
                         case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
-                        case RequiredTargets.FollowGroup: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
+                        case RequiredTargets.Group: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
                         default: break;
                     }
-                    noTarget = noCamera || x.ComponentOwner.Follow == null;
                 }
             }
             if (noCamera)
             {
                 InspectorUtility.HelpBoxWithButton(
-                    "This component is intended to be used only with a CinemachineCamera.", UnityEditor.MessageType.Warning,
+                    "This component is intended to be used only with a CinemachineCamera.", MessageType.Warning,
                     new GUIContent("Add\nCinemachineCamera"), () => AddCmCameraToTargets(targets));
                 EditorGUILayout.Space();
             }
@@ -205,13 +203,13 @@ namespace Cinemachine.Editor
                 string text = string.Empty;
                 switch (requiredTargets)
                 {
-                    case RequiredTargets.Follow: text = "A Tracking Target is required in the CinemachineCamera."; break;
+                    case RequiredTargets.Tracking: text = "A Tracking Target is required in the CinemachineCamera."; break;
                     case RequiredTargets.LookAt: text = "A LookAt Tracking Target is required in the CinemachineCamera."; break;
-                    case RequiredTargets.FollowGroup: text = "Tracking Target in the CinemachineCamera must be a Target Group."; break;
+                    case RequiredTargets.Group: text = "The Tracking Target in the CinemachineCamera must be a Target Group."; break;
                     default: break;
                 }
                 if (text.Length > 0)
-                    EditorGUILayout.HelpBox(text, UnityEditor.MessageType.Warning);
+                    EditorGUILayout.HelpBox(text, MessageType.Warning);
                 EditorGUILayout.Space();
             }
         }

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -419,7 +419,7 @@ namespace Cinemachine.Editor
                 EditorApplication.delayCall += callback;
             else
                 callback();
-            owner.RegisterCallback<DetachFromPanelEvent>((e) => UserDidSomething -= callback);
+            owner.RegisterCallback<DetachFromPanelEvent>(_ => UserDidSomething -= callback);
         }
 
         /// <summary>
@@ -430,7 +430,7 @@ namespace Cinemachine.Editor
             this VisualElement owner, EditorApplication.CallbackFunction callback)
         {
             EditorApplication.update += callback;
-            owner.RegisterCallback<DetachFromPanelEvent>((e) => EditorApplication.update -= callback);
+            owner.RegisterCallback<DetachFromPanelEvent>(_ => EditorApplication.update -= callback);
         }
         
         /// <summary>
@@ -441,7 +441,7 @@ namespace Cinemachine.Editor
             this VisualElement owner, EditorApplication.CallbackFunction callback)
         {
             owner.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
-            void OnGeometryChanged(GeometryChangedEvent e)
+            void OnGeometryChanged(GeometryChangedEvent _)
             {
                 owner.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged); // call only once
                 callback();

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -421,6 +421,17 @@ namespace Cinemachine.Editor
                 callback();
             owner.RegisterCallback<DetachFromPanelEvent>((e) => UserDidSomething -= callback);
         }
+
+        /// <summary>
+        /// Convenience extension for EditorApplication.update callbacks, making it easier to use lambdas.
+        /// Cleans itself up when the owner is undisplayed.  Works in inspectors and PropertyDrawers.
+        /// </summary>
+        public static void ContinuousUpdate(
+            this VisualElement owner, EditorApplication.CallbackFunction callback)
+        {
+            EditorApplication.update += callback;
+            owner.RegisterCallback<DetachFromPanelEvent>((e) => EditorApplication.update -= callback);
+        }
         
         /// <summary>
         /// Draw a bold header in the inspector - hack to get around missing UITK functionality

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -434,6 +434,22 @@ namespace Cinemachine.Editor
         }
         
         /// <summary>
+        /// Convenience extension to get a callback after initial geometry creation, making it easier to use lambdas.
+        /// Callback will only be called once.  Works in inspectors and PropertyDrawers.
+        /// </summary>
+        public static void OnInitialGeometryChanged(
+            this VisualElement owner, EditorApplication.CallbackFunction callback)
+        {
+            owner.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            void OnGeometryChanged(GeometryChangedEvent e)
+            {
+                // Only once
+                owner.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged); // call only once
+                callback();
+            }
+        }
+        
+        /// <summary>
         /// Draw a bold header in the inspector - hack to get around missing UITK functionality
         /// </summary>
         /// <param name="ux">Container in which to put the header</param>

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -443,7 +443,6 @@ namespace Cinemachine.Editor
             owner.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
             void OnGeometryChanged(GeometryChangedEvent e)
             {
-                // Only once
                 owner.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged); // call only once
                 callback();
             }

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -17,7 +17,8 @@ namespace Cinemachine.Editor
     static class InspectorUtility
     {
         /// <summary>
-        /// Callback that happens whenever something undoable happens, either with objects or with selection.
+        /// Callback that happens whenever something undoable happens, either with 
+        /// objects or with selection.  This is a good way to track user activity.
         /// </summary>
         public static EditorApplication.CallbackFunction UserDidSomething;
 
@@ -406,6 +407,19 @@ namespace Cinemachine.Editor
         // this is a hack to get around some vertical alignment issues in UITK
         public static float SingleLineHeight => EditorGUIUtility.singleLineHeight - EditorGUIUtility.standardVerticalSpacing;
 
+        /// <summary>
+        /// Convenience extension for UserDidSomething callbacks, making it easier to use lambdas.
+        /// Cleans itself up when the owner is undisplayed.  Works in inspectors and PropertyDrawers.
+        /// </summary>
+        public static void TrackAnyUserActivity(
+            this VisualElement owner, EditorApplication.CallbackFunction callback, bool doInitialCallback = true)
+        {
+            UserDidSomething += callback;
+            if (doInitialCallback)
+                EditorApplication.delayCall += callback;
+            owner.RegisterCallback<DetachFromPanelEvent>((e) => UserDidSomething -= callback);
+        }
+        
         /// <summary>
         /// Draw a bold header in the inspector - hack to get around missing UITK functionality
         /// </summary>

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -412,11 +412,13 @@ namespace Cinemachine.Editor
         /// Cleans itself up when the owner is undisplayed.  Works in inspectors and PropertyDrawers.
         /// </summary>
         public static void TrackAnyUserActivity(
-            this VisualElement owner, EditorApplication.CallbackFunction callback, bool doInitialCallback = true)
+            this VisualElement owner, EditorApplication.CallbackFunction callback, bool delayInitialCallback = false)
         {
             UserDidSomething += callback;
-            if (doInitialCallback)
+            if (delayInitialCallback)
                 EditorApplication.delayCall += callback;
+            else
+                callback();
             owner.RegisterCallback<DetachFromPanelEvent>((e) => UserDidSomething -= callback);
         }
         

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -295,14 +295,11 @@ namespace Cinemachine
                 var components = GetComponents<CinemachineComponentBase>();
                 for (int i = 0; i < components.Length; ++i)
                 {
-                    if (components[i].enabled)
-                    {
 #if UNITY_EDITOR
-                        if (m_Pipeline[(int)components[i].Stage] != null)
-                            Debug.LogWarning("Multiple " + components[i].Stage + " components on " + name);
+                    if (m_Pipeline[(int)components[i].Stage] != null)
+                        Debug.LogWarning("Multiple " + components[i].Stage + " components on " + name);
 #endif
-                        m_Pipeline[(int)components[i].Stage] = components[i];
-                    }
+                    m_Pipeline[(int)components[i].Stage] = components[i];
                 }
             }
         }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
@@ -61,7 +61,7 @@ namespace Cinemachine
         }
 
         /// <summary>True if the component is valid, i.e. it has a noise definition and is enabled.</summary>
-        public override bool IsValid { get { return enabled && NoiseProfile != null; } }
+        public override bool IsValid { get => enabled && NoiseProfile != null; }
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Noise stage</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLockToTarget.cs
@@ -24,17 +24,17 @@ namespace Cinemachine
         Vector3 m_PreviousTargetPosition;
 
         /// <summary>True if component is enabled and has a LookAt defined</summary>
-        public override bool IsValid { get { return enabled && FollowTarget != null; } }
+        public override bool IsValid { get => enabled && FollowTarget != null; }
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Body; }
 
         /// <summary>
         /// Report maximum damping time needed for this component.
         /// </summary>
         /// <returns>Highest damping setting in this component</returns>
-        public override float GetMaxDampTime() { return Damping; }
+        public override float GetMaxDampTime() => Damping;
 
         /// <summary>Applies the composer rules and orients the camera accordingly</summary>
         /// <param name="curState">The current camera state</param>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
@@ -14,11 +14,11 @@ namespace Cinemachine
     public class CinemachineHardLookAt : CinemachineComponentBase
     {
         /// <summary>True if component is enabled and has a LookAt defined</summary>
-        public override bool IsValid { get { return enabled && LookAtTarget != null; } }
+        public override bool IsValid { get => enabled && LookAtTarget != null; }
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Aim; }
 
         /// <summary>Applies the composer rules and orients the camera accordingly</summary>
         /// <param name="curState">The current camera state</param>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSameAsFollowTarget.cs
@@ -26,17 +26,17 @@ namespace Cinemachine
         Quaternion m_PreviousReferenceOrientation = Quaternion.identity;
 
         /// <summary>True if component is enabled and has a Follow target defined</summary>
-        public override bool IsValid { get { return enabled && FollowTarget != null; } }
+        public override bool IsValid { get => enabled && FollowTarget != null; }
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Aim; } }
+        public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Aim; }
 
         /// <summary>
         /// Report maximum damping time needed for this component.
         /// </summary>
         /// <returns>Highest damping setting in this component</returns>
-        public override float GetMaxDampTime() { return Damping; }
+        public override float GetMaxDampTime() => Damping;
 
         /// <summary>Orients the camera to match the Follow target's orientation</summary>
         /// <param name="curState">The current camera state</param>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
@@ -184,7 +184,7 @@ namespace Cinemachine
 
         /// <summary>Get the Cinemachine Pipeline stage that this component implements.
         /// Always returns the Aim stage</summary>
-        public override CinemachineCore.Stage Stage { get { return CinemachineCore.Stage.Body; } }
+        public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Body; }
 
         /// <summary>
         /// Report maximum damping time needed for this component.
@@ -194,7 +194,8 @@ namespace Cinemachine
         { 
             return Mathf.Max(
 #if CINEMACHINE_PHYSICS
-                AvoidObstacles.Enabled ? Mathf.Max(AvoidObstacles.DampingIntoCollision, AvoidObstacles.DampingFromCollision) : 0,
+                AvoidObstacles.Enabled ? Mathf.Max(
+                    AvoidObstacles.DampingIntoCollision, AvoidObstacles.DampingFromCollision) : 0,
 #else
                 0,
 #endif

--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -126,6 +126,16 @@ namespace Cinemachine
             CreateControllers();
         }
 
+        void OnDisable()
+        {
+            foreach (var t in m_AxisResetters)
+                if ((t as UnityEngine.Object) != null)
+                    t.UnregisterResetHandler(OnResetInput);
+            m_Axes.Clear();
+            m_AxisOwners.Clear();
+            m_AxisResetters.Clear();
+        }
+
 #if UNITY_EDITOR
         static List<IInputAxisSource> s_AxisTargetsCache = new List<IInputAxisSource>();
         internal bool ConrollersAreValid()
@@ -141,14 +151,6 @@ namespace Cinemachine
         }
         internal void SynchronizeControllers() => CreateControllers();
 #endif
-
-        void OnDisable()
-        {
-            m_Axes.Clear();
-            foreach (var t in m_AxisResetters)
-                if ((t as UnityEngine.Object) != null)
-                    t.UnregisterResetHandler(OnResetInput);
-        }
 
         void CreateControllers()
         {


### PR DESCRIPTION
### Purpose of this PR

We were using `EditorApplication.update` and `VisualElement.schedule.Execute` to perform UX updating in cases where it was not possible to track specific property value changes in an event-driven way.  This was problematic for these reasons:
- They are called much more often than necessary.  It is usually sufficient to call them only when the user does something that affects the undo state
- `EditorApplication.update` needs to be cleaned up when the UX is taken down.  This meant that lambdas could not be used, and that complicated the life of the callers, who then needed to set up member variables and remember to clean up in OnDisable. PropertyDrawers could not use it at all, because they do not have an OnDisable method.

The recently-added `InspectorUtility.UserDidSomething` solved the call-too-often problem, but it still had to be cleaned up in OnDisable and could not be used in PropertyDrawers.

The solution is to add 3 static VisualElement extension methods to `InspectorUtility`: 
- `TrackAnyUserActivity` wraps `InspectorUtility.UserDidSomething`, calling a supplied callback when the user does anything that affects the Undo stack. 
- `ContinuousUpdate` which is a wrapper for `EditorApplication.update`.
- `OnInitialGeometryChanged` implements a one-time callback after the UI geometry is created, allowing you to capture settings that are not available at first, such as resolved style.

None of these methods require cleanup by the caller.  The first two methods will clean themselves up automatically when the ux is undisplayed, so no OnDisable handling is necessary.  Because of this, these methods can be used in PropertyDrawers.  `OnInitialGeometryChanged` cleans itself up on the first callback.

Due to the streamlined cleanup, the APIs of `CmCameraInspectorUtility` and `CmPipelineComponentInspectorUtility` have been simplified, because the complexity of managing OnDisable() is gone.  

Note: a couple of instances of `VisualElement.schedule.Execute` were left in the code, either because it's the correct approach, or because removing it caused problems.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Editor-only.  No effect on runtime.  

### Comments to reviewers

All inspectors need to be tested by playing with them, especially in such a way as to make the components come and go, then undoing and redoing and seeing if everything looks right, and that there are no messages in the console.  Also the Timeline Clip inspector should be tested separately (using Timeline 1.8.2), as it has a different lifecycle.
