### PR TITLE
CMCL-0000: Fix blending bug due to un-updated state

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -392,7 +392,7 @@ namespace Unity.Cinemachine
         /// <inheritdoc />
         public bool IsLiveChild(ICinemachineCamera cam, bool dominantChildOnly = false)
         {
-            if (CinemachineCore.SoloCamera == cam || m_BlendManager.IsLive(cam, dominantChildOnly))
+            if (CinemachineCore.SoloCamera == cam || m_BlendManager.IsLive(cam))
                 return true;
 
             // Walk up the parents
@@ -508,7 +508,8 @@ namespace Unity.Cinemachine
 
             float deltaTime = GetEffectiveDeltaTime(false);
             if (!Application.isPlaying || BlendUpdateMethod != BrainUpdateMethods.FixedUpdate)
-                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), deltaTime, LookupBlend);
+                m_BlendManager.UpdateRootFrame(
+                    TopCameraFromPriorityQueue(), DefaultWorldUp, deltaTime, LookupBlend);
 
             m_BlendManager.ComputeCurrentBlend();
 
@@ -559,7 +560,8 @@ namespace Unity.Cinemachine
             // Choose the active vcam and apply it to the Unity camera
             if (BlendUpdateMethod == BrainUpdateMethods.FixedUpdate)
             {
-                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), Time.fixedDeltaTime, LookupBlend);
+                m_BlendManager.UpdateRootFrame(
+                    TopCameraFromPriorityQueue(), DefaultWorldUp, Time.fixedDeltaTime, LookupBlend);
                 ProcessActiveCamera(Time.fixedDeltaTime);
             }
         }

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -93,10 +93,9 @@ namespace Unity.Cinemachine
         /// or part of a current blend, either directly or indirectly because its parents are live.
         /// </summary>
         /// <param name="vcam">The camera to test whether it is live</param>
-        /// <param name="dominantChildOnly">If true, will only return true if this vcam is the dominant live child</param>
         /// <returns>True if the camera is live (directly or indirectly)
         /// or part of a blend in progress.</returns>
-        public bool IsLive(ICinemachineCamera cam, bool dominantChildOnly = false) => m_CurrentLiveCameras.Uses(cam);
+        public bool IsLive(ICinemachineCamera cam) => m_CurrentLiveCameras.Uses(cam);
 
         /// <summary>Get the current state, representing the active camera and blend state.</summary>
         public CameraState CameraState => m_CurrentLiveCameras.State;

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -192,10 +192,11 @@ namespace Unity.Cinemachine
         /// Call this every frame with the current active camera of the root frame.
         /// </summary>
         /// <param name="activeCamera">Current active camera (pre-override)</param>
+        /// <param name="up">Current world up</param>
         /// <param name="deltaTime">How much time has elapsed, for computing blends</param>
         /// <param name="lookupBlend">Delegate to use to find a blend definition, when a blend is being created</param>
         public void UpdateRootFrame(
-            ICinemachineCamera activeCamera, float deltaTime, 
+            ICinemachineCamera activeCamera, Vector3 up, float deltaTime, 
             CinemachineBlendDefinition.LookupBlendDelegate lookupBlend)
         {
             // Make sure there is a first stack frame
@@ -278,6 +279,7 @@ namespace Unity.Cinemachine
                     frame.Blend.TimeInBlend = 0;
                 }
             }
+            frame.UpdateCameraState(up, deltaTime);
         }
 
         /// <summary>

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -90,7 +90,7 @@ namespace Unity.Cinemachine
 
         /// <inheritdoc />
         public virtual bool IsLiveChild(ICinemachineCamera cam, bool dominantChildOnly = false)
-            => m_BlendManager.IsLive(cam, dominantChildOnly);
+            => m_BlendManager.IsLive(cam);
 
         /// <summary>The list of child cameras.  These are just the immediate children in the hierarchy.</summary>
         public List<CinemachineVirtualCameraBase> ChildCameras 
@@ -283,7 +283,7 @@ namespace Unity.Cinemachine
             ICinemachineCamera activeCamera, Vector3 worldUp, float deltaTime,
             CinemachineBlendDefinition.LookupBlendDelegate lookupBlend)
         {
-            m_BlendManager.UpdateRootFrame(activeCamera, deltaTime, lookupBlend);
+            m_BlendManager.UpdateRootFrame(activeCamera, worldUp, deltaTime, lookupBlend);
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(this, worldUp, deltaTime);
         }

--- a/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
+++ b/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
@@ -55,7 +55,7 @@ namespace Unity.Cinemachine.Tests.Editor
 
         void ProcessFrame(ICinemachineCamera cam, float deltaTime)
         {
-            m_BlendManager.UpdateRootFrame(cam, deltaTime, (outgoing, incoming)
+            m_BlendManager.UpdateRootFrame(cam, Vector3.up, deltaTime, (outgoing, incoming)
                 => new (CinemachineBlendDefinition.Styles.EaseInOut, 1)); // constant blend time of 1
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(m_Mixer, Vector3.up, deltaTime);


### PR DESCRIPTION
### Purpose of this PR

Fix bug introduced by recent brain refactor.
Caused by framestack frame 0 not being updated, which introduced a default state into the blend.
Was visible in the running race scene during blends.

Also a little API cleanup.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
