### PR TITLE
CMCL-1467: Runtime UITK should react to Input System

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - InputAxisController has the option to suppress input while the attached camera is blending.
 - Added CinemachineCameraEvents and CinemachineBrainEvents behaviours for event processing.
 - Added BlendFinished and CameraDeactivated events.
+- Samples UI works with both built-in Input System.
 
 ### Changed
 - All namespaces changed from "Cinemachine" to "Unity.Cinemachine".

--- a/com.unity.cinemachine/Samples~/HDRP~/Lighting.prefab.meta
+++ b/com.unity.cinemachine/Samples~/HDRP~/Lighting.prefab.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: c3bf66bbf25c9406c8bc17d224a9e664
-PrefabImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/com.unity.cinemachine/Samples~/InputSystem~/HelpUI.prefab
+++ b/com.unity.cinemachine/Samples~/InputSystem~/HelpUI.prefab
@@ -66,24 +66,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   VisibleAtStart: 0
   HelpTitle: 
-  HelpText: 'This scene shows a Clearshot camera set up so that the shot quality
-    is driven by target visibility.
-
-
-    The player is moved automatically on the
-    z-axis. Observe that once the player is occluded a new camera is selected to
-    frame it.
-
-
-    The ClearShot camera has 3 child cameras. Clearshot selects from
-    its children based on shot quality. When more than one camera has the highest
-    quality shot, then their priority value determines which one is selected.
-
-
-    The
-    shot quality evaluation (line of sight) is done by the CinemachineDeoccluder
-    extension found on the Clearshot camera. The user can supply their own shot evaluator
-    by implementing IShotQualityEvaluator.'
+  HelpText:
   OnHelpDismissed:
     m_PersistentCalls:
       m_Calls: []

--- a/com.unity.cinemachine/Samples~/InputSystem~/HelpUI.prefab
+++ b/com.unity.cinemachine/Samples~/InputSystem~/HelpUI.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8580608773889138619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5177910821003284110}
+  - component: {fileID: 3670039913357253434}
+  - component: {fileID: 1808852317780390430}
+  - component: {fileID: 4470382000084071451}
+  - component: {fileID: 628105433370710716}
+  m_Layer: 5
+  m_Name: HelpUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5177910821003284110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580608773889138619}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3670039913357253434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580608773889138619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: e1340a64b3dbc4c60a6d59ca2fc83df8, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: 625ec32eada784ffa8da2d56a8bd43c2,
+    type: 3}
+  m_SortingOrder: 0
+--- !u!114 &1808852317780390430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580608773889138619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be49d5e8cf7024d6b8f8d5b9872c0f91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  VisibleAtStart: 0
+  HelpTitle: 
+  HelpText: 'This scene shows a Clearshot camera set up so that the shot quality
+    is driven by target visibility.
+
+
+    The player is moved automatically on the
+    z-axis. Observe that once the player is occluded a new camera is selected to
+    frame it.
+
+
+    The ClearShot camera has 3 child cameras. Clearshot selects from
+    its children based on shot quality. When more than one camera has the highest
+    quality shot, then their priority value determines which one is selected.
+
+
+    The
+    shot quality evaluation (line of sight) is done by the CinemachineDeoccluder
+    extension found on the Clearshot camera. The user can supply their own shot evaluator
+    by implementing IShotQualityEvaluator.'
+  OnHelpDismissed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4470382000084071451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580608773889138619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &628105433370710716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580608773889138619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0


### PR DESCRIPTION
### Purpose of this PR
[CMCL-1467](https://jira.unity3d.com/browse/CMCL-1467): Runtime UITK only works with built-in input system by default. For Input System, it needs to have an Event System + Input System UI Module. 

The fix is similar to how HDRP specific changes are made:
I added a new folder to our samples: InputSystem~. This has a HelpUI.prefab, which replaces the root contents with an Input System appropriate one when importing the samples.

The new prefab root has these extra components:
<img width="462" alt="Screen Shot 2023-04-04 at 5 47 47 PM" src="https://user-images.githubusercontent.com/57672095/229930200-7ba103bc-f107-4be3-b95b-be02a71c3cee.png">

This way our runtime ui button can react to both built-in and input system one depending on which one is installed. When both are installed, we use input system.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested:
    - [x] Active Input Handling: Input Manager (works by default)
    - [x] Active Input Handling: Input System (works with replaced prefab)
    - [x] Active Input Handling: Both (works with replaced prefab)

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version
