### PR TITLE
CMCL-1387: Tag field in PropertyDrawer in uitk

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/TagFieldPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/TagFieldPropertyDrawer.cs
@@ -1,22 +1,22 @@
 using UnityEngine;
 using UnityEditor;
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 
 namespace Cinemachine.Editor
 {
     [CustomPropertyDrawer(typeof(TagFieldAttribute))]
     class TagFieldPropertyDrawer : PropertyDrawer
     {
-        const float hSpace = 2;
-        private string tagValue = "";
-        GUIContent clearText = new GUIContent("Clear", "Set the tag to empty");
-        
+        readonly GUIContent m_ClearText = new ("Clear", "Set the tag to empty");
+
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
-            var textDimensions = GUI.skin.button.CalcSize(clearText);
-
+            const float hSpace = 2;
+            var textDimensions = GUI.skin.button.CalcSize(m_ClearText);
             rect.width -= textDimensions.x + hSpace;
             
-            tagValue = property.stringValue;
+            var tagValue = property.stringValue;
             EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
             EditorGUI.BeginChangeCheck();
             tagValue = EditorGUI.TagField(rect, EditorGUI.BeginProperty(rect, label, property), tagValue);
@@ -26,9 +26,38 @@ namespace Cinemachine.Editor
 
             rect.x += rect.width + hSpace; rect.width = textDimensions.x; rect.height -=1;
             GUI.enabled = tagValue.Length > 0;
-            if (GUI.Button(rect, clearText))
+            if (GUI.Button(rect, m_ClearText))
                 property.stringValue = string.Empty;
             GUI.enabled = true;
+        }
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var row = new InspectorUtility.LabeledRow(property.displayName, property.tooltip);
+
+            var enabled = row.Contents.AddChild(new Toggle() { style = { marginTop = 2, marginLeft = 0 }});
+            enabled.RegisterValueChangedCallback((evt) => 
+            {
+                property.stringValue = evt.newValue ? "Untagged" : string.Empty;
+                property.serializedObject.ApplyModifiedProperties();
+            });
+
+            var tagField = row.Contents.AddChild(new TagField("", property.stringValue) 
+                { tooltip = property.tooltip, style = { flexGrow = 1, marginTop = 0, marginBottom = 0 }});
+            tagField.RegisterValueChangedCallback((evt) =>
+            {
+                property.stringValue = evt.newValue;
+                property.serializedObject.ApplyModifiedProperties();
+            });
+
+            row.TrackPropertyWithInitialCallback(property, (p) => 
+            {
+                var isEmpty = string.IsNullOrEmpty(p.stringValue);
+                enabled.SetValueWithoutNotify(!isEmpty);
+                tagField.SetVisible(!isEmpty);
+                tagField.value = p.stringValue;
+            });
+            return row;
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Tag field PropertyDrawer in UITK.
Changed the UX a little, making it clearer.  Instead of this:
![image](https://user-images.githubusercontent.com/6424658/221416655-cf74e2bc-f14c-4e0d-9759-016a16ce67ef.png)

we have this:

![image](https://user-images.githubusercontent.com/6424658/221416685-412ccc6f-eaa2-4e66-9c3d-182652641c40.png)
![image](https://user-images.githubusercontent.com/6424658/221416707-7feb8b8a-0c04-4837-a711-e8eea9c191bb.png)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
