### PR TITLE
CMCL-1395: Remove m_ from BlendDefinition members

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -144,9 +144,9 @@ namespace Cinemachine.Editor
                     SerializedProperty blendProp = l.serializedProperty.GetArrayElementAtIndex(
                             index).FindPropertyRelative(() => def.Blend);
 
-                    blendProp.FindPropertyRelative(() => def2.m_Style).enumValueIndex
-                        = (int)CinemachineBlendDefinition.Style.EaseInOut;
-                    blendProp.FindPropertyRelative(() => def2.m_Time).floatValue = 2f;
+                    blendProp.FindPropertyRelative(() => def2.Style).enumValueIndex
+                        = (int)CinemachineBlendDefinition.Styles.EaseInOut;
+                    blendProp.FindPropertyRelative(() => def2.Time).floatValue = 2f;
                 };
         }
     }

--- a/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
+++ b/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
@@ -142,7 +142,7 @@ namespace Cinemachine.Editor
             blendListCamera.Instructions = new ()
             {
                 new () { Camera = childVcam1, Hold = 1 },
-                new () { Camera = childVcam2, Blend = new () { m_Style = CinemachineBlendDefinition.Style.EaseInOut, m_Time = 2f }}
+                new () { Camera = childVcam2, Blend = new () { Style = CinemachineBlendDefinition.Styles.EaseInOut, Time = 2f }}
             };
         }
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/BlendDefinitionPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/BlendDefinitionPropertyDrawer.cs
@@ -9,13 +9,14 @@ namespace Cinemachine.Editor
     [CustomPropertyDrawer(typeof(CinemachineBlendDefinition))]
     class BlendDefinitionPropertyDrawer : PropertyDrawer
     {
-        CinemachineBlendDefinition m_MyClass = new(); // to access name strings
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
+            CinemachineBlendDefinition def = new(); // to access name strings
+
             float vSpace = 0;
             float floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
 
-            SerializedProperty timeProp = property.FindPropertyRelative(() => m_MyClass.m_Time);
+            SerializedProperty timeProp = property.FindPropertyRelative(() => def.Time);
             GUIContent timeText = new GUIContent(" s", timeProp.tooltip);
             var textDimensions = GUI.skin.label.CalcSize(timeText);
 
@@ -24,15 +25,15 @@ namespace Cinemachine.Editor
             rect.y += vSpace; rect.height = EditorGUIUtility.singleLineHeight;
             rect.width -= floatFieldWidth + textDimensions.x;
 
-            SerializedProperty styleProp = property.FindPropertyRelative(() => m_MyClass.m_Style);
-            bool isCustom = styleProp.enumValueIndex == (int)CinemachineBlendDefinition.Style.Custom;
+            SerializedProperty styleProp = property.FindPropertyRelative(() => def.Style);
+            bool isCustom = styleProp.enumValueIndex == (int)CinemachineBlendDefinition.Styles.Custom;
             var r = rect;
             if (isCustom)
                 r.width -= 2 * r.height;
             EditorGUI.PropertyField(r, styleProp, GUIContent.none);
             if (isCustom)
             {
-                SerializedProperty curveProp = property.FindPropertyRelative(() => m_MyClass.m_CustomCurve);
+                SerializedProperty curveProp = property.FindPropertyRelative(() => def.CustomCurve);
                 r.x += r.width;
                 r.width = 2 * rect.height;
                 EditorGUI.BeginChangeCheck();
@@ -43,7 +44,7 @@ namespace Cinemachine.Editor
                     curveProp.serializedObject.ApplyModifiedProperties();
                 }
             }
-            if (styleProp.intValue != (int)CinemachineBlendDefinition.Style.Cut)
+            if (styleProp.intValue != (int)CinemachineBlendDefinition.Styles.Cut)
             {
                 float oldWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = textDimensions.x;
@@ -58,6 +59,7 @@ namespace Cinemachine.Editor
 
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
+            CinemachineBlendDefinition def = new(); // to access name strings
             var floatFieldWidth = EditorGUIUtility.singleLineHeight * 2.5f;
 
             VisualElement ux, contents;
@@ -72,15 +74,15 @@ namespace Cinemachine.Editor
                 ux = row;
             }
 
-            var styleProp = property.FindPropertyRelative(() => m_MyClass.m_Style);
+            var styleProp = property.FindPropertyRelative(() => def.Style);
             contents.Add(new PropertyField(styleProp, "")
                 { style = { flexGrow = 1, flexBasis = floatFieldWidth }});
 
-            var curveProp = property.FindPropertyRelative(() => m_MyClass.m_CustomCurve);
+            var curveProp = property.FindPropertyRelative(() => def.CustomCurve);
             var curveWidget = contents.AddChild(new PropertyField(curveProp, "")
                 { style = { flexGrow = 0, flexBasis = floatFieldWidth }});
 
-            var timeProp = property.FindPropertyRelative(() => m_MyClass.m_Time);
+            var timeProp = property.FindPropertyRelative(() => def.Time);
             var timeWidget = contents.AddChild(new InspectorUtility.CompactPropertyField(timeProp, "s")
                 { style = { flexGrow = 0, flexBasis = floatFieldWidth, marginLeft = 4 }});
 
@@ -88,8 +90,8 @@ namespace Cinemachine.Editor
             contents.TrackPropertyValue(styleProp, OnStyleChanged);
             void OnStyleChanged(SerializedProperty p)
             {
-                curveWidget.SetVisible(p.intValue == (int)CinemachineBlendDefinition.Style.Custom);
-                timeWidget.SetVisible(p.intValue != (int)CinemachineBlendDefinition.Style.Cut);
+                curveWidget.SetVisible(p.intValue == (int)CinemachineBlendDefinition.Styles.Custom);
+                timeWidget.SetVisible(p.intValue != (int)CinemachineBlendDefinition.Styles.Cut);
             }
 
             return ux;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -193,7 +193,7 @@ namespace Cinemachine
             + "blend between two Virtual Cameras")]
         [FormerlySerializedAs("m_DefaultBlend")]
         public CinemachineBlendDefinition DefaultBlend
-            = new CinemachineBlendDefinition(CinemachineBlendDefinition.Style.EaseInOut, 2f);
+            = new CinemachineBlendDefinition(CinemachineBlendDefinition.Styles.EaseInOut, 2f);
 
         /// <summary>
         /// This is the asset which contains custom settings for specific blends.
@@ -268,7 +268,7 @@ namespace Cinemachine
 
         void OnValidate()
         {
-            DefaultBlend.m_Time = Mathf.Max(0, DefaultBlend.m_Time);
+            DefaultBlend.Time = Mathf.Max(0, DefaultBlend.Time);
         }
 
         void Reset()
@@ -281,7 +281,7 @@ namespace Cinemachine
             UpdateMethod = UpdateMethods.SmartUpdate;
             BlendUpdateMethod = BrainUpdateMethods.LateUpdate;
             LensModeOverride = new LensModeOverrideSettings { DefaultMode = LensSettings.OverrideModes.Perspective };
-            DefaultBlend = new CinemachineBlendDefinition(CinemachineBlendDefinition.Style.EaseInOut, 2f);
+            DefaultBlend = new CinemachineBlendDefinition(CinemachineBlendDefinition.Styles.EaseInOut, 2f);
             CustomBlends = null;
             CameraCutEvent = new BrainEvent();
             CameraActivatedEvent = new VcamActivatedEvent();

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
@@ -48,7 +48,7 @@ namespace Cinemachine
         /// <summary>The blend which is used if you don't explicitly define a blend between two Virtual Cameras</summary>
         [Tooltip("The blend which is used if you don't explicitly define a blend between two Virtual Cameras")]
         [FormerlySerializedAs("m_DefaultBlend")]
-        public CinemachineBlendDefinition DefaultBlend = new(CinemachineBlendDefinition.Style.Cut, 0);
+        public CinemachineBlendDefinition DefaultBlend = new(CinemachineBlendDefinition.Styles.Cut, 0);
 
         /// <summary>This is the asset which contains custom settings for specific blends</summary>
         [HideInInspector]
@@ -75,7 +75,7 @@ namespace Cinemachine
             ActivateAfter = 0;
             MinDuration = 0;
             RandomizeChoice = false;
-            DefaultBlend = new (CinemachineBlendDefinition.Style.EaseInOut, 0.5f);
+            DefaultBlend = new (CinemachineBlendDefinition.Styles.EaseInOut, 0.5f);
             CustomBlends = null;
         }
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -76,7 +76,7 @@ namespace Cinemachine
         /// </summary>
         [Tooltip("The blend which is used if you don't explicitly define a blend between two Virtual Camera children")]
         [FormerlySerializedAs("m_DefaultBlend")]
-        public CinemachineBlendDefinition DefaultBlend = new (CinemachineBlendDefinition.Style.EaseInOut, 0.5f);
+        public CinemachineBlendDefinition DefaultBlend = new (CinemachineBlendDefinition.Styles.EaseInOut, 0.5f);
 
         /// <summary>
         /// This is the asset which contains custom settings for specific child blends.
@@ -120,7 +120,7 @@ namespace Cinemachine
             AnimatedTarget = null;
             LayerIndex = 0;
             Instructions = null;
-            DefaultBlend = new (CinemachineBlendDefinition.Style.EaseInOut, 0.5f);
+            DefaultBlend = new (CinemachineBlendDefinition.Styles.EaseInOut, 0.5f);
             CustomBlends = null;
         }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -1,6 +1,7 @@
 using Cinemachine.Utility;
 using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Cinemachine
 {
@@ -144,7 +145,7 @@ namespace Cinemachine
     public struct CinemachineBlendDefinition
     {
         /// <summary>Supported predefined shapes for the blend curve.</summary>
-        public enum Style
+        public enum Styles
         {
             /// <summary>Zero-length blend</summary>
             Cut,
@@ -166,67 +167,70 @@ namespace Cinemachine
 
         /// <summary>The shape of the blend curve.</summary>
         [Tooltip("Shape of the blend curve")]
-        public Style m_Style;
+        [FormerlySerializedAs("m_Style")]
+        public Styles Style;
 
         /// <summary>The duration (in seconds) of the blend, if not a cut.  
         /// If style is a cut, then this value is ignored.</summary>
         [Tooltip("Duration of the blend, in seconds")]
-        public float m_Time;
+        [FormerlySerializedAs("m_Time")]
+        public float Time;
 
         /// <summary>
         /// Get the duration of the blend, in seconds.  Will return 0 if blend style is a cut.
         /// </summary>
-        public float BlendTime { get { return m_Style == Style.Cut ? 0 : m_Time; } }
+        public float BlendTime => Style == Styles.Cut ? 0 : Time; 
 
         /// <summary>Constructor</summary>
         /// <param name="style">The shape of the blend curve.</param>
         /// <param name="time">The duration (in seconds) of the blend</param>
-        public CinemachineBlendDefinition(Style style, float time)
+        public CinemachineBlendDefinition(Styles style, float time)
         {
-            m_Style = style;
-            m_Time = time;
-            m_CustomCurve = null;
+            Style = style;
+            Time = time;
+            CustomCurve = null;
         }
 
         /// <summary>
         /// A user-defined AnimationCurve, used only if style is Custom.
         /// Curve MUST be normalized, i.e. time range [0...1], value range [0...1].
         /// </summary>
-        public AnimationCurve m_CustomCurve;
+        [FormerlySerializedAs("m_CustomCurve")]
+        public AnimationCurve CustomCurve;
 
-        static AnimationCurve[] sStandardCurves;
+        static AnimationCurve[] s_StandardCurves;
         void CreateStandardCurves()
         {
-            sStandardCurves = new AnimationCurve[(int)Style.Custom];
+            s_StandardCurves = new AnimationCurve[(int)Styles.Custom];
 
-            sStandardCurves[(int)Style.Cut] = null;
-            sStandardCurves[(int)Style.EaseInOut] = AnimationCurve.EaseInOut(0f, 0f, 1, 1f);
+            s_StandardCurves[(int)Styles.Cut] = null;
+            s_StandardCurves[(int)Styles.EaseInOut] = AnimationCurve.EaseInOut(0f, 0f, 1, 1f);
 
-            sStandardCurves[(int)Style.EaseIn] = AnimationCurve.Linear(0f, 0f, 1, 1f);
-            Keyframe[] keys = sStandardCurves[(int)Style.EaseIn].keys;
+            s_StandardCurves[(int)Styles.EaseIn] = AnimationCurve.Linear(0f, 0f, 1, 1f);
+            Keyframe[] keys = s_StandardCurves[(int)Styles.EaseIn].keys;
             keys[0].outTangent = 1.4f;
             keys[1].inTangent = 0;
-            sStandardCurves[(int)Style.EaseIn].keys = keys;
+            s_StandardCurves[(int)Styles.EaseIn].keys = keys;
 
-            sStandardCurves[(int)Style.EaseOut] = AnimationCurve.Linear(0f, 0f, 1, 1f);
-            keys = sStandardCurves[(int)Style.EaseOut].keys;
+            s_StandardCurves[(int)Styles.EaseOut] = AnimationCurve.Linear(0f, 0f, 1, 1f);
+            keys = s_StandardCurves[(int)Styles.EaseOut].keys;
             keys[0].outTangent = 0;
             keys[1].inTangent = 1.4f;
-            sStandardCurves[(int)Style.EaseOut].keys = keys;
+            s_StandardCurves[(int)Styles.EaseOut].keys = keys;
 
-            sStandardCurves[(int)Style.HardIn] = AnimationCurve.Linear(0f, 0f, 1, 1f);
-            keys = sStandardCurves[(int)Style.HardIn].keys;
+            s_StandardCurves[(int)Styles.HardIn] = AnimationCurve.Linear(0f, 0f, 1, 1f);
+            keys = s_StandardCurves[(int)Styles.HardIn].keys;
             keys[0].outTangent = 0;
             keys[1].inTangent = 3f;
-            sStandardCurves[(int)Style.HardIn].keys = keys;
+            s_StandardCurves[(int)Styles.HardIn].keys = keys;
 
-            sStandardCurves[(int)Style.HardOut] = AnimationCurve.Linear(0f, 0f, 1, 1f);
-            keys = sStandardCurves[(int)Style.HardOut].keys;
+            s_StandardCurves[(int)Styles.HardOut] = AnimationCurve.Linear(0f, 0f, 1, 1f);
+            keys = s_StandardCurves[(int)Styles.HardOut].keys;
             keys[0].outTangent = 3f;
             keys[1].inTangent = 0;
-            sStandardCurves[(int)Style.HardOut].keys = keys;
+            s_StandardCurves[(int)Styles.HardOut].keys = keys;
 
-            sStandardCurves[(int)Style.Linear] = AnimationCurve.Linear(0f, 0f, 1, 1f);
+            s_StandardCurves[(int)Styles.Linear] = AnimationCurve.Linear(0f, 0f, 1, 1f);
         }
 
         /// <summary>
@@ -238,15 +242,14 @@ namespace Cinemachine
         {
             get
             {
-                if (m_Style == Style.Custom)
+                if (Style == Styles.Custom)
                 {
-                    if (m_CustomCurve == null)
-                        m_CustomCurve = AnimationCurve.EaseInOut(0f, 0f, 1, 1f);
-                    return m_CustomCurve;
+                    CustomCurve ??= AnimationCurve.EaseInOut(0f, 0f, 1, 1f);
+                    return CustomCurve;
                 }
-                if (sStandardCurves == null)
+                if (s_StandardCurves == null)
                     CreateStandardCurves();
-                return sStandardCurves[(int)m_Style];
+                return s_StandardCurves[(int)Style];
             }
         }
     }
@@ -261,13 +264,13 @@ namespace Cinemachine
         public void SetState(CameraState state) { State = state; }
 
         public string Name { get; private set; }
-        public string Description { get { return ""; }}
+        public string Description => string.Empty;
         public Transform LookAt { get; set; }
         public Transform Follow { get; set; }
         public CameraState State { get; private set; }
-        public bool IsValid { get { return true; } }
-        public ICinemachineCamera ParentCamera { get { return null; } }
-        public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) { return false; }
+        public bool IsValid => true;
+        public ICinemachineCamera ParentCamera => null;
+        public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) => false;
         public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
         public void InternalUpdateCameraState(Vector3 worldUp, float deltaTime) {}
         public void OnTransitionFromCamera(ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime) {}
@@ -284,16 +287,16 @@ namespace Cinemachine
         public BlendSourceVirtualCamera(CinemachineBlend blend) { Blend = blend; }
         public CinemachineBlend Blend { get; set; }
 
-        public string Name { get { return "Mid-blend"; }}
-        public string Description { get { return Blend == null ? "(null)" : Blend.Description; }}
+        public string Name => "Mid-blend";
+        public string Description => Blend == null ? "(null)" : Blend.Description;
         public Transform LookAt { get; set; }
         public Transform Follow { get; set; }
         public CameraState State { get; private set; }
-        public bool IsValid { get { return Blend != null && Blend.IsValid; } }
-        public ICinemachineCamera ParentCamera { get { return null; } }
+        public bool IsValid => Blend != null && Blend.IsValid; 
+        public ICinemachineCamera ParentCamera => null;
         public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false)
-            { return Blend != null && (vcam == Blend.CamA || vcam == Blend.CamB); }
-        public CameraState CalculateNewState(float deltaTime) { return State; }
+            => Blend != null && (vcam == Blend.CamA || vcam == Blend.CamB);
+        public CameraState CalculateNewState(float deltaTime) => State;
         public void UpdateCameraState(Vector3 worldUp, float deltaTime)
         {
             if (Blend != null)

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -252,7 +252,7 @@ namespace Cinemachine
                     // How far have we blended?  That is what we must undo
                     var progress = blendStartPosition 
                         + (1 - blendStartPosition) * activeBlend.TimeInBlend / activeBlend.Duration;
-                    blendDef.m_Time *= progress;
+                    blendDef.Time *= progress;
                     m_BlendStartPosition = 1 - progress;
                 }
 

--- a/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
@@ -20,7 +20,7 @@ namespace Tests.Runtime
 
             // Blending
             m_Brain.DefaultBlend = 
-                new CinemachineBlendDefinition(CinemachineBlendDefinition.Style.Linear, k_BlendingTime);
+                new CinemachineBlendDefinition(CinemachineBlendDefinition.Styles.Linear, k_BlendingTime);
             
 #if CINEMACHINE_V3_OR_HIGHER
             m_Source = CreateGameObject("A", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();


### PR DESCRIPTION
### Purpose of this PR

We forgot to remove the m_ from the members of CinemachineBlendDefinition.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

