### PR TITLE
CMCL-0000: Expose upgrade functionality

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New IgnoreTarget blend hint will blend rotations without considering the tracking target.
+- Cinemachine 2 to Cinemachine 3 upgrade functionality is now public.
 
 ### Changed
 - All namespaces changed from "Cinemachine" to "Unity.Cinemachine".

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -19,7 +19,7 @@ namespace Unity.Cinemachine.Editor
     /// <summary>
     /// Upgrades cm2 to cm3
     /// </summary>
-    class CinemachineUpgradeManager
+    public class CinemachineUpgradeManager
     {
         const string k_UnupgradableTag = " BACKUP - not fully upgradable by CM";
 
@@ -127,7 +127,7 @@ namespace Unity.Cinemachine.Editor
         /// <summary>Returns true if any of the objects are prefab instances or prefabs.</summary>
         /// <param name="objects"></param>
         /// <returns></returns>
-        public static bool ObjectsUsePrefabs(UnityEngine.Object[] objects)
+        internal static bool ObjectsUsePrefabs(UnityEngine.Object[] objects)
         {
             for (int i = 0; i < objects.Length; ++i)
             {
@@ -147,7 +147,7 @@ namespace Unity.Cinemachine.Editor
         /// <summary>Returns true if any of the objects are prefab instances or prefabs.</summary>
         /// <param name="objects"></param>
         /// <returns></returns>
-        public static bool CurrentSceneUsesPrefabs()
+        internal static bool CurrentSceneUsesPrefabs()
         {
             var manager = new CinemachineUpgradeManager(false);
             var scene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();


### PR DESCRIPTION
### Purpose of this PR
Virtual Production team would like to access the cm2-cm3 upgrade functionality, because they have the VirtualCameraActor component that uses Cinemachine. They would like to provide the upgrade functionality without losing the reference to the vcam in their component.

They could expose internals like we did for HDRP, but I think this can be useful to other packages/users too.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version