### PR TITLE
CMCL-1430: MixingCamera calls OnTransitionFromCamera correctly for all its children

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Fixed
+- Bugfix: MixingCamera calls OnTransitionFromCamera correctly for all its children.
 
+### Added
 - New IgnoreTarget blend hint will blend rotations without considering the tracking target.
 
 ### Changed

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -196,11 +196,7 @@ namespace Unity.Cinemachine
         {
             base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             for (int i = 0; i < MaxCameras && i < ChildCameras.Count; ++i)
-            {
-                var vcam = ChildCameras[i];
-                if (vcam.isActiveAndEnabled && GetWeight(i) > UnityVectorExtensions.Epsilon)
-                    vcam.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
-            }
+                ChildCameras[i].OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             InternalUpdateCameraState(worldUp, deltaTime);
         }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1430: MixingCamera was not calling OnTransitionFromCamera for its disabled or 0-weight children.  It must call for all of them regardless of weight and enabled status.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

