### PR TITLE
CMCL-0000: Add default target indicator

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CmCameraEditor.cs
@@ -56,14 +56,26 @@ namespace Unity.Cinemachine.Editor
             ux.AddHeader("Global Settings");
             this.AddGlobalControls(ux);
 
-            ux.AddHeader("Procedural Motion");
+            var defaultTargetLabel = new Label() { style = { alignSelf = Align.FlexEnd, opacity = 0.5f }};
+            var row = ux.AddChild(new InspectorUtility.LabeledRow("<b>Procedural Motion</b>", "", defaultTargetLabel));
+            row.focusable = false;
+            row.style.paddingTop = InspectorUtility.SingleLineHeight / 2;
+            row.style.paddingBottom = EditorGUIUtility.standardVerticalSpacing;
+
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Target)));
             this.AddPipelineDropdowns(ux);
 
             ux.AddSpace();
             this.AddExtensionsDropdown(ux);
 
-            ux.TrackAnyUserActivity(() => CmCameraInspectorUtility.SortComponents(target as CinemachineVirtualCameraBase));
+            ux.TrackAnyUserActivity(() => 
+            {
+                bool haveDefault = Target.Target.TrackingTarget != Target.Follow;
+                defaultTargetLabel.SetVisible(haveDefault);
+                if (haveDefault)
+                    defaultTargetLabel.text = "Default target: " + Target.Follow.name;
+                CmCameraInspectorUtility.SortComponents(target as CinemachineVirtualCameraBase);
+            });
 
             return ux;
         }


### PR DESCRIPTION
When the CmCamera's manager parent has a default target defined, show this in the inspector:

![image](https://user-images.githubusercontent.com/6424658/225335438-3acb1b79-46b6-4ccd-a868-520bedc17749.png)
