### PR TITLE
CMCL-1373: Handling input smarter (2)

### DIFF
--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -294,7 +294,7 @@ namespace Cinemachine
         /// <returns>Returns the value of the input device.</returns>
         protected virtual float ReadInput(InputAction action, IInputAxisSource.AxisDescriptor.Hints hint)
         {
-#if true
+#if false
             // GML Temporary fix until this issue is sorted out
             switch (hint)
             {

--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -294,32 +294,23 @@ namespace Cinemachine
         /// <returns>Returns the value of the input device.</returns>
         protected virtual float ReadInput(InputAction action, IInputAxisSource.AxisDescriptor.Hints hint)
         {
-#if false
-            // GML Temporary fix until this issue is sorted out
-            switch (hint)
-            {
-                case IInputAxisSource.AxisDescriptor.Hints.X: return action.ReadValue<Vector2>().x;
-                case IInputAxisSource.AxisDescriptor.Hints.Y: return action.ReadValue<Vector2>().y;
-                default: return action.ReadValue<float>();
-            }
-#else
             var activeControl = action.activeControl;
             if (activeControl == null)
                 return 0f;
             
             var actionControlType = activeControl.valueType;
-            if (actionControlType == typeof(float))
-                return action.ReadValue<float>();
-            if (actionControlType == typeof(Vector2))
+            if (actionControlType == typeof(Vector2) || action.expectedControlType == "Vector2")
                 return hint == IInputAxisSource.AxisDescriptor.Hints.Y
                     ? action.ReadValue<Vector2>().y
                     : action.ReadValue<Vector2>().x;
+            if (actionControlType == typeof(float))
+                return action.ReadValue<float>();
+            
 
             Debug.LogError("The valueType of InputAction provided to " + name + " is not handled by default. " +
                 "You need to create a class inheriting InputAxisController and you need to override the " +
                 "ReadInput method to handle your case.");
             return 0f;
-#endif
         }
         
         float ReadInputAction(Controller c, IInputAxisSource.AxisDescriptor.Hints hint)

--- a/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/InputAxisController.cs
@@ -294,22 +294,29 @@ namespace Cinemachine
         /// <returns>Returns the value of the input device.</returns>
         protected virtual float ReadInput(InputAction action, IInputAxisSource.AxisDescriptor.Hints hint)
         {
-            var activeControl = action.activeControl;
-            if (activeControl == null)
-                return 0f;
-            
-            var actionControlType = activeControl.valueType;
-            if (actionControlType == typeof(Vector2) || action.expectedControlType == "Vector2")
-                return hint == IInputAxisSource.AxisDescriptor.Hints.Y
-                    ? action.ReadValue<Vector2>().y
-                    : action.ReadValue<Vector2>().x;
-            if (actionControlType == typeof(float))
-                return action.ReadValue<float>();
-            
-
-            Debug.LogError("The valueType of InputAction provided to " + name + " is not handled by default. " +
-                "You need to create a class inheriting InputAxisController and you need to override the " +
-                "ReadInput method to handle your case.");
+            var control = action.activeControl;
+            if (control != null)
+            {
+                try 
+                {
+                    // If we can read as a Vector2, do so
+                    if (control.valueType == typeof(Vector2) || action.expectedControlType == "Vector2")
+                    {
+                        var value = action.ReadValue<Vector2>();
+                        return hint == IInputAxisSource.AxisDescriptor.Hints.Y ? value.y : value.x;
+                    }
+                    // Default: assume type is float
+                    return action.ReadValue<float>(); 
+                }
+                catch (InvalidOperationException)
+                {
+                    Debug.LogError("An action in the " + name + " object is mapped to a "
+                        + control.valueType.Name + " control.  The default inmplementation of "
+                        + "InputAxisController.ReadInput can only handle float or Vector2 types. "
+                        + "To handle other types you can create a class inheriting "
+                        + "InputAxisController with the ReadInput method overridden.");
+                }
+            }
             return 0f;
         }
         


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1373](https://jira.unity3d.com/browse/CMCL-1373): 
Unfortunately, there is no one API for checking what the input type to read is. I could not break the current solution, but it feels fragile nevertheless.

Maybe it is better to only support Vector2.

Slack discussion with input team: https://unity.slack.com/archives/C09Q7LYP9/p1676555716510299
Original PR: https://github.com/Unity-Technologies/com.unity.cinemachine/pull/790

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested (in our samples scenes)

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version