### PR TITLE
CMCL-1410: Upgrader should reopen the original scene after it's done

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Full physical camera support for builtin pipeline.
 - LensPresets and PhysicalLensPresets are now separate assets.
 - CinemachineInputAxisController refactored to be more easily customized.
+- CinemachineUpgradeManager re-opens original scene after upgrade is complete.
 
 
 ## [3.0.0-pre.4] - 2023-02-09

--- a/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/CinemachineUpgradeManager.cs
@@ -107,6 +107,7 @@ namespace Unity.Cinemachine.Editor
                 "I made a backup, go ahead", "Cancel"))
             {
                 Thread.Sleep(1); // this is needed so the Display Dialog closes, and lets the progress bar open
+                var originalScenePath = EditorSceneManager.GetActiveScene().path;
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Initializing...", 0);
                 var manager = new CinemachineUpgradeManager(true);
                 manager.PrepareUpgrades(out var conversionLinksPerScene, out var timelineRenames);
@@ -121,6 +122,7 @@ namespace Unity.Cinemachine.Editor
                 EditorUtility.DisplayProgressBar(k_ProgressBarTitle, "Cleaning up...", 1);
                 manager.CleanupPrefabAssets();
                 EditorUtility.ClearProgressBar();
+                EditorSceneManager.OpenScene(originalScenePath); // re-open scene where the user was before upgrading
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1419](https://jira.unity3d.com/browse/CMCL-1419): Upgrader reopens the original scene after it's done now.

### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
-  [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

