### PR TITLE
CMCL-0000: fix legacy upgrade mechanism and more

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -50,7 +50,7 @@ namespace Unity.Cinemachine
     [ExecuteAlways]
     [AddComponentMenu("Cinemachine/Cinemachine Camera")]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineCamera.html")]
-    public sealed class CinemachineCamera : CinemachineVirtualCameraBase, ISerializationCallbackReceiver
+    public sealed class CinemachineCamera : CinemachineVirtualCameraBase
     {
         /// <summary>The Tracking and LookAt targets for this camera.</summary>
         [NoSaveDuringPlay]

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineClearShot.cs
@@ -79,9 +79,9 @@ namespace Unity.Cinemachine
             CustomBlends = null;
         }
 
-        protected internal override void LegacyUpgradeMayBeCalledFromThread(int streamedVersion)
+        protected internal override void PerformLegacyUpgrade(int streamedVersion)
         {
-            base.LegacyUpgradeMayBeCalledFromThread(streamedVersion);
+            base.PerformLegacyUpgrade(streamedVersion);
             if (streamedVersion < 20220721)
             {
                 DefaultTarget = new DefaultTargetSettings 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSequencerCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSequencerCamera.cs
@@ -84,9 +84,9 @@ namespace Unity.Cinemachine
             }
         }
 
-        protected internal override void LegacyUpgradeMayBeCalledFromThread(int streamedVersion)
+        protected internal override void PerformLegacyUpgrade(int streamedVersion)
         {
-            base.LegacyUpgradeMayBeCalledFromThread(streamedVersion);
+            base.PerformLegacyUpgrade(streamedVersion);
             if (streamedVersion < 20220721)
             {
                 DefaultTarget = new DefaultTargetSettings 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -124,9 +124,9 @@ namespace Unity.Cinemachine
             CustomBlends = null;
         }
 
-        protected internal override void LegacyUpgradeMayBeCalledFromThread(int streamedVersion)
+        protected internal override void PerformLegacyUpgrade(int streamedVersion)
         {
-            base.LegacyUpgradeMayBeCalledFromThread(streamedVersion);
+            base.PerformLegacyUpgrade(streamedVersion);
             if (streamedVersion < 20220721)
             {
                 DefaultTarget = new DefaultTargetSettings 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -62,7 +62,7 @@ namespace Unity.Cinemachine
     [ExecuteAlways]
     [DisallowMultipleComponent]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineTargetGroup.html")]
-    public class CinemachineTargetGroup : MonoBehaviour, ICinemachineTargetGroup, ISerializationCallbackReceiver
+    public class CinemachineTargetGroup : MonoBehaviour, ICinemachineTargetGroup
     {
         /// <summary>Holds the information that represents a member of the group</summary>
         [Serializable] public class Target
@@ -171,16 +171,12 @@ namespace Unity.Cinemachine
         [SerializeField, FormerlySerializedAs("m_Targets")]
         Target[] m_LegacyTargets;
 
-        /// <summary>Post-Serialization handler - performs legacy upgrade</summary>
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        void Awake()
         {
             if (m_LegacyTargets != null && m_LegacyTargets.Length > 0)
                 Targets.AddRange(m_LegacyTargets);
             m_LegacyTargets = null;
         }
-
-        /// <summary>Pre-Serialization handler - this implementation does nothing</summary>
-        void ISerializationCallbackReceiver.OnBeforeSerialize() {}
 
         /// <summary>Obsolete Targets</summary>
         [Obsolete("m_Targets is obsolete.  Please use Targets instead")]

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -131,9 +131,9 @@ namespace Unity.Cinemachine
         [FormerlySerializedAs("m_Lens")]
         LegacyLensSettings m_LegacyLens;
 
-        internal protected override void LegacyUpgradeMayBeCalledFromThread(int streamedVersion)
+        internal protected override void PerformLegacyUpgrade(int streamedVersion)
         {
-            base.LegacyUpgradeMayBeCalledFromThread(streamedVersion);
+            base.PerformLegacyUpgrade(streamedVersion);
             if (streamedVersion < 20221011)
             {
                 if (m_LegacyHeadingBias != float.MaxValue)

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineInputProvider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineInputProvider.cs
@@ -1,7 +1,8 @@
-﻿#if CINEMACHINE_UNITY_INPUTSYSTEM
-using System;
-using System.Linq;
+﻿using System;
 using UnityEngine;
+
+#if CINEMACHINE_UNITY_INPUTSYSTEM
+using System.Linq;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Users;
 
@@ -118,8 +119,6 @@ namespace Unity.Cinemachine
     }
 }
 #else
-using UnityEngine;
-
 namespace Unity.Cinemachine
 {
     /// <summary>

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineInputProvider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineInputProvider.cs
@@ -132,3 +132,25 @@ namespace Unity.Cinemachine
     public class CinemachineInputProvider : MonoBehaviour {}
 }
 #endif
+
+namespace Unity.Cinemachine
+{
+    [Obsolete("IInputAxisProvider is deprecated.  Use InputAxis and InputAxisController instead")]
+    public static class CinemachineInputProviderExtensions
+    {
+        /// <summary>
+        /// Locate the first component that implements AxisState.IInputAxisProvider.
+        /// </summary>
+        /// <returns>The first AxisState.IInputAxisProvider or null if none</returns>
+        public static AxisState.IInputAxisProvider GetInputAxisProvider(this CinemachineVirtualCameraBase vcam)
+        {
+            var components = vcam.GetComponentsInChildren<MonoBehaviour>();
+            for (int i = 0; i < components.Length; ++i)
+            {
+                if (components[i] is AxisState.IInputAxisProvider provider)
+                    return provider;
+            }
+            return null;
+        }
+    }
+}

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineVirtualCamera.cs
@@ -73,9 +73,9 @@ namespace Unity.Cinemachine
         [FormerlySerializedAs("m_Lens")]
         LegacyLensSettings m_LegacyLens;
 
-        internal protected override void LegacyUpgradeMayBeCalledFromThread(int streamedVersion)
+        internal protected override void PerformLegacyUpgrade(int streamedVersion)
         {
-            base.LegacyUpgradeMayBeCalledFromThread(streamedVersion);
+            base.PerformLegacyUpgrade(streamedVersion);
             if (streamedVersion < 20221011)
             {
                 if (m_LegacyTransitions.m_BlendHint != 0)


### PR DESCRIPTION
### Purpose of this PR

Several bugfixes:

- The legacy upgrade mechanism (not to be confused with the upgrader) was broken.  Because it was not called synchronously, there was no guarantee that it got called after the relevant fields we properly initialized.  Moved it to where it's guaranteed to be called properly.
- ForceCameraPostion() was overflowing the stack - fix was to not call it for the parent (parent is calling it for the children - duh)
- vcam.GetInputAxisProvider() was re-added for use by deprecated classes

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
