### PR TITLE
CMCL-1420 better BlenderSettings inspector

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -242,7 +242,7 @@ namespace Unity.Cinemachine.Editor
                 if (availableCameras.FindIndex(x => x == p.stringValue) < 0)
                     row.AddChild(InspectorUtility.MiniHelpIcon("No in-scene camera matches this name"));
                 var popup = row.AddChild(InspectorUtility.MiniDropdownButton(
-                    "Choose from currently-avaliable cameras", new ContextualMenuManipulator((evt) => 
+                    "Choose from currently-available cameras", new ContextualMenuManipulator((evt) => 
                 {
                     for (int i = 0; i < availableCameras.Count; ++i)
                         evt.menu.AppendAction(availableCameras[i], 

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -595,6 +595,27 @@ namespace Unity.Cinemachine.Editor
             return button;
         }
 
+        /// <summary>A small dropdown context menu, suitable for embedding in an inspector row</summary>
+        /// <param name="tooltip">The tooltip text</param>
+        /// <param name="contextMenu">The context menu to show when the button is pressed</param>
+        public static Button MiniDropdownButton(string tooltip = null, ContextualMenuManipulator contextMenu = null)
+        {
+            var button = new Button { tooltip = tooltip, style = 
+            {
+                backgroundImage = (StyleBackground)EditorGUIUtility.IconContent("dropdown").image,
+                width = InspectorUtility.SingleLineHeight, height = InspectorUtility.SingleLineHeight,
+                alignSelf = Align.Center,
+                paddingRight = 0, borderRightWidth = 0, marginRight = 0
+            }};
+            if (contextMenu != null)
+            {
+                contextMenu.activators.Clear();
+                contextMenu.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
+                button.AddManipulator(contextMenu);
+            }
+            return button;
+        }
+
         /// <summary>
         /// This is a hack to get proper layout within th inspector.
         /// There seems to be no sanctioned way to get the current inspector label width.

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlenderSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlenderSettings.cs
@@ -17,13 +17,13 @@ namespace Unity.Cinemachine
         [Serializable]
         public struct CustomBlend
         {
-            /// <summary>When blending from this camera</summary>
-            [Tooltip("When blending from this camera")]
+            /// <summary>When blending from a camera with this name</summary>
+            [Tooltip("When blending from a camera with this name")]
             [FormerlySerializedAs("m_From")]
             public string From;
 
-            /// <summary>When blending to this camera</summary>
-            [Tooltip("When blending to this camera")]
+            /// <summary>When blending to a camera with this name</summary>
+            [Tooltip("When blending to a camera with this name")]
             [FormerlySerializedAs("m_To")]
             public string To;
 
@@ -37,7 +37,7 @@ namespace Unity.Cinemachine
         [FormerlySerializedAs("m_CustomBlends")]
         public CustomBlend[] CustomBlends = null;
 
-        /// <summary>Internal API for the inspector editopr: a label to represent any camera</summary>
+        /// <summary>Internal API for the inspector editor: a label to represent any camera</summary>
         internal const string kBlendFromAnyCameraLabel = "**ANY CAMERA**";
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

It was unclear that camera specifications in blender settings are strings and do not necessarily have to match any cameras currently in the scene.  The old dropdown hid this.  Now it's more clear.  Also updated the tooltips.

![image](https://user-images.githubusercontent.com/6424658/225633786-03242675-0e63-4b90-8eef-8a06e056ea5f.png)

Note: you have to undefine USE_IMGUI_INSTRUCTION_LIST in CinemachineBlenderSettingsEditor.cs in order to see the changes, because they're UITK-only.
