### PR TITLE
CMCL-0000: event behaviours support manager cameras

### DIFF
--- a/com.unity.cinemachine/Documentation~/CinemachineBrainEvents.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineBrainEvents.md
@@ -2,9 +2,9 @@
 
 When Cinemachine Cameras are activated, global events are sent via CinemachineCore.  Scripts can add listeners to those events and take action based on them.  Listeners will receive events for all cameras and all brains.
 
-Sometimes it's desirable to have events sent only for a specific Cinemachine Brain, so that scripts can be notified based on this specific brain's activity without having to provide code to filter the events.  The Cinemachine Brain Events component fills this need.
+Sometimes it's desirable to have events sent only for a specific Cinemachine Brain or Cinemachine Camera Manager, so that scripts can be notified based on this specific objects's activity without having to provide code to filter the events.  The Cinemachine Brain Events component fills this need.
 
-If you add it to a CinemachineBrain object, it will expose events that will be fired based on that brain's activity.  Any listeners you add will be called when the events happen for that brain.
+If you add it to a CinemachineBrain object or other object implementing `ICinemachineMixer` such as a Cinemachine Camera Manager, it will expose events that will be fired based on that objects's activity.  Any listeners you add will be called when the events happen for that object.
 
 If you are looking for events that fire for a specific CinemachineCamera, see [Cinemachine Camera Events](CinemachineCameraEvents.md).
 
@@ -16,5 +16,5 @@ If you are looking for events that fire for a specific CinemachineCamera, see [C
 | __Camera Deactivated Event__ | This event will fire whenever a Cinemachine Camera stops being live.  If a blend is involved, then the event will fire after the last frame of the blend. |
 | __Camera Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
 | __Camera Cut Event__ | This is called when a zero-length blend happens. |
-| __Updated Event__ | This event is sent immediately after the brain has processed all the CinemachineCameras, and has updated the main Camera.  Code that depends on the main camera position or that wants to modify it can be executed from this event handler. |
+| __Brain Updated Event__ | This event is sent immediately after the brain has processed all the CinemachineCameras, and has updated the main Camera.  Code that depends on the main camera position or that wants to modify it can be executed from this event handler. |
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEventsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEventsEditor.cs
@@ -14,26 +14,33 @@ namespace Unity.Cinemachine.Editor
         {
             var ux = new VisualElement();
 
-            var noBrainHelp = ux.AddChild(
-                new HelpBox("This behaviour will only work with a CinemachineBrain component.", 
+            var wrongComponentHelp = ux.AddChild(
+                new HelpBox("This behaviour will only work with the following components: "
+                    + InspectorUtility.GetAssignableBehaviourNames(typeof(ICinemachineMixer)), 
                 HelpBoxMessageType.Warning));
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDeactivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraBlendFinishedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraCutEvent)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.UpdatedEvent)));
+            var brainEvent = ux.AddChild(
+                new PropertyField(serializedObject.FindProperty(() => Target.BrainUpdatedEvent)));
 
             // Update state
             ux.TrackAnyUserActivity(() =>
             {
-                var noBrain = false;
-                for (int i = 0; i < targets.Length && !noBrain; ++i)
+                var haveBrain = false;
+                var noMixer = false;
+                for (int i = 0; i < targets.Length; ++i)
                 {
                     var t = targets[i] as CinemachineBrainEvents;
-                    noBrain |= !t.TryGetComponent<CinemachineBrain>(out _);
+                    if (t == null)
+                        break;
+                    noMixer |= !t.TryGetComponent<ICinemachineMixer>(out _);
+                    haveBrain |= t.TryGetComponent<CinemachineBrain>(out _);
                 }
-                noBrainHelp?.SetVisible(noBrain);
+                wrongComponentHelp?.SetVisible(noMixer);
+                brainEvent?.SetVisible(haveBrain);
             });
 
             return ux;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraEventsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraEventsEditor.cs
@@ -13,10 +13,30 @@ namespace Unity.Cinemachine.Editor
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
-            this.AddMissingCmCameraHelpBox(ux);
+
+            var wrongComponentHelp = ux.AddChild(
+                new HelpBox("This behaviour will only work with the following components: "
+                    + InspectorUtility.GetAssignableBehaviourNames(typeof(CinemachineVirtualCameraBase)), 
+                HelpBoxMessageType.Warning));
+
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDeactivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraBlendFinishedEvent)));
+
+            // Update state
+            ux.TrackAnyUserActivity(() =>
+            {
+                var noCamera = false;
+                for (int i = 0; i < targets.Length && !noCamera; ++i)
+                {
+                    var t = targets[i] as CinemachineCameraEvents;
+                    if (t == null)
+                        break;
+                    noCamera |= !t.TryGetComponent<CinemachineVirtualCameraBase>(out _);
+                }
+                wrongComponentHelp?.SetVisible(noCamera);
+            });
+
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -241,20 +241,18 @@ namespace Unity.Cinemachine.Editor
             var targets = editor.targets;
             for (int i = 0; i < targets.Length && !noCamera; ++i)
             {
-                var t = targets[i] as CinemachineComponentBase;
-                if (t != null)
+                if (targets[i] is CinemachineComponentBase c)
                 {
-                    noCamera |= t.VirtualCamera == null || t.VirtualCamera is CinemachineCameraManagerBase;
+                    noCamera |= c.VirtualCamera == null || c.VirtualCamera is CinemachineCameraManagerBase;
                     switch (requiredTargets)
                     {
-                        case RequiredTargets.Tracking: noTarget |= t.FollowTarget == null; break;
-                        case RequiredTargets.LookAt: noTarget |= t.LookAtTarget == null; break;
-                        case RequiredTargets.Group: noTarget |= t.FollowTargetAsGroup == null; break;
+                        case RequiredTargets.Tracking: noTarget |= c.FollowTarget == null; break;
+                        case RequiredTargets.LookAt: noTarget |= c.LookAtTarget == null; break;
+                        case RequiredTargets.Group: noTarget |= c.FollowTargetAsGroup == null; break;
                     }
                 }
-                else
+                else if (targets[i] is CinemachineExtension x)
                 {
-                    var x = targets[i] as CinemachineExtension;
                     noCamera |= x.ComponentOwner == null;
                     switch (requiredTargets)
                     {

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -82,13 +82,13 @@ namespace Unity.Cinemachine
             base.OnDisable();
         }
 
-        /// </inheritdoc />
+        /// <inheritdoc />
         public override string Description => m_BlendManager.Description;
 
-        /// </inheritdoc />
+        /// <inheritdoc />
         public override CameraState State => m_State;
 
-        /// </inheritdoc />
+        /// <inheritdoc />
         public virtual bool IsLiveChild(ICinemachineCamera cam, bool dominantChildOnly = false)
             => m_BlendManager.IsLive(cam, dominantChildOnly);
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -82,17 +82,14 @@ namespace Unity.Cinemachine
             base.OnDisable();
         }
 
-        /// <summary>Gets a brief debug description of this virtual camera, for use when displaying debug info</summary>
+        /// </inheritdoc />
         public override string Description => m_BlendManager.Description;
 
-        /// <summary>The resulting CameraState for the current live child and blend</summary>
+        /// </inheritdoc />
         public override CameraState State => m_State;
 
-        /// <summary>Check whether the vcam a live child of this camera.</summary>
-        /// <param name="cam">The Virtual Camera to check</param>
-        /// <param name="dominantChildOnly">If true, will only return true if this vcam is the dominant live child</param>
-        /// <returns>True if the vcam is currently actively influencing the state of this vcam</returns>
-        public override bool IsLiveChild(ICinemachineCamera cam, bool dominantChildOnly = false)
+        /// </inheritdoc />
+        public virtual bool IsLiveChild(ICinemachineCamera cam, bool dominantChildOnly = false)
             => m_BlendManager.IsLive(cam, dominantChildOnly);
 
         /// <summary>The list of child cameras.  These are just the immediate children in the hierarchy.</summary>

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -26,8 +26,7 @@ namespace Unity.Cinemachine
     /// Unity cameras simultaneously.
     /// </summary>
     [SaveDuringPlay]
-    public abstract class CinemachineVirtualCameraBase 
-        : MonoBehaviour, ICinemachineCamera, ICinemachineMixer
+    public abstract class CinemachineVirtualCameraBase : MonoBehaviour, ICinemachineCamera
     {
         /// <summary>Priority can be used to control which Cm Camera is live when multiple CM Cameras are 
         /// active simultaneously.  The most-recently-activated CinemachineCamera will take control, unless there 
@@ -421,7 +420,7 @@ namespace Unity.Cinemachine
             {
                 if (!m_ChildStatusUpdated || !Application.isPlaying)
                     UpdateStatusAsChild();
-                return m_ParentVcam;
+                return m_ParentVcam as ICinemachineMixer;
             }
         }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -424,13 +424,6 @@ namespace Unity.Cinemachine
             }
         }
 
-        /// <summary>Check whether the vcam a live child of this camera.
-        /// This base class implementation always returns false.</summary>
-        /// <param name="vcam">The Virtual Camera to check</param>
-        /// <param name="dominantChildOnly">If true, will only return true if this vcam is the dominant live child</param>
-        /// <returns>True if the vcam is currently actively influencing the state of this vcam</returns>
-        public virtual bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false) => false;
-
         /// <summary>Get the LookAt target for the Aim component in the Cinemachine pipeline.</summary>
         public abstract Transform LookAt { get; set; }
 

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -15,7 +15,7 @@ namespace Unity.Cinemachine
     [ExecuteAlways]
     [ExcludeFromPreset]
     [AddComponentMenu("")] // Don't display in add component menu
-    public class CinemachineFreeLook : CinemachineVirtualCameraBase, AxisState.IRequiresInput
+    public class CinemachineFreeLook : CinemachineVirtualCameraBase, AxisState.IRequiresInput, ICinemachineMixer
     {
         /// <summary>Object for the camera children to look at (the aim target)</summary>
         [Tooltip("Object for the camera children to look at (the aim target).")]
@@ -300,7 +300,7 @@ namespace Unity.Cinemachine
         /// <param name="vcam">The Virtual Camera to check</param>
         /// <param name="dominantChildOnly">If truw, will only return true if this vcam is the dominant live child</param>
         /// <returns>True if the vcam is currently actively influencing the state of this vcam</returns>
-        public override bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false)
+        public bool IsLiveChild(ICinemachineCamera vcam, bool dominantChildOnly = false)
         {
             // Do not update the rig cache here or there will be infinite loop at creation time
             if (!RigsAreCreated)

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineBrainEvents.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineBrainEvents.cs
@@ -1,12 +1,11 @@
-using System;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace Unity.Cinemachine
 {
     /// <summary>
-    /// This component will generate brain-specific events.
-    /// Add it to a a GameObject that has a CinemachineBrain.
+    /// This component will generate mixer-specific events.
+    /// Add it to a a GameObject that has a CinemachineBrain or another ICinemachineMixer, 
+    /// such as a CinemachineCameraManager.
     /// </summary>
     [AddComponentMenu("Cinemachine/Helpers/Cinemachine Brain Events")]
     [SaveDuringPlay]
@@ -43,18 +42,19 @@ namespace Unity.Cinemachine
         /// </summary>
         [Tooltip("This event is fired when there is a camera cut.  A camera cut is a camera "
             + "activation with a zero-length blend.")]
-        public CinemachineCore.BrainEvent CameraCutEvent = new ();
+        public CinemachineCore.CameraEvent CameraCutEvent = new ();
 
-        /// <summary>This event will fire after the brain updates its Camera</summary>
+        /// <summary>This event will fire after the brain updates its Camera.
+        /// This evenet will only fire if this component is attached to a CinemachineBrain.</summary>
         [Tooltip("This event will fire after the brain updates its Camera.")]
-        public CinemachineCore.BrainEvent UpdatedEvent = new ();
+        public CinemachineCore.BrainEvent BrainUpdatedEvent = new ();
 
-        CinemachineBrain m_Brain;
+        ICinemachineMixer m_Mixer;
 
         void OnEnable()
         {
-            TryGetComponent(out m_Brain);
-            if (m_Brain != null)
+            TryGetComponent(out m_Mixer);
+            if (m_Mixer != null)
             {
                 CinemachineCore.CameraActivatedEvent.AddListener(OnCameraActivated);
                 CinemachineCore.CameraDeactivatedEvent.AddListener(OnCameraDeactivated);
@@ -73,30 +73,30 @@ namespace Unity.Cinemachine
 
         void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt)
         {
-            if (evt.Origin == (ICinemachineMixer)m_Brain)
+            if (evt.Origin == m_Mixer)
             {
-                CameraActivatedEvent.Invoke(m_Brain, evt.IncomingCamera);
+                CameraActivatedEvent.Invoke(m_Mixer, evt.IncomingCamera);
                 if (evt.IsCut)
-                    CameraCutEvent.Invoke(m_Brain);
+                    CameraCutEvent.Invoke(m_Mixer, evt.IncomingCamera);
             }
         }
 
         void OnCameraDeactivated(ICinemachineMixer mixer, ICinemachineCamera cam)
         {
-            if (mixer == (ICinemachineMixer)m_Brain)
+            if (mixer == m_Mixer)
                 CameraDeactivatedEvent.Invoke(mixer, cam);
         }
 
         void OnBlendFinished(ICinemachineMixer mixer, ICinemachineCamera cam)
         {
-            if (mixer == (ICinemachineMixer)m_Brain)
-                CameraBlendFinishedEvent.Invoke(m_Brain, cam);
+            if (mixer == m_Mixer)
+                CameraBlendFinishedEvent.Invoke(m_Mixer, cam);
         }
 
         void OnCameraUpdated(CinemachineBrain brain)
         {
-            if (brain == m_Brain)
-                UpdatedEvent.Invoke(brain);
+            if ((ICinemachineMixer)brain == m_Mixer)
+                BrainUpdatedEvent.Invoke(brain);
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineCameraEvents.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineCameraEvents.cs
@@ -1,17 +1,10 @@
-using System;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace Unity.Cinemachine
 {
     /// <summary>
     /// This component will generate camera-specific activation and deactivation events.
     /// Add it to a Cinemachine Camera.
-    /// 
-    /// GML todo: add events for
-    ///  - Blend finished
-    ///  - Camera deactivated
-    ///  - Camera activated (deprecate OnCameraLive)
     /// </summary>
     [AddComponentMenu("Cinemachine/Helpers/Cinemachine Camera Events")]
     [SaveDuringPlay]


### PR DESCRIPTION
### Purpose of this PR

- CinemachineBrainEvents behaviour can now be added to manager cameras.  These will fire based on the activity of the child cameras.
- CinemachineCameraEvents can also be added to manager cameras.  These will fire based on the activity of the manager camera itself.
- Fixed: CinemachineVirtualCameraBase was erroneously implementing ICinemachineMixer.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [x] Updated user documentation

