### PR TITLE
CMCL-0000: Refactor TransitionParams, add IgnoreTarget hint

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - InputAxisController handles float and Vector2 automatically. Other input types need to be handled by a custom script inheriting InputAxisController.
 
+### Added
+
+- IgnoreTarget blend hint will blend rotations without considering the tracking target.
+
 
 ## [3.0.0-pre.4] - 2023-02-09
 

--- a/com.unity.cinemachine/Documentation~/CinemachineCamera.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineCamera.md
@@ -51,6 +51,7 @@ However, the real magic comes when you add Procedural Components to bring the ca
 | | _Cylindrical Position_ | During a blend, camera will take a cylindrical path around the Tracking target (vertical co-ordinate is linearly interpolated). |
 | | _Screen Space Aim When Targets Differ_ | During a blend, Tracking target position will interpolate in screen space instead of world space. |
 | | _Inherit Position_ | When this CinemachineCamera goes live, force the initial position to be the same as the current position of the Unity Camera, if possible. |
+| | _IgnoreTarget_ | Don't consider the Tracking Target when blending rotations, just to a spherical interpolation. |
 | __Position Control__ || Shortcut for setting the procedural positioning behavior of the CinemachineCamera.  |
 | __Rotation Control__ || Shortcut for setting the procedural rotation behavior of the CinemachineCamera.  |
 | __Noise__ || Shortcut for setting the procedural noise behavior of the CinemachineCamera.  |

--- a/com.unity.cinemachine/Documentation~/CinemachineExternalCamera.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineExternalCamera.md
@@ -7,6 +7,11 @@ This component will expose a non-cinemachine camera to the cinemachine ecosystem
 ## Properties:
 
 | **Property:** | **Function:** |
-|:---|:---|
-| __Look At__ | The object that the camera is looking at, if defined. This can be empty, but setting this may improve the quality of the blends to and from this camera. |
-| __Blend Hint__ | Hint for blending positions to and from this camera.  |
+|:---|:---|:---|
+| __Look At__ || The object that the camera is looking at, if defined. This can be empty, but setting this may improve the quality of the blends to and from this camera. |
+| __Blend Hint__ || Provides hints for blending positions to and from the CinemachineCamera. Values can be combined together. |
+| | _Spherical Position_ | During a blend, camera will take a spherical path around the Tracking target. |
+| | _Cylindrical Position_ | During a blend, camera will take a cylindrical path around the Tracking target (vertical co-ordinate is linearly interpolated). |
+| | _Screen Space Aim When Targets Differ_ | During a blend, Tracking target position will interpolate in screen space instead of world space. |
+| | _Inherit Position_ | When this CinemachineCamera goes live, force the initial position to be the same as the current position of the Unity Camera, if possible. |
+| | _IgnoreTarget_ | Don't consider the Tracking Target when blending rotations, just to a spherical interpolation. |

--- a/com.unity.cinemachine/Editor/Utility/CinemachineEditorAnalytics.cs
+++ b/com.unity.cinemachine/Editor/Utility/CinemachineEditorAnalytics.cs
@@ -173,8 +173,7 @@ namespace Cinemachine.Editor
                 }
             }
             
-            public void SetTransitionsAndLens(
-                CinemachineVirtualCameraBase.TransitionParams transitions, LensSettings lens)
+            public void SetTransitionsAndLens(TransitionParams transitions, LensSettings lens)
             {
                 blend_hint = transitions.BlendHint.ToString();
                 inherit_position = transitions.InheritPosition;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -219,7 +219,7 @@ namespace Cinemachine
                 m_State.ReferenceLookAt = (LookAtTargetAsVcam != null) 
                     ? LookAtTargetAsVcam.State.GetFinalPosition() : TargetPositionCache.GetTargetPosition(lookAt);
             InvokeComponentPipeline(ref m_State, deltaTime);
-            ApplyPositionBlendMethod(ref m_State, Transitions.BlendHint);
+            m_State.BlendHint = (CameraState.BlendHintValue)Transitions.BlendHint;
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.
@@ -262,8 +262,6 @@ namespace Cinemachine
                 InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
                 if (stage == CinemachineCore.Stage.Aim)
                 {
-                    if (c == null)
-                        state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget; // no aim
                     // If we have saved a Body for after Aim, do it now
                     if (postAimBody != null)
                     {

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -27,7 +27,7 @@ namespace Cinemachine
         [Tooltip("Hint for transitioning to and from this virtual camera")]
         [FormerlySerializedAs("m_PositionBlending")]
         [FormerlySerializedAs("m_BlendHint")]
-        public BlendHint TransitionHint = 0;
+        public TransitionParams.BlendHints TransitionHint = 0;
 
         Camera m_Camera;
         CameraState m_State = CameraState.Default;
@@ -74,7 +74,7 @@ namespace Cinemachine
                     m_State.ReferenceLookAt = m_State.RawPosition + Vector3.Project(
                         dir, State.RawOrientation * Vector3.forward);
             }
-            ApplyPositionBlendMethod(ref m_State, TransitionHint);
+            m_State.BlendHint = (CameraState.BlendHintValue)TransitionHint;
             InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Finalize, ref m_State, deltaTime);
         }
     }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -194,7 +194,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             m_ResetHandler?.Invoke(); // cancel re-centering
             if (fromCam != null

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -159,7 +159,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             m_ResetHandler?.Invoke(); // Cancel re-centering
             if (fromCam != null && transitionParams.InheritPosition  

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
@@ -179,7 +179,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             if (fromCam != null && transitionParams.InheritPosition
                  && !CinemachineCore.Instance.IsLiveInBlend(VirtualCamera))

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -85,22 +85,23 @@ namespace Cinemachine
         {
             /// <summary>Normal state blending</summary>
             Nothing = 0,
+            /// <summary>Spherical blend about the LookAt target (if any)</summary>
+            SphericalPositionBlend = TransitionParams.BlendHints.SphericalPosition,
+            /// <summary>Cylindrical blend about the LookAt target (if any)</summary>
+            CylindricalPositionBlend = TransitionParams.BlendHints.CylindricalPosition,
+            /// <summary>Radial blend when the LookAt target changes(if any)</summary>
+            ScreenSpaceAimWhenTargetsDiffer = TransitionParams.BlendHints.ScreenSpaceAimWhenTargetsDiffer,
+            /// <summary>Ignore the LookAt target and just slerp the orientation</summary>
+            IgnoreLookAtTarget = TransitionParams.BlendHints.IgnoreTarget,
+
             /// <summary>This state does not affect the camera position</summary>
-            NoPosition = 1,
+            NoPosition = 32,
             /// <summary>This state does not affect the camera rotation</summary>
-            NoOrientation = 2,
+            NoOrientation = 64,
             /// <summary>Combination of NoPosition and NoOrientation</summary>
             NoTransform = NoPosition | NoOrientation,
-            /// <summary>Spherical blend about the LookAt target (if any)</summary>
-            SphericalPositionBlend = 4,
-            /// <summary>Cylindrical blend about the LookAt target (if any)</summary>
-            CylindricalPositionBlend = 8,
-            /// <summary>Radial blend when the LookAt target changes(if any)</summary>
-            RadialAimBlend = 16,
-            /// <summary>Ignore the LookAt target and just slerp the orientation</summary>
-            IgnoreLookAtTarget = 32,
             /// <summary>This state does not affect the lens</summary>
-            NoLens = 64,
+            NoLens = 128,
         }
 
         /// <summary>
@@ -270,8 +271,7 @@ namespace Cinemachine
                     adjustedT = Mathf.Abs((lens.FieldOfView - fovA) / (fovB - fovA));
                 }
                 // Linear interpolation of lookAt target point
-                state.ReferenceLookAt = Vector3.Lerp(
-                        stateA.ReferenceLookAt, stateB.ReferenceLookAt, adjustedT);
+                state.ReferenceLookAt = Vector3.Lerp(stateA.ReferenceLookAt, stateB.ReferenceLookAt, adjustedT);
             }
             
             // Raw position
@@ -285,7 +285,7 @@ namespace Cinemachine
 
             // Interpolate the LookAt in Screen Space if requested
             if (state.HasLookAt() 
-                && ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.RadialAimBlend) != 0)
+                && ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.ScreenSpaceAimWhenTargetsDiffer) != 0)
             {
                 state.ReferenceLookAt = state.RawPosition + Vector3.Slerp(
                         stateA.ReferenceLookAt - state.RawPosition, 
@@ -297,7 +297,7 @@ namespace Cinemachine
             if (((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.NoOrientation) == 0)
             {
                 Vector3 dirTarget = Vector3.zero;
-                if (state.HasLookAt())//&& ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.RadialAimBlend) == 0)
+                if (state.HasLookAt())//&& ((stateA.BlendHint | stateB.BlendHint) & BlendHintValue.ScreenSpaceAimWhenTargetsDiffer) == 0)
                 {
                     // If orientations are different, use LookAt to blend them
                     float angle = Quaternion.Angle(stateA.RawOrientation, stateB.RawOrientation);

--- a/com.unity.cinemachine/Runtime/Core/CinemachineComponentBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineComponentBase.cs
@@ -190,7 +190,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public virtual bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams) => false;
+            ref TransitionParams transitionParams) => false;
 
         /// <summary>This is called to notify the component that a target got warped,
         /// so that the component can update its internal state to make the camera

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -423,34 +423,6 @@ namespace Cinemachine
         /// Returns Channels.Default otherwise.</returns>
         public OutputChannel.Channels GetChannel() => PriorityAndChannel.GetChannel();
 
-        /// <summary>Hint for transitioning to and from this virtual camera</summary>
-        [Flags]
-        public enum BlendHint
-        {
-            /// <summary>Spherical blend about Tracking target position</summary>
-            SphericalPosition = 1,
-            /// <summary>Cylindrical blend about Tracking target position (vertical co-ordinate is linearly interpolated)</summary>
-            CylindricalPosition = 2,
-            /// <summary>Screen-space blend between LookAt targets instead of world space lerp of target position</summary>
-            ScreenSpaceAimWhenTargetsDiffer = 4,
-            /// <summary>When this virtual camera goes Live, attempt to force the position to be the same 
-            /// as the current position of the Unity Camera</summary>
-            InheritPosition = 8
-        }
-
-        /// <summary>Applies a position blend hint to a camera state</summary>
-        /// <param name="state">The state to apply the hint to</param>
-        /// <param name="hint">The hint to apply</param>
-        protected void ApplyPositionBlendMethod(ref CameraState state, BlendHint hint)
-        {
-            if ((hint & BlendHint.SphericalPosition) != 0)
-                state.BlendHint |= CameraState.BlendHintValue.SphericalPositionBlend;
-            if ((hint & BlendHint.CylindricalPosition) != 0)
-                state.BlendHint |= CameraState.BlendHintValue.CylindricalPositionBlend;
-            if ((hint & BlendHint.ScreenSpaceAimWhenTargetsDiffer) != 0)
-                state.BlendHint |= CameraState.BlendHintValue.RadialAimBlend;
-        }
-
         /// <summary>The GameObject owner of the Virtual Camera behaviour.</summary>
         public GameObject VirtualCameraGameObject
         {
@@ -523,39 +495,6 @@ namespace Cinemachine
         /// <param name="worldUp">Default world Up, set by the CinemachineBrain</param>
         /// <param name="deltaTime">Delta time for time-based effects (ignore if less than 0)</param>
         public abstract void InternalUpdateCameraState(Vector3 worldUp, float deltaTime);
-
-        /// <summary> Collection of parameters that influence how this virtual camera transitions from
-        /// other virtual cameras </summary>
-        [Serializable]
-        public struct TransitionParams
-        {
-            /// <summary>Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although 
-            /// not all combinations make sense.  In the case of conflicting hints, Cinemachine will 
-            /// make an arbitrary choice.</summary>
-            [Tooltip("Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although "
-                + "not all combinations make sense.  In the case of conflicting hints, Cinemachine will "
-                + "make an arbitrary choice.")]
-            public BlendHint BlendHint;
-
-            /// <summary>Shortcut to read InheritPosition flag in BlendHint</summary>
-            public bool InheritPosition => (BlendHint & BlendHint.InheritPosition) != 0;
-
-            /// <summary>
-            /// These events fire when a transition occurs
-            /// </summary>
-            [Serializable]
-            public struct TransitionEvents
-            {
-                /// <summary>This event fires when the CinemachineCamera goes Live</summary>
-                [Tooltip("This event fires when the CinemachineCamera goes Live")]
-                public CinemachineBrain.VcamActivatedEvent OnCameraLive;
-            }
-            /// <summary>
-            /// These events fire when a transition occurs
-            /// </summary>
-            [Tooltip("These events fire when a transition occurs")]
-            public TransitionEvents Events;
-        }
 
         /// <summary>Notification that this virtual camera is going live.
         /// Base class implementation must be called by any overridden method.</summary>

--- a/com.unity.cinemachine/Runtime/Core/TransitionParams.cs
+++ b/com.unity.cinemachine/Runtime/Core/TransitionParams.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using System;
+
+namespace Cinemachine
+{
+    /// <summary> Collection of parameters that influence how a virtual camera transitions from
+    /// other virtual cameras </summary>
+    [Serializable]
+    public struct TransitionParams
+    {
+        /// <summary>Hint for transitioning to and from this virtual camera</summary>
+        [Flags]
+        public enum BlendHints
+        {
+            /// <summary>Spherical blend about Tracking target position</summary>
+            SphericalPosition = 1, 
+            /// <summary>Cylindrical blend about Tracking target position (vertical co-ordinate is linearly interpolated)</summary>
+            CylindricalPosition = 2,
+            /// <summary>Screen-space blend between LookAt targets instead of world space lerp of target position</summary>
+            ScreenSpaceAimWhenTargetsDiffer = 4,
+            /// <summary>When this virtual camera goes Live, attempt to force the position to be the same 
+            /// as the current position of the Unity Camera</summary>
+            InheritPosition = 8,
+            /// <summary>Do not consider the tracking target when blending, just do a spherical interpolation</summary>
+            IgnoreTarget = 16
+        }
+
+        /// <summary>Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although 
+        /// not all combinations make sense.  In the case of conflicting hints, Cinemachine will 
+        /// make an arbitrary choice.</summary>
+        [Tooltip("Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although "
+            + "not all combinations make sense.  In the case of conflicting hints, Cinemachine will "
+            + "make an arbitrary choice.")]
+        public BlendHints BlendHint;
+
+        /// <summary>Shortcut to read InheritPosition flag in BlendHint</summary>
+        public bool InheritPosition => (BlendHint & BlendHints.InheritPosition) != 0;
+
+        /// <summary>
+        /// These events fire when a transition occurs
+        /// </summary>
+        [Serializable]
+        public struct TransitionEvents
+        {
+            /// <summary>This event fires when the CinemachineCamera goes Live</summary>
+            [Tooltip("This event fires when the CinemachineCamera goes Live")]
+            public CinemachineBrain.VcamActivatedEvent OnCameraLive;
+        }
+        /// <summary>
+        /// These events fire when a transition occurs
+        /// </summary>
+        [Tooltip("These events fire when a transition occurs")]
+        public TransitionEvents Events;
+    }
+}

--- a/com.unity.cinemachine/Runtime/Core/TransitionParams.cs.meta
+++ b/com.unity.cinemachine/Runtime/Core/TransitionParams.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: dfe0fb0bbb597e04b83227c82d9f0c62
+timeCreated: 1488314898
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -359,7 +359,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             if (fromCam != null && transitionParams.InheritPosition
                  && !CinemachineCore.Instance.IsLiveInBlend(VirtualCamera))

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -146,14 +146,14 @@ namespace Cinemachine
                 if (m_LegacyTransitions.m_BlendHint != 0)
                 {
                     if (m_LegacyTransitions.m_BlendHint == 3)
-                        Transitions.BlendHint = BlendHint.ScreenSpaceAimWhenTargetsDiffer;
+                        Transitions.BlendHint = TransitionParams.BlendHints.ScreenSpaceAimWhenTargetsDiffer;
                     else
-                        Transitions.BlendHint = (BlendHint)m_LegacyTransitions.m_BlendHint;
+                        Transitions.BlendHint = (TransitionParams.BlendHints)m_LegacyTransitions.m_BlendHint;
                     m_LegacyTransitions.m_BlendHint = 0;
                 }
                 if (m_LegacyTransitions.m_InheritPosition)
                 {
-                    Transitions.BlendHint |= BlendHint.InheritPosition;
+                    Transitions.BlendHint |= TransitionParams.BlendHints.InheritPosition;
                     m_LegacyTransitions.m_InheritPosition = false;
                 }
                 if (m_LegacyTransitions.m_OnCameraLive != null)
@@ -383,7 +383,7 @@ namespace Cinemachine
 
             // Update the current state by invoking the component pipeline
             m_State = CalculateNewState(worldUp, deltaTime);
-            ApplyPositionBlendMethod(ref m_State, Transitions.BlendHint);
+            m_State.BlendHint = (CameraState.BlendHintValue)Transitions.BlendHint;
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.  Leave the orientation alone, because it

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineOrbitalTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineOrbitalTransposer.cs
@@ -418,7 +418,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             m_RecenterToTargetHeading.DoRecentering(ref m_XAxis, -1, 0);
             m_RecenterToTargetHeading.CancelRecentering();

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
@@ -211,7 +211,7 @@ namespace Cinemachine
         /// <returns>True if the vcam should do an internal update as a result of this call</returns>
         public override bool OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime,
-            ref CinemachineVirtualCameraBase.TransitionParams transitionParams)
+            ref TransitionParams transitionParams)
         {
             m_HorizontalRecentering.DoRecentering(ref m_HorizontalAxis, -1, 0);
             m_VerticalRecentering.DoRecentering(ref m_VerticalAxis, -1, 0);

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
@@ -78,14 +78,14 @@ namespace Cinemachine
                 if (m_LegacyTransitions.m_BlendHint != 0)
                 {
                     if (m_LegacyTransitions.m_BlendHint == 3)
-                        Transitions.BlendHint = BlendHint.ScreenSpaceAimWhenTargetsDiffer;
+                        Transitions.BlendHint = TransitionParams.BlendHints.ScreenSpaceAimWhenTargetsDiffer;
                     else
-                        Transitions.BlendHint = (BlendHint)m_LegacyTransitions.m_BlendHint;
+                        Transitions.BlendHint = (TransitionParams.BlendHints)m_LegacyTransitions.m_BlendHint;
                     m_LegacyTransitions.m_BlendHint = 0;
                 }
                 if (m_LegacyTransitions.m_InheritPosition)
                 {
-                    Transitions.BlendHint |= BlendHint.InheritPosition;
+                    Transitions.BlendHint |= TransitionParams.BlendHints.InheritPosition;
                     m_LegacyTransitions.m_InheritPosition = false;
                 }
                 if (m_LegacyTransitions.m_OnCameraLive != null)
@@ -162,7 +162,7 @@ namespace Cinemachine
 
             // Update the state by invoking the component pipeline
             m_State = CalculateNewState(worldUp, deltaTime);
-            ApplyPositionBlendMethod(ref m_State, Transitions.BlendHint);
+            m_State.BlendHint = (CameraState.BlendHintValue)Transitions.BlendHint;
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.
@@ -496,7 +496,6 @@ namespace Cinemachine
             // Then components
             if (m_ComponentPipeline == null)
             {
-                state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
                 for (var stage = CinemachineCore.Stage.Body; stage <= CinemachineCore.Stage.Finalize; ++stage)
                     InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
             }
@@ -526,8 +525,6 @@ namespace Cinemachine
 
                     if (stage == CinemachineCore.Stage.Aim)
                     {
-                        if (c == null)
-                            state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
                         // If we have saved a Body for after Aim, do it now
                         if (postAimBody != null)
                         {


### PR DESCRIPTION
### Purpose of this PR

IgnoreTarget blend hint is necessary because sometimes you just want to slerp the angle.
It used to be added by default when there was no Aim component, but this is too pushy.  It needs to be on-demand only.

Refactored the TransitionParams, to make a hint translation function unnecessary - a cast is now sufficient.  API is simplified as a result.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [x] Updated user documentation
