### PR TITLE
CMCL-1424: InputAxisController can suppress input while camera is blending

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - New IgnoreTarget blend hint will blend rotations without considering the tracking target.
+- InputAxisController has the option to suppress input while the attached camera is blending.
 
 ### Changed
 - All namespaces changed from "Cinemachine" to "Unity.Cinemachine".

--- a/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
@@ -18,6 +18,7 @@ If you like, you can also use CinemachineInputAxisController with your own scrip
 | __Player Index__ | Which player's input controls to query. Leave this at the default value of -1 for single-player games. Otherwise, this should be the index of the player in the `UnityEngine.Input.InputUser.all` list. This setting only appears if Unity's Input package is installed. |
 | __Auto Enable Inputs__ | If Unity's Input package is installed, this option is available. It will automatically enable any mapped input actions at startup |
 | __Scan Recursively__ | If set, a recursive search for IInputAxisOwners behaviours will be performed.  Otherwise, only behaviours attached directly to this GameObject will be considered, and child objects will be ignored. |
+| __Suppress Input While Blending__ | If set and if this component is attached to a CinemachineCamera, input will not be processed while the camera is participating in a blend. |
 | __Enabled__ | The controller will drive the input axis while this value is true.  If false, the axis will not be driven by the controller. |
 | __Legacy Input__ | If the legacy input manager is being used, the Input Axis Name to query is specified here. |
 | __Legacy Gain__ | If the legacy input manager is being used, the input value read will be multiplied by this amount. |

--- a/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
@@ -24,6 +24,8 @@ namespace Unity.Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.PlayerIndex)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.AutoEnableInputs)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.ScanRecursively)));
+            var suppressInput = ux.AddChild(
+                new PropertyField(serializedObject.FindProperty(() => Target.SuppressInputWhileBlending)));
 
             ux.AddHeader("Driven Axes");
             var list = ux.AddChild(new ListView()
@@ -48,11 +50,12 @@ namespace Unity.Cinemachine.Editor
 
             ux.TrackAnyUserActivity(() =>
             {
-                if (Target != null && !Target.ControllersAreValid())
+                if (!Target.ControllersAreValid())
                 {
                     Undo.RecordObject(Target, "SynchronizeControllers");
                     Target.SynchronizeControllers();
                 }
+                suppressInput.SetVisible(Target.TryGetComponent<CinemachineVirtualCameraBase>(out _));
             });
             return ux;
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -61,7 +61,6 @@ namespace Unity.Cinemachine
 
 
         CinemachineVirtualCameraBase m_LiveChild;
-        CinemachineBlend m_ActiveBlend;
         CameraState m_State = CameraState.Default;
         Dictionary<CinemachineVirtualCameraBase, int> m_IndexMap;
 
@@ -139,7 +138,7 @@ namespace Unity.Cinemachine
         /// <summary>
         /// Get the current active blend in progress.  Will return null if no blend is in progress.
         /// </summary>
-        public override CinemachineBlend ActiveBlend => PreviousStateIsValid ? m_ActiveBlend : null;
+        public override CinemachineBlend ActiveBlend => null;
 
         /// <summary>The State of the current live child</summary>
         public override CameraState State => m_State;
@@ -210,10 +209,7 @@ namespace Unity.Cinemachine
         {
             UpdateCameraCache();
             if (!PreviousStateIsValid)
-            {
                 m_LiveChild = null;
-                m_ActiveBlend = null;
-            }
 
             var children = ChildCameras;
             m_LiveChild = null;

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -814,13 +814,13 @@ namespace Unity.Cinemachine
         /// <summary>Check to see whether this camera is currently participating in a blend 
         /// within its parent manager or in a CinemacineBrain</summary>
         /// <returns>True if the camera is participating in a blend</returns>
-        public bool IsParticipatinInBlend()
+        public bool IsParticipatingInBlend()
         {
             if (IsLive)
             {
                 var parent = ParentCamera as CinemachineCameraManagerBase;
                 if (parent != null)
-                    return (parent.ActiveBlend != null && parent.ActiveBlend.Uses(this)) || parent.IsParticipatinInBlend();
+                    return (parent.ActiveBlend != null && parent.ActiveBlend.Uses(this)) || parent.IsParticipatingInBlend();
                 var brain = CinemachineCore.Instance.FindPotentialTargetBrain(this);
                 if (brain != null)
                     return brain.ActiveBlend != null && brain.ActiveBlend.Uses(this);

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -110,6 +110,18 @@ namespace Unity.Cinemachine
 
         // Cache for GameObject name, to avoid GC allocs
         string m_CachedName;
+        bool m_WasStarted;
+        bool m_SlaveStatusUpdated = false;
+        CinemachineVirtualCameraBase m_ParentVcam = null;
+
+        Transform m_CachedFollowTarget;
+        CinemachineVirtualCameraBase m_CachedFollowTargetVcam;
+        ICinemachineTargetGroup m_CachedFollowTargetGroup;
+
+        Transform m_CachedLookAtTarget;
+        CinemachineVirtualCameraBase m_CachedLookAtTargetVcam;
+        ICinemachineTargetGroup m_CachedLookAtTargetGroup;
+
 
         //============================================================================
         // Legacy streaming support
@@ -452,7 +464,7 @@ namespace Unity.Cinemachine
         /// <param name="vcam">The Virtual Camera to check</param>
         /// <param name="dominantChildOnly">If true, will only return true if this vcam is the dominant live child</param>
         /// <returns>True if the vcam is currently actively influencing the state of this vcam</returns>
-        public virtual bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) { return false; }
+        public virtual bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) => false;
 
         /// <summary>Get the LookAt target for the Aim component in the Cinemachine pipeline.</summary>
         public abstract Transform LookAt { get; set; }
@@ -496,29 +508,6 @@ namespace Unity.Cinemachine
                 PreviousStateIsValid = false;
         }
 
-        /// <summary>Maintains the global vcam registry.  Always call the base class implementation.</summary>
-        protected virtual void OnDestroy()
-        {
-            CinemachineCore.Instance.CameraDestroyed(this);
-        }
-
-        /// <summary>Base class implementation makes sure the priority queue remains up-to-date.</summary>
-        protected virtual void OnTransformParentChanged()
-        {
-            CinemachineCore.Instance.CameraDisabled(this);
-            CinemachineCore.Instance.CameraEnabled(this);
-            UpdateSlaveStatus();
-            UpdateVcamPoolStatus();
-        }
-
-        bool m_WasStarted;
-
-        /// <summary>Derived classes should call base class implementation.</summary>
-        protected virtual void Start()
-        {
-            m_WasStarted = true;
-        }
-        
         /// <summary>
         /// Called on inactive object when being artificially activated by timeline.
         /// This is necessary because Awake() isn't called on inactive gameObjects.
@@ -545,6 +534,27 @@ namespace Unity.Cinemachine
         }
 #endif
 
+        /// <summary>Base class implementation makes sure the priority queue remains up-to-date.</summary>
+        protected virtual void OnTransformParentChanged()
+        {
+            CinemachineCore.Instance.CameraDisabled(this);
+            CinemachineCore.Instance.CameraEnabled(this);
+            UpdateSlaveStatus();
+            UpdateVcamPoolStatus();
+        }
+
+        /// <summary>Maintains the global vcam registry.  Always call the base class implementation.</summary>
+        protected virtual void OnDestroy()
+        {
+            CinemachineCore.Instance.CameraDestroyed(this);
+        }
+
+        /// <summary>Derived classes should call base class implementation.</summary>
+        protected virtual void Start()
+        {
+            m_WasStarted = true;
+        }
+        
         /// <summary>Base class implementation adds the virtual camera from the priority queue.</summary>
         protected virtual void OnEnable()
         {
@@ -581,9 +591,6 @@ namespace Unity.Cinemachine
             if (Priority.Value != m_QueuePriority)
                 UpdateVcamPoolStatus(); // Force a re-sort
         }
-
-        bool m_SlaveStatusUpdated = false;
-        CinemachineVirtualCameraBase m_ParentVcam = null;
 
         void UpdateSlaveStatus()
         {
@@ -707,14 +714,6 @@ namespace Unity.Cinemachine
             return state;
         }
 
-        Transform m_CachedFollowTarget;
-        CinemachineVirtualCameraBase m_CachedFollowTargetVcam;
-        ICinemachineTargetGroup m_CachedFollowTargetGroup;
-
-        Transform m_CachedLookAtTarget;
-        CinemachineVirtualCameraBase m_CachedLookAtTargetVcam;
-        ICinemachineTargetGroup m_CachedLookAtTargetGroup;
-
         void InvalidateCachedTargets()
         {
             m_CachedFollowTarget = null;
@@ -808,5 +807,25 @@ namespace Unity.Cinemachine
         /// <param name="stage">The stage for which we want the component</param>
         /// <returns>The Cinemachine component for that stage, or null if not present.</returns>
         public virtual CinemachineComponentBase GetCinemachineComponent(CinemachineCore.Stage stage) => null;
+
+        /// <summary>Returns true if this camera is currently live for some CinemachineBrain.</summary>
+        public bool IsLive => CinemachineCore.Instance.IsLive(this);
+
+        /// <summary>Check to see whether this camera is currently participating in a blend 
+        /// within its parent manager or in a CinemacineBrain</summary>
+        /// <returns>True if the camera is participating in a blend</returns>
+        public bool IsParticipatinInBlend()
+        {
+            if (IsLive)
+            {
+                var parent = ParentCamera as CinemachineCameraManagerBase;
+                if (parent != null)
+                    return (parent.ActiveBlend != null && parent.ActiveBlend.Uses(this)) || parent.IsParticipatinInBlend();
+                var brain = CinemachineCore.Instance.FindPotentialTargetBrain(this);
+                if (brain != null)
+                    return brain.ActiveBlend != null && brain.ActiveBlend.Uses(this);
+            }
+            return false;
+        }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -52,6 +52,12 @@ namespace Unity.Cinemachine
             + "and child objects will be ignored")]
         public bool ScanRecursively = true;
         
+        /// <summary>If set, input will not be processed while the Cinemachine Camera is 
+        /// participating in a blend.</summary>
+        [Tooltip("If set, input will not be processed while the Cinemachine Camera is "
+            + "participating in a blend.")]
+        public bool SuppressInputWhileBlending = true;
+
         /// <summary>
         /// Each discovered axis will get a Controller to drive it in Update().
         /// </summary>
@@ -106,6 +112,7 @@ namespace Unity.Cinemachine
             PlayerIndex = -1;
             AutoEnableInputs = true;
             ScanRecursively = true;
+            SuppressInputWhileBlending = true;
         }
 
         void OnEnable()
@@ -242,6 +249,10 @@ namespace Unity.Cinemachine
         {
             if (!Application.isPlaying)
                 return;
+
+            if (SuppressInputWhileBlending && TryGetComponent<CinemachineVirtualCameraBase>(out var vcam))
+                if (vcam.IsParticipatinInBlend())
+                    return;
 
             var deltaTime = Time.deltaTime;
             //bool gotInput = false;

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -250,9 +250,10 @@ namespace Unity.Cinemachine
             if (!Application.isPlaying)
                 return;
 
-            if (SuppressInputWhileBlending && TryGetComponent<CinemachineVirtualCameraBase>(out var vcam))
-                if (vcam.IsParticipatinInBlend())
-                    return;
+            if (SuppressInputWhileBlending 
+                && TryGetComponent<CinemachineVirtualCameraBase>(out var vcam)
+                && vcam.IsParticipatingInBlend())
+                return;
 
             var deltaTime = Time.deltaTime;
             //bool gotInput = false;


### PR DESCRIPTION
### Purpose of this PR

Raised by a user on the forum: https://forum.unity.com/threads/disabling-the-cinemachines-inputs-from-an-active-state-during-state-transitions.1412670/

The idea is to have an option to suppress user input (Orbital/PanTilt) when a camera is in a blend. 

Possible places to put the option:
- ~In the OrbitalFollow and PanTilt behaviours, as a checkbox~
- ~In the BlendHints, as a flag~
- In the InputAxisController (this was done)

![image](https://user-images.githubusercontent.com/6424658/225737853-80acfcae-df6f-4774-8b8d-cb8717e97fbc.png)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low

