### PR TITLE
CMCL-0000: transition settings section in inspector

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -6,16 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed 
-
-- Renamed .asmdef files to follow the convention Unity.[PackageName]
-
 ### Added
 
 - New IgnoreTarget blend hint will blend rotations without considering the tracking target.
 
 ### Changed
 - CinemachineBlendListCamera has been renamed to CinemachineSequencerCamera.
+- Renamed .asmdef files to follow the convention: Unity.[PackageName].
+- Several settings moved to Transition Settings section of inspector.
 
 
 ## [3.0.0-pre.4] - 2023-02-09

--- a/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineClearShotEditor.cs
@@ -29,8 +29,7 @@ namespace Cinemachine.Editor
 
             var helpBox = ux.AddChild(new HelpBox());
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
+            this.AddTransitionsSection(ux);
 
             ux.AddHeader("Global Settings");
             this.AddGlobalControls(ux);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineExternalCameraEditor.cs
@@ -15,9 +15,7 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.TransitionHint)));
+            this.AddTransitionsSection(ux, new () { serializedObject.FindProperty(() => Target.TransitionHint) });
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.LookAtTarget)));
 
             return ux;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineMixingCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineMixingCameraEditor.cs
@@ -19,8 +19,7 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
+            this.AddTransitionsSection(ux);
 
             ux.AddHeader("Global Settings");
             this.AddGlobalControls(ux);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSequencerCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSequencerCameraEditor.cs
@@ -20,8 +20,7 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
+            this.AddTransitionsSection(ux);
 
             ux.AddHeader("Global Settings");
             this.AddGlobalControls(ux);

--- a/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -33,8 +33,7 @@ namespace Cinemachine.Editor
             var noTargetHelp = ux.AddChild(new HelpBox("An Animated Target is required.", HelpBoxMessageType.Warning));
 
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
+            this.AddTransitionsSection(ux);
 
             ux.AddHeader("Global Settings");
             this.AddGlobalControls(ux);

--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -50,9 +50,7 @@ namespace Cinemachine.Editor
             var ux = new VisualElement();
 
             this.AddCameraStatus(ux);
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.StandbyUpdate)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PriorityAndChannel)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Transitions)));
+            this.AddTransitionsSection(ux, new () { serializedObject.FindProperty(() => Target.Transitions) });
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Lens)));
 
             ux.AddHeader("Global Settings");

--- a/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
@@ -60,9 +60,8 @@ namespace Cinemachine.Editor
             }
 
             // toggle.text is to the right side of the checkbox
-            UpdateToggleText(enabledProp);
-            foldout.TrackPropertyValue(enabledProp, UpdateToggleText);
-            void UpdateToggleText(SerializedProperty p) => foldoutToggle.text = p.boolValue ? null : a.ToggleDisabledText;
+            foldout.TrackPropertyWithInitialCallback(enabledProp, (p) => 
+                foldoutToggle.text = p.boolValue ? null : a.ToggleDisabledText);
 
             return foldout;
         }

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -127,6 +127,29 @@ namespace Cinemachine.Editor
             });
         }
 
+        static bool s_TransitionsExpanded = false;
+
+        public static void AddTransitionsSection(
+            this UnityEditor.Editor editor, VisualElement ux, 
+            List<SerializedProperty> otherProperties = null)
+        {
+            var serializedObject = editor.serializedObject;
+            var target = editor.target as CinemachineVirtualCameraBase;
+
+            var foldout = ux.AddChild(new Foldout 
+            { 
+                value = s_TransitionsExpanded,
+                text = "Transition Settings", 
+                tooltip = "Settings to control how this camera interacts with other cameras" 
+            });
+            foldout.RegisterValueChangedCallback((evt) => s_TransitionsExpanded = evt.newValue);
+            foldout.Add(new PropertyField(serializedObject.FindProperty(() => target.PriorityAndChannel)));
+            foldout.Add(new PropertyField(serializedObject.FindProperty(() => target.StandbyUpdate)));
+            if (otherProperties != null)
+                foreach (var p in otherProperties)
+                    foldout.Add(new PropertyField(p));
+        }
+
         /// <summary>Add the pipeline control dropdowns in the inspector</summary>
         public static void AddPipelineDropdowns(this UnityEditor.Editor editor, VisualElement ux)
         {

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -142,7 +142,11 @@ namespace Cinemachine.Editor
                 text = "Transition Settings", 
                 tooltip = "Settings to control how this camera interacts with other cameras" 
             });
-            foldout.RegisterValueChangedCallback((evt) => s_TransitionsExpanded = evt.newValue);
+            foldout.RegisterValueChangedCallback((evt) => 
+            {
+                if (evt.target == foldout)
+                    s_TransitionsExpanded = evt.newValue;
+            });
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => target.PriorityAndChannel)));
             foldout.Add(new PropertyField(serializedObject.FindProperty(() => target.StandbyUpdate)));
             if (otherProperties != null)

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -65,6 +65,7 @@ namespace Cinemachine
 
         /// <summary>Parameters that influence how this CinemachineCamera transitions from other CinemachineCameras.</summary>
         [Tooltip("Parameters that influence how this CinemachineCamera transitions from other CinemachineCameras")]
+        [HideFoldout]
         public TransitionParams Transitions;
 
         CameraState m_State = CameraState.Default;

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -46,12 +46,11 @@ namespace Cinemachine
             + "The default priority is 0.  Often it is sufficient to leave the default setting.  "
             + "In special cases where you want a CinemachineCamera to have a higher or lower priority than 0, "
             + "the value can be set here.")]
-        [FoldoutWithEnabledButton(toggleText: "(using default)")]
+        [FoldoutWithEnabledButton(toggleText: " (using default)")]
         public OutputChannel PriorityAndChannel = OutputChannel.Default;
 
         /// <summary>A sequence number that represents object activation order of vcams.  
         /// Used for priority sorting.</summary>
-        [FormerlySerializedAs("m_ActivationId")]
         internal int ActivationId;
 
         int m_QueuePriority = int.MaxValue;

--- a/com.unity.cinemachine/Runtime/Core/OutputChannel.cs
+++ b/com.unity.cinemachine/Runtime/Core/OutputChannel.cs
@@ -55,6 +55,10 @@ namespace Cinemachine
         [Tooltip("Enable this to expose the Priority and Output Channel fields")]
         public bool Enabled;
 
+        /// <summary>Priority to use, if Enabled is true</summary>
+        [Tooltip("Priority to use.  0 is default.  Camera with highest priority is prioritized.")]
+        public int Priority;
+
         /// <summary>
         /// This controls which CinemachineBrain will be driven by this camera.  It is needed when there are
         /// multiple CinemachineBrains in the scene (for example, when implementing split-screen).
@@ -62,10 +66,6 @@ namespace Cinemachine
         [Tooltip("This controls which CinemachineBrain will be driven by this camera.  It is needed when there are "
             + "multiple CinemachineBrains in the scene (for example, when implementing split-screen).")]
         public Channels Channel;
-
-        /// <summary>Priority to use, if Enabled is true</summary>
-        [Tooltip("Priority to use.  0 is default.  Camera with highest priority is prioritized.")]
-        public int Priority;
 
         /// <summary>Create a default value for this item</summary>
         public static OutputChannel Default => new() { Channel = Channels.Default };


### PR DESCRIPTION
### Purpose of this PR

Inspector simplification.  Created Transition Settings foldout to fold lesser-used items, reducing clutter.
![image](https://user-images.githubusercontent.com/6424658/222169806-29ce183f-7eb2-4403-bb2b-c59445cfdca8.png)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

