### PR TITLE
CMCL-1378: AxisName PropertyDrawer in uitk, plus TrackPropertyWithInitialCallback

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisNamePropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisNamePropertyDrawer.cs
@@ -42,12 +42,12 @@ namespace Cinemachine.Editor
                 EditorGUIUtility.labelWidth = oldLabelWidth;
             }
         }
-#if false  // GML incomplete code.  This is not working yet in UITK - stay in IMGUI for now
+
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
             var row = new VisualElement { style = { flexDirection = FlexDirection.Row }};
             row.Add(new PropertyField(property, "") { style = { flexGrow = 1 }});
-            var error = new Label 
+            var error = row.AddChild(new Label 
             { 
                 style = 
                 { 
@@ -57,11 +57,21 @@ namespace Cinemachine.Editor
                     alignSelf = Align.Center,
                     paddingRight = 0, borderRightWidth = 0, marginRight = 0
                 }
-            };
-            row.Add(error);
+            });
+
+            row.TrackPropertyWithInitialCallback(property, (p) =>
+            {
+                // Is the axis name valid?
+                var nameError = string.Empty;
+                var nameValue = property.stringValue;
+                if (nameValue.Length > 0)
+                    try { CinemachineCore.GetInputAxis(nameValue); }
+                    catch (ArgumentException e) { nameError = e.Message; }
+                error.SetVisible(!string.IsNullOrEmpty(nameError));
+            });
+
             return row;
         }
-#endif
     }
 }
 #endif

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -160,9 +160,8 @@ namespace Cinemachine.Editor
             m_ParentElement.Add(new PropertyField(serializedObject.FindProperty(() => Target.DisplayName)));
             m_ParentElement.AddSpace();
 
-            // Component editors.  We delay the initial update because otherwise we get
-            // infinite loops (something to do with UITK throttling Bind calls)
-            m_ParentElement.TrackAnyUserActivity(UpdateComponentEditors, true);
+            // Component editors
+            m_ParentElement.TrackAnyUserActivity(UpdateComponentEditors);
 
             return m_ParentElement;
         }

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -72,7 +72,7 @@ namespace Cinemachine.Editor
             });
 
             // Capture "normal" colors
-            ux.OnInitialGeometryChanged(() =>
+            ux.OnInitialGeometry(() =>
             {
                 var normalColor = statusText.resolvedStyle.color;
                 var normalBkgColor = soloButton.resolvedStyle.backgroundColor;


### PR DESCRIPTION
### Purpose of this PR

- InputAxisNamePropertyDrawer now as uitk implementation.
- InspectorUtility.ContinuousUpdate performs an initial callback using OnGeometryChanged.  This eliminates initial flicker when widget is first displayed.
- Added InspectorUtility.TrackPropertyWithInitialCallback, implementing the pattern:

```MyCallback();
widget.TrackPropertyValue(property, MyCallback);
void MyCallback() { bla bla bla}```

Also changed InspectorUtility.TrackAnyUserActivity so that the initial callback uses OnGeometryChanged instead of calling immediately, so that dynamically-created widgets are available at callback tim.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
