### PR TITLE
CMCL-0000: Check if installed Cinemachine is 3 or newer assembly definition

### DIFF
--- a/com.unity.cinemachine/Editor/Unity.Cinemachine.Editor.asmdef
+++ b/com.unity.cinemachine/Editor/Unity.Cinemachine.Editor.asmdef
@@ -83,6 +83,11 @@
             "name": "com.unity.inputsystem",
             "expression": "1.0.0",
             "define": "CINEMACHINE_UNITY_INPUTSYSTEM"
+        },
+        {
+            "name": "com.unity.cinemachine",
+            "expression": "3.0.0-pre.4",
+            "define": "CINEMACHINE_3_OR_NEWER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
### Purpose of this PR
LiveCapture team needs this (`CINEMACHINE_3_OR_NEWER`), so they can #if the public API that exposes our internal upgrader code. Similarly how I did it with HDRP, but HDRP luckily had a check that I could use.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 