### PR TITLE
CMCL-0000: Add EmbeddedAssetEditorUtility.AddAssetSelectorWithPresets

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/CameraTargetPropertyDrawer.cs
@@ -86,14 +86,13 @@ namespace Cinemachine.Editor
 
             var row = new VisualElement { style = { flexDirection = FlexDirection.Row }};
             row.Add(new PropertyField(property) { style = { flexGrow = 1 }});
-            var button = new Button { style = 
+            var button = row.AddChild(new Button { style = 
             { 
                 backgroundImage = (StyleBackground)EditorGUIUtility.IconContent("_Popup").image,
                 width = InspectorUtility.SingleLineHeight, height = InspectorUtility.SingleLineHeight,
                 alignSelf = Align.Center,
                 paddingRight = 0, borderRightWidth = 0, marginRight = 0
-            }};
-            row.Add(button);
+            }});
 
             var manipulator = new ContextualMenuManipulator((evt) => 
             {

--- a/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 
 namespace Cinemachine.Editor
 {
+    // GML todo: remove this class, replace with EmbeddedAssetEditorUtility.AddAssetSelectorWithPresets
+
     [CustomPropertyDrawer(typeof(CinemachineEmbeddedAssetPropertyAttribute))]
     class EmbeddedAssetPropertyDrawer : PropertyDrawer
     {

--- a/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
+++ b/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
@@ -205,8 +205,7 @@ namespace Cinemachine.Utility
                     var index = Int32.Parse(elements[1].Trim(']'));
                     if (type.IsArray)
                     {
-                        var a = obj as Array;
-                        if (a == null || a.Length <= index)
+                        if (obj is not Array a || a.Length <= index)
                             return null;
                         obj = a.GetValue(index);
                     }

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePropertyAttribute.cs
@@ -83,6 +83,7 @@ namespace Cinemachine
     /// <summary>
     /// Used for custom drawing in the inspector.  Inspector will show a foldout with the asset contents
     /// </summary>
+    /// GML TODO: delete this attribute
     public sealed class CinemachineEmbeddedAssetPropertyAttribute : PropertyAttribute 
     {
         /// <summary>If true, inspector will display a warning if the embedded asset is null</summary>


### PR DESCRIPTION
### Purpose of this PR

UITK replacement for EmbeddedAssetPropertyDrawer, which can be deleted once impulse editor stops using it.
EmbeddedAssetEditorUtility.AddAssetSelectorWithPresets is not being used currently.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

