### PR TITLE
CMCL-0000: Refactor CinemachineCameraManagerBase to be more useful for customizing

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CinemachineInputAxisController refactored to be more easily customized.
 - Samples are compatible with Built-in, Universal, and High Definition Render Pipelines.
 - CinemachineUpgradeManager re-opens original scene after upgrade is complete.
+- Refactored CinemachineCameraManagerBase refactored to be more useful for customizing.
 
 
 ## [3.0.0-pre.4] - 2023-02-09

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CinemachineInputAxisController refactored to be more easily customized.
 - Samples are compatible with Built-in, Universal, and High Definition Render Pipelines.
 - CinemachineUpgradeManager re-opens original scene after upgrade is complete.
-- Refactored CinemachineCameraManagerBase refactored to be more useful for customizing.
+- Refactored CinemachineCameraManagerBase to be more useful for customizing.
 
 
 ## [3.0.0-pre.4] - 2023-02-09

--- a/com.unity.cinemachine/Documentation~/CinemachineManagerCameras.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineManagerCameras.md
@@ -14,3 +14,18 @@ Cinemachine includes these manager cameras:
 
 Because manager cameras act like normal CinemachineCameras, you can nest them. In other words, create arbitrarily complex camera rigs that combine regular CinemachineCameras and manager cameras.
 
+## Making Your Own Custom Manager Camera
+
+It is also possible to make your own manager camera that selects its current active child according to an arbitrary algorithmn that you provide.  For instance, if you are making a 2D Platformer and want a camera rig that frames itself differently according to whether the character is moving right or left, or jumping, or falling, a custom CameraManager class might be a good approach.
+
+To do this, make a new class that inherits `CinemachineCameraManagerBase`.  This base class implements an array of CinemachineCamera children, and a blender. 
+
+Next, implement the abstract `ChooseCurrentCamera` method.  This is called every frame while the manager is active, and should return the child camera that ought to be active this frame.  Your custom class can make that decision any way it likes.  In the example, it would look at the player state to find out the facing direction and the jumping/falling state, and choose the appropriate child camera.
+
+If the new desired camera is different from what it was on the last frame, CinemachineCameraManagerBase will initiate a blend, according to what you set up in its DefaultBlend and CustomBlends fields.
+
+Once you've added the child cameras with the settings you like for each player state and have wired them into your manager instance, you will have a Cinemachine rig that adjusts itself according to player state.  The rig itself will look to the rest of the system just like an ordinary CinemachineCamera, and so can be used wherever CinemachineCameras can - including being nested within other rigs.
+
+
+### Managed Cameras need to be GameObject children of the manager
+This is mainly to prevent problems that can occur if you nest managers and end up with a recursive loop.  Forcing the managed cameras to be childen makes recursion impossible.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -71,7 +71,7 @@ namespace Unity.Cinemachine
                 SetWeight(i, Mathf.Max(0, GetWeight(i)));
         }
 
-        /// <summary>Reset the component to default values.</summary>
+        /// <inheritdoc />
         protected override void Reset()
         {
             base.Reset();
@@ -79,10 +79,10 @@ namespace Unity.Cinemachine
                 SetWeight(i, i == 0 ? 1 : 0);
         }
         
-        /// <summary>The resulting CameraState for the current live child and blend</summary>
+        /// <inheritdoc />
         public override CameraState State => m_CameraState;
 
-        /// <summary>Gets a brief debug description of this virtual camera, for use when displaying debug info</summary>
+        /// <inheritdoc />
         public override string Description 
         {
             get
@@ -166,10 +166,7 @@ namespace Unity.Cinemachine
                     + ((vcam != null) ? vcam.Name : "(null)"));
         }
 
-        /// <summary>Check whether the vcam a live child of this camera.</summary>
-        /// <param name="vcam">The Virtual Camera to check</param>
-        /// <param name="dominantChildOnly">If true, will only return true if this vcam is the dominant live child</param>
-        /// <returns>True if the vcam is currently actively influencing the state of this vcam</returns>
+        /// <inheritdoc />
         public override bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false)
         {
             if (dominantChildOnly)
@@ -181,8 +178,7 @@ namespace Unity.Cinemachine
             return false;
         }
 
-        /// <summary>Rebuild the cached list of child cameras.</summary>
-        /// <returns>True, if rebuild was needed. False, otherwise.</returns>
+        /// <inheritdoc />
         protected override bool UpdateCameraCache()
         {
             if (!base.UpdateCameraCache())
@@ -194,25 +190,16 @@ namespace Unity.Cinemachine
             return true;
         }
 
-        /// <summary>Notification that this virtual camera is going live.</summary>
-        /// <param name="fromCam">The camera being deactivated.  May be null.</param>
-        /// <param name="worldUp">Default world Up, set by the CinemachineBrain</param>
-        /// <param name="deltaTime">Delta time for time-based effects (ignore if less than or equal to 0)</param>
+        /// <inheritdoc />
         public override void OnTransitionFromCamera(
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime)
         {
-            base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             for (int i = 0; i < MaxCameras && i < ChildCameras.Count; ++i)
                 ChildCameras[i].OnTransitionFromCamera(fromCam, worldUp, deltaTime);
-            InternalUpdateCameraState(worldUp, deltaTime);
+            base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
         }
 
-        /// <summary>Internal use only.  Do not call this method.
-        /// Called by CinemachineCore at designated update time
-        /// so the vcam can position itself and track its targets.  This implementation
-        /// computes and caches the weighted blend of the tracked cameras.</summary>
-        /// <param name="worldUp">Default world Up, set by the CinemachineBrain</param>
-        /// <param name="deltaTime">Delta time for time-based effects (ignore if less than 0)</param>
+        /// <inheritdoc />
         public override void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
         {
             UpdateCameraCache();
@@ -248,5 +235,8 @@ namespace Unity.Cinemachine
             InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Finalize, ref m_CameraState, deltaTime);
             PreviousStateIsValid = true;
         }
+
+        /// <inheritdoc />
+        protected override CinemachineVirtualCameraBase ChooseCurrentCamera(Vector3 worldUp, float deltaTime) => null;
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Unity.Cinemachine
 {
@@ -34,10 +35,24 @@ namespace Unity.Cinemachine
         [FoldoutWithEnabledButton]
         public DefaultTargetSettings DefaultTarget;
 
-        /// State for CreateActiveBlend().  Used in the case of backing out of a blend in progress.
+        /// <summary>
+        /// The blend which is used if you don't explicitly define a blend between two Virtual Camera children.
+        /// </summary>
+        [Tooltip("The blend which is used if you don't explicitly define a blend between two Virtual Camera children")]
+        [FormerlySerializedAs("m_DefaultBlend")]
+        public CinemachineBlendDefinition DefaultBlend = new (CinemachineBlendDefinition.Styles.EaseInOut, 0.5f);
+
+        /// <summary>
+        /// This is the asset which contains custom settings for specific child blends.
+        /// </summary>
+        [Tooltip("This is the asset which contains custom settings for specific child blends")]
+        [FormerlySerializedAs("m_CustomBlends")]
+        public CinemachineBlenderSettings CustomBlends = null;
+
         List<CinemachineVirtualCameraBase> m_ChildCameras;
         readonly BlendManager m_BlendManager = new ();
         CameraState m_State = CameraState.Default;
+        ICinemachineCamera m_TransitioningFrom;
 
         /// <summary>Reset the component to default values.</summary>
         protected virtual void Reset()
@@ -139,6 +154,62 @@ namespace Unity.Cinemachine
             }
         }
 
+        /// <summary>Internal use only.  Do not call this method.
+        /// Called by CinemachineCore at designated update time
+        /// so the vcam can position itself and track its targets.  This implementation
+        /// updates all the children, chooses the best one, and implements any required blending.</summary>
+        /// <param name="worldUp">Default world Up, set by the CinemachineBrain</param>
+        /// <param name="deltaTime">Delta time for time-based effects (ignore if less than or equal to 0)</param>
+        public override void InternalUpdateCameraState(Vector3 worldUp, float deltaTime)
+        {
+            UpdateCameraCache();
+            if (!PreviousStateIsValid)
+                ResetLiveChild();
+
+            // Choose the best camera - auto-activate it if it's inactive
+            var best = ChooseCurrentCamera(worldUp, deltaTime);
+            if (best != null && !best.gameObject.activeInHierarchy)
+            {
+                best.gameObject.SetActive(true);
+                best.UpdateCameraState(worldUp, deltaTime);
+            }
+            SetLiveChild(best, worldUp, deltaTime, LookupBlend);
+
+            // Special case to handle being called from OnTransitionFromCamera() - GML todo: fix this
+            if (m_TransitioningFrom != null && !IsBlending && LiveChild != null)
+            {
+                LiveChild.OnCameraActivated(new ICinemachineCamera.ActivationEventParams
+                {
+                    Origin = this,
+                    OutgoingCamera = m_TransitioningFrom,
+                    IncomingCamera = LiveChild,
+                    IsCut = false,
+                    WorldUp = worldUp, 
+                    DeltaTime = deltaTime
+                });
+            }
+
+            FinalizeCameraState(deltaTime);
+            m_TransitioningFrom = null;
+            PreviousStateIsValid = true;
+        }
+        
+        /// <summary>Find a blend curve for blending from one child camera to another.</summary>
+        /// <param name="outgoing">The camera we're blending from.</param>
+        /// <param name="incoming">The camera we're blending to.</param>
+        /// <returns>The blend to use for this camera transition.</returns>
+        protected virtual CinemachineBlendDefinition LookupBlend(ICinemachineCamera outgoing, ICinemachineCamera incoming)
+            => CinemachineBlenderSettings.LookupBlend(outgoing, incoming, DefaultBlend, CustomBlends, this);
+            
+        /// <summary>
+        /// Choose the appropriate current camera from among the ChildCameras, based on current state.
+        /// If the returned camera is different from the current camera, an appropriate transition will be made.
+        /// </summary>
+        /// <param name="worldUp">Default world Up, set by the CinemachineBrain</param>
+        /// <param name="deltaTime">Delta time for time-based effects (ignore if less than or equal to 0)</param>
+        /// <returns>The current child camera that should be active. Must be present in ChildCameras.</returns>
+        protected abstract CinemachineVirtualCameraBase ChooseCurrentCamera(Vector3 worldUp, float deltaTime);
+        
         /// <summary>This is called to notify the vcam that a target got warped,
         /// so that the vcam can update its internal state to make the camera
         /// also warp seamlessly.</summary>
@@ -173,7 +244,9 @@ namespace Unity.Cinemachine
             ICinemachineCamera fromCam, Vector3 worldUp, float deltaTime)
         {
             base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
+            m_TransitioningFrom  = fromCam;
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
+            InternalUpdateCameraState(worldUp, deltaTime);
         }
 
         /// <summary>Force a rebuild of the child camera cache.  


### PR DESCRIPTION
### Purpose of this PR

Refactored CinemachineCameraManagerBase to be more useful for making custom managers.

CinemachineCameraManagerBase is now responsible for managing ChildCameras and blends.  Client only needs to implement ChooseCurrentCamera() method, which chooses the appropriate child for the current frame.  It can do this however it likes.

Very little boilerplate is needed.  

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
