### PR TITLE
CMCL-1431: MixingCamera calls OnTransitionFromCamera correctly 

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: AxisState was not respecting timescale == 0
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
 - URP: add temporal effects reset on camera cut for URP 14.0.4 and up
+- Bugfix: MixingCamera calls OnTransitionFromCamera correctly for all its children
 
 
 ## [2.9.5] - 2023-01-16

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -251,11 +251,7 @@ namespace Cinemachine
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
             CinemachineVirtualCameraBase[] children = ChildCameras;
             for (int i = 0; i < MaxCameras && i < children.Length; ++i)
-            {
-                CinemachineVirtualCameraBase vcam = children[i];
-                if (vcam.isActiveAndEnabled && GetWeight(i) > UnityVectorExtensions.Epsilon)
-                    vcam.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
-            }
+                children[i].OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             InternalUpdateCameraState(worldUp, deltaTime);
         }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1431: MixingCamera was not calling OnTransitionFromCamera for its disabled or 0-weight children.  It must call for all of them regardless of weight and enabled status.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

