### PR TITLE
CMCL-1459: only vcams with no aim will ignore look at target by default

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
 - URP: add temporal effects reset on camera cut for URP 14.0.4 and up
 - Bugfix: MixingCamera calls OnTransitionFromCamera correctly for all its children
+- Bugfix: Passive vcams with noise were not respecting transform's z rotation during blends
 
 
 ## [2.9.5] - 2023-01-16

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -488,9 +488,9 @@ namespace Cinemachine
             InvokePrePipelineMutateCameraStateCallback(this, ref state, deltaTime);
 
             // Then components
+            bool haveAim = false;
             if (m_ComponentPipeline == null)
             {
-                state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
                 for (var stage = CinemachineCore.Stage.Body; stage <= CinemachineCore.Stage.Finalize; ++stage)
                     InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
             }
@@ -515,22 +515,21 @@ namespace Cinemachine
                             continue; // do the body stage of the pipeline after Aim
                         }
                         c.MutateCameraState(ref state, deltaTime);
+                        haveAim = stage == CinemachineCore.Stage.Aim;
                     }
                     InvokePostPipelineStageCallback(this, stage, ref state, deltaTime);
 
-                    if (stage == CinemachineCore.Stage.Aim)
+                    // If we have saved a Body for after Aim, do it now
+                    if (stage == CinemachineCore.Stage.Aim && postAimBody != null)
                     {
-                        if (c == null)
-                            state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
-                        // If we have saved a Body for after Aim, do it now
-                        if (postAimBody != null)
-                        {
-                            postAimBody.MutateCameraState(ref state, deltaTime);
-                            InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Body, ref state, deltaTime);
-                        }
+                        postAimBody.MutateCameraState(ref state, deltaTime);
+                        InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Body, ref state, deltaTime);
                     }
                 }
             }
+            if (!haveAim)
+                state.BlendHint |= CameraState.BlendHintValue.IgnoreLookAtTarget;
+
             return state;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Bugfix: Passive vcams with noise were not respecting transform's z rotation during blends.
See description here: https://forum.unity.com/threads/was-there-a-change-in-transitions-with-a-roll-of-z-axis-dutch.1417956/#post-8913316

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

This is not a problem for CM3 because it has IgnoreLooktTarget blend hint, which for back-compatibility reasons is difficult to add to 2.9

