### PR TITLE
CMCL-1446: remove linq and foreach

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -191,9 +191,9 @@ namespace Unity.Cinemachine.Editor
                 availableCameras.Clear();
                 availableCameras.Add(string.Empty);
                 availableCameras.Add(CinemachineBlenderSettings.kBlendFromAnyCameraLabel);
-                foreach (var c in allCameras)
-                    if (c != null && !availableCameras.Contains(c.Name))
-                        availableCameras.Add(c.Name);
+                for (int i = 0; i < allCameras.Count; ++i)
+                    if (allCameras[i] != null && !availableCameras.Contains(allCameras[i].Name))
+                        availableCameras.Add(allCameras[i].Name);
                 list.RefreshItems();  // rebuild the list
             });
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineConfiner2DEditor.cs
@@ -110,16 +110,18 @@ namespace Unity.Cinemachine.Editor
 
             // Draw input confiner
             Gizmos.color = color;
-            foreach (var path in originalPath )
+            for (int i = 0; i < originalPath.Count; ++i)
             {
+                var path = originalPath[i];
                 for (var index = 0; index < path.Count; index++)
                     Gizmos.DrawLine(path[index], path[(index + 1) % path.Count]);
             }
 
             // Draw confiner for current camera size
             Gizmos.color = colorDimmed;
-            foreach (var path in s_CurrentPathCache)
+            for (int i = 0; i < s_CurrentPathCache.Count; ++i)
             {
+                var path = s_CurrentPathCache[i];
                 for (var index = 0; index < path.Count; index++)
                     Gizmos.DrawLine(path[index], path[(index + 1) % path.Count]);
             }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineDeoccluderEditor.cs
@@ -48,13 +48,14 @@ namespace Unity.Cinemachine.Editor
                     Gizmos.DrawLine(pos, pos + forwardFeelerVector * distance);
 
                     // Show the avoidance path, for debugging
-                    List<List<Vector3>> debugPaths = collider.DebugPaths;
-                    foreach (var path in debugPaths)
+                    for (int i = 0; i < collider.DebugPaths.Count; ++i)
                     {
+                        var path = collider.DebugPaths[i];
                         Gizmos.color = CinemachineDeoccluderPrefs.CameraPathColor.Value;
                         Vector3 p0 = vcam.State.ReferenceLookAt;
-                        foreach (var p in path)
+                        for (int j = 0; j < path.Count; ++j)
                         {
+                            var p = path[j];
                             Gizmos.DrawLine(p0, p);
                             p0 = p;
                         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -120,8 +120,10 @@ namespace Unity.Cinemachine.Editor
 
             // Create the parent map in the target
             List<CinemachineStateDrivenCamera.ParentHash> parents = new();
-            foreach (var i in collector.StateParentLookup)
-                parents.Add(new CinemachineStateDrivenCamera.ParentHash { Hash = i.Key, HashOfParent = i.Value });
+            var iter = collector.StateParentLookup.GetEnumerator();
+            while (iter.MoveNext())
+                parents.Add(new CinemachineStateDrivenCamera.ParentHash 
+                    { Hash = iter.Current.Key, HashOfParent = iter.Current.Value });
             Target.HashOfParent = parents.ToArray();
         }
 
@@ -155,10 +157,10 @@ namespace Unity.Cinemachine.Editor
             void CollectStatesFromFSM(
                 AnimatorStateMachine fsm, string hashPrefix, int parentHash, string displayPrefix)
             {
-                ChildAnimatorState[] states = fsm.states;
+                var states = fsm.states;
                 for (int i = 0; i < states.Length; i++)
                 {
-                    AnimatorState state = states[i].state;
+                    var state = states[i].state;
                     int hash = AddState(Animator.StringToHash(hashPrefix + state.name),
                         parentHash, displayPrefix + state.name);
 
@@ -168,16 +170,17 @@ namespace Unity.Cinemachine.Editor
                     if (clips.Count > 1)
                     {
                         string substatePrefix = displayPrefix + state.name + ".";
-                        foreach (AnimationClip c in clips)
+                        for (int j = 0; j < clips.Count; ++j)
                             AddState(
-                                CinemachineStateDrivenCamera.CreateFakeHash(hash, c),
-                                hash, substatePrefix + c.name);
+                                CinemachineStateDrivenCamera.CreateFakeHash(hash, clips[j]),
+                                hash, substatePrefix + clips[j].name);
                     }
                 }
 
-                ChildAnimatorStateMachine[] fsmChildren = fsm.stateMachines;
-                foreach (var child in fsmChildren)
+                var fsmChildren = fsm.stateMachines;
+                for (int i = 0; i < fsmChildren.Length; ++i)
                 {
+                    var child = fsmChildren[i];
                     string name = hashPrefix + child.stateMachine.name;
                     string displayName = displayPrefix + child.stateMachine.name;
                     int hash = AddState(Animator.StringToHash(name), parentHash, displayName);
@@ -195,8 +198,8 @@ namespace Unity.Cinemachine.Editor
                 if (tree != null)
                 {
                     var children = tree.children;
-                    foreach (var child in children)
-                        clips.AddRange(CollectClips(child.motion));
+                    for (int i = 0; i < children.Length; ++i)
+                        clips.AddRange(CollectClips(children[i].motion));
                 }
                 return clips;
             }
@@ -227,8 +230,9 @@ namespace Unity.Cinemachine.Editor
             m_CameraIndexLookup = new();
             vcams.Add("(none)");
             var children = Target.ChildCameras;
-            foreach (var c in children)
+            for (int i = 0; i < children.Count; ++i)
             {
+                var c = children[i];
                 m_CameraIndexLookup[c] = vcams.Count;
                 vcams.Add(c.Name);
             }

--- a/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
@@ -1,7 +1,6 @@
 using UnityEditor;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
-using System.Linq;
 
 namespace Unity.Cinemachine.Editor
 {
@@ -86,10 +85,12 @@ namespace Unity.Cinemachine.Editor
 #if CINEMACHINE_UNITY_INPUTSYSTEM
                     if (actionName.Length != 0)
                     {
-                        var asset = ScriptableObjectUtility.kPackageRoot 
+                        var assetPath = ScriptableObjectUtility.kPackageRoot 
                             + "/Runtime/Input/CinemachineDefaultInputActions.inputactions";
-                        controller.Input.InputAction = (UnityEngine.InputSystem.InputActionReference)
-                            AssetDatabase.LoadAllAssetsAtPath(asset).FirstOrDefault(x => x.name == actionName);
+                        var assets = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+                        for (int i = 0; controller.Input.InputAction == null && i < assets.Length; ++i)
+                            if (assets[i].name == actionName)
+                                controller.Input.InputAction = (UnityEngine.InputSystem.InputActionReference)assets[i];
                     }
                     controller.Input.Gain = invertY ? -1 : 1;
 #endif

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachinePostProcessingEditor.cs
@@ -152,8 +152,7 @@ namespace Unity.Cinemachine.Editor
 
         void RefreshEffectListEditor(PostProcessProfile asset)
         {
-            if (m_EffectList == null)
-                m_EffectList = new EffectListEditor(this);
+            m_EffectList ??= new EffectListEditor(this);
             m_EffectList.Clear();
             if (asset != null)
                 m_EffectList.Init(asset, new SerializedObject(asset));
@@ -176,8 +175,9 @@ namespace Unity.Cinemachine.Editor
             asset.settings.Clear();
             AssetDatabase.CreateAsset(asset, path);
 
-            foreach (var item in origin.settings)
+            for (int i = 0; i < origin.settings.Count; ++i)
             {
+                var item = origin.settings[i];
                 var itemCopy = UnityEngine.Object.Instantiate(item);
                 itemCopy.hideFlags = HideFlags.HideInInspector | HideFlags.HideInHierarchy;
                 itemCopy.name = item.name;

--- a/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/PostProcessing/CinemachineVolumeSettingsEditor.cs
@@ -172,8 +172,7 @@ namespace Unity.Cinemachine.Editor
 
         void RefreshVolumeComponentEditor(VolumeProfile asset)
         {
-            if (m_ComponentList == null)
-                m_ComponentList = new VolumeComponentListEditor(this);
+            m_ComponentList ??= new VolumeComponentListEditor(this);
             m_ComponentList.Clear();
             if (asset != null)
                 m_ComponentList.Init(asset, new SerializedObject(asset));
@@ -196,8 +195,9 @@ namespace Unity.Cinemachine.Editor
             asset.components.Clear();
             AssetDatabase.CreateAsset(asset, path);
 
-            foreach (var item in origin.components)
+            for (int i = 0; i < origin.components.Count; ++i)
             {
+                var item = origin.components[i];
                 var itemCopy = Instantiate(item);
                 itemCopy.hideFlags = HideFlags.HideInInspector | HideFlags.HideInHierarchy;
                 itemCopy.name = item.name;

--- a/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 namespace Unity.Cinemachine.Editor
 {
     // GML todo: remove this class, replace with EmbeddedAssetEditorUtility.AddAssetSelectorWithPresets
+    // Currently only used by CinemachineImpulseDefinition editor
 
     [CustomPropertyDrawer(typeof(CinemachineEmbeddedAssetPropertyAttribute))]
     class EmbeddedAssetPropertyDrawer : PropertyDrawer
@@ -20,7 +21,7 @@ namespace Unity.Cinemachine.Editor
 
         bool WarnIfNull => attribute is CinemachineEmbeddedAssetPropertyAttribute attr && attr.WarnIfNull;
 
-        float HeaderHeight { get { return EditorGUIUtility.singleLineHeight * 1.5f; } }
+        float HeaderHeight => EditorGUIUtility.singleLineHeight * 1.5f; 
         float DrawHeader(Rect rect, string text)
         {
             float delta = HeaderHeight - EditorGUIUtility.singleLineHeight;

--- a/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -171,9 +171,9 @@ namespace Unity.Cinemachine.Editor
                     InspectorUtility.AddAssetsFromPackageSubDirectory(
                         mAssetTypes[i], mAssetPresets, "Presets/Noise");
             }
-            List<GUIContent> presetNameList = new List<GUIContent>();
-            foreach (var n in mAssetPresets)
-                presetNameList.Add(new GUIContent("Presets/" + n.name));
+            List<GUIContent> presetNameList = new ();
+            for (int i = 0; i < mAssetPresets.Count; ++i)
+                presetNameList.Add(new GUIContent("Presets/" + mAssetPresets[i].name));
             mAssetPresetNames = presetNameList.ToArray();
         }
 
@@ -223,18 +223,20 @@ namespace Unity.Cinemachine.Editor
                 }
 
                 RebuildPresetList();
-                int i = 0;
-                foreach (var a in mAssetPresets)
+                int index = 0;
+                for (int i = 0; i < mAssetPresets.Count; ++i)
                 {
-                    menu.AddItem(mAssetPresetNames[i++], false, () =>
+                    var a = mAssetPresets[i];
+                    menu.AddItem(mAssetPresetNames[index++], false, () =>
                         {
                             property.objectReferenceValue = a;
                             property.serializedObject.ApplyModifiedProperties();
                         });
                 }
 
-                foreach (var t in mAssetTypes)
+                for (int i = 0; i < mAssetTypes.Length; ++i)
                 {
+                    var t = mAssetTypes[i];
                     menu.AddItem(new GUIContent("New " + InspectorUtility.NicifyClassName(t)), false, () =>
                         {
                             string title = "Create New " + t.Name + " asset";

--- a/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
@@ -34,9 +34,9 @@ namespace Unity.Cinemachine.Editor
                 if (index != GetImplementationIndex(property))
                 {
                     var targets = property.serializedObject.targetObjects;
-                    foreach (var t in targets)
+                    for (int i = 0; i < targets.Length; ++i)
                     {
-                        var o = new SerializedObject(t);
+                        var o = new SerializedObject(targets[i]);
                         var p2 = o.FindProperty(property.propertyPath);
                         p2.managedReferenceValue = (index == 0) 
                             ? null : Activator.CreateInstance(AutoDollyMenuItems.s_AllItems[index]);

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -82,8 +82,8 @@ namespace Unity.Cinemachine.Editor
 
         void DestroySubeditors()
         {
-            foreach (var e in m_Subeditors)
-                e.Dispose();
+            for (int i = 0; i < m_Subeditors.Count; ++i)
+                m_Subeditors[i].Dispose();
             m_Subeditors.Clear();
         }
 
@@ -191,8 +191,8 @@ namespace Unity.Cinemachine.Editor
                     m_Subeditors.Add(new Subeditor(vcam.transform));
                     for (int i = 0; i < m_ComponentsCache.Count; ++i)
                         m_Subeditors.Add(new Subeditor(m_ComponentsCache[i]));
-                    foreach (var e in m_Subeditors)
-                        m_ParentElement.Add(e.Foldout);
+                    for (int i = 0; i < m_Subeditors.Count; ++i)
+                        m_ParentElement.Add(m_Subeditors[i].Foldout);
                 }
             }
         }

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -145,9 +145,8 @@ namespace Unity.Cinemachine.Editor
             ux.Add(new PropertyField(serializedObject.FindProperty(() => target.Priority)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => target.OutputChannel)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => target.StandbyUpdate)));
-            if (otherProperties != null)
-                foreach (var p in otherProperties)
-                    ux.Add(new PropertyField(p));
+            for (int i = 0; otherProperties != null && i < otherProperties.Count; ++i)
+                ux.Add(new PropertyField(otherProperties[i]));
         }
 
         /// <summary>Add the pipeline control dropdowns in the inspector</summary>
@@ -319,8 +318,10 @@ namespace Unity.Cinemachine.Editor
                     && t.GetCustomAttribute<CameraPipelineAttribute>() != null
                     && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
-                foreach (var t in allTypes)
+                var iter = allTypes.GetEnumerator();
+                while (iter.MoveNext())
                 {
+                    var t = iter.Current;
                     var stage = (int)t.GetCustomAttribute<CameraPipelineAttribute>().Stage;
                     s_StageData[stage].Types.Add(t);
                     s_StageData[stage].Choices.Add(InspectorUtility.NicifyClassName(t));
@@ -335,8 +336,10 @@ namespace Unity.Cinemachine.Editor
                     = ReflectionHelpers.GetTypesInAllDependentAssemblies(
                             (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t) 
                                 && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
-                foreach (Type t in allExtensions)
+                var iter2 = allExtensions.GetEnumerator();
+                while (iter2.MoveNext())
                 {
+                    var t = iter2.Current;
                     s_ExtentionTypes.Add(t);
                     s_ExtentionNames.Add(t.Name);
                 }
@@ -541,7 +544,8 @@ namespace Unity.Cinemachine.Editor
                 var selectedCam = (selected >= 0 && selected < list.itemsSource.Count) 
                     ? list.itemsSource[selected] as CinemachineVirtualCameraBase : null;
                 var name = selectedCam != null ? selectedCam.Name : "Child";
-                foreach (var index in added)
+                var iter = added.GetEnumerator();
+                while (iter.MoveNext())
                     CinemachineMenu.CreatePassiveCmCamera(name, vcam.gameObject);
                 Selection.activeObject = vcam;
                 vcam.InvalidateCameraCache();
@@ -549,9 +553,10 @@ namespace Unity.Cinemachine.Editor
 
             list.itemsRemoved += (removed) =>
             {
-                foreach (var index in removed)
+                var iter = removed.GetEnumerator();
+                while (iter.MoveNext())
                 {
-                    var child = list.itemsSource[index] as CinemachineVirtualCameraBase;
+                    var child = list.itemsSource[iter.Current] as CinemachineVirtualCameraBase;
                     if (child != null)
                         Undo.DestroyObjectImmediate(child.gameObject);
                 }

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -116,7 +115,10 @@ namespace Unity.Cinemachine.Editor
                     (Type t) => typeof(IInputAxisController).IsAssignableFrom(t) && !t.IsAbstract 
                         && typeof(MonoBehaviour).IsAssignableFrom(t)
                         && t.GetCustomAttribute<ObsoleteAttribute>() == null);
-                s_AllAxisControllerTypes = allTypes.ToList();
+                s_AllAxisControllerTypes = new();
+                var iter = allTypes.GetEnumerator();
+                while (iter.MoveNext())
+                    s_AllAxisControllerTypes.Add(iter.Current);
             }
             ContextualMenuManipulator menu = null;
             if (s_AllAxisControllerTypes.Count > 1)

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -125,8 +125,11 @@ namespace Unity.Cinemachine.Editor
             {
                 menu = new ContextualMenuManipulator((evt) => 
                 {
-                    foreach (var t in s_AllAxisControllerTypes)
+                    for (int i = 0; i < s_AllAxisControllerTypes.Count; ++i)
+                    {
+                        var t = s_AllAxisControllerTypes[i];
                         evt.menu.AppendAction(ObjectNames.NicifyVariableName(t.Name), (action) => AddController(t));
+                    }
                 });
             }
 

--- a/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
@@ -5,7 +5,6 @@ using UnityEngine.UIElements;
 using UnityEditor.UIElements;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Linq;
 using Object = UnityEngine.Object;
 
 namespace Unity.Cinemachine.Editor
@@ -229,9 +228,14 @@ namespace Unity.Cinemachine.Editor
             static List<Type> GetAssetTypes(Type baseType)
             {
                 // GML todo: optimize with TypeCache
-                return ReflectionHelpers.GetTypesInAllDependentAssemblies(
+                var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies(
                     (Type t) => baseType.IsAssignableFrom(t) && !t.IsAbstract 
-                        && t.GetCustomAttribute<ObsoleteAttribute>() == null).ToList();
+                        && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var list = new List<Type>();
+                var iter = allTypes.GetEnumerator();
+                while (iter.MoveNext())
+                    list.Add(iter.Current);
+                return list;
             }
 
             // Local function

--- a/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
@@ -157,10 +157,10 @@ namespace Unity.Cinemachine.Editor
                         return copyFrom == null ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal;
                     }
                 );
-                int i = 0;
-                foreach (var a in presetAssets)
+                for (int i = 0; i < presetAssets.Count; ++i)
                 {
-                    evt.menu.AppendAction(presetNames[i++], 
+                    var a = presetAssets[i];
+                    evt.menu.AppendAction(presetNames[i], 
                         (action) => 
                         {
                             property.objectReferenceValue = a;
@@ -189,8 +189,9 @@ namespace Unity.Cinemachine.Editor
                         return copyFrom == null ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal;
                     }
                 );
-                foreach (var t in assetTypes)
+                for (int i = 0; i < assetTypes.Count; ++i)
                 {
+                    var t = assetTypes[i];
                     evt.menu.AppendAction("New " + InspectorUtility.NicifyClassName(t), 
                         (action) => 
                         {
@@ -247,10 +248,10 @@ namespace Unity.Cinemachine.Editor
 
                 if (!string.IsNullOrEmpty(presetPath))
                 {
-                    foreach (var t in assetTypes)
-                        InspectorUtility.AddAssetsFromPackageSubDirectory(t, presetAssets, presetPath);
-                    foreach (var n in presetAssets)
-                        presetNames.Add("Presets/" + n.name);
+                    for (int i = 0; i < assetTypes.Count; ++i)
+                        InspectorUtility.AddAssetsFromPackageSubDirectory(assetTypes[i], presetAssets, presetPath);
+                    for (int i = 0; i < presetAssets.Count; ++i)
+                        presetNames.Add("Presets/" + presetAssets[i].name);
                 }
                 return presetAssets;
             }

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -174,12 +174,13 @@ namespace Unity.Cinemachine.Editor
                 var info = new DirectoryInfo(path);
                 path += "/";
                 var fileInfo = info.GetFiles();
-                foreach (var file in fileInfo)
+                for (int i = 0; i < fileInfo.Length; ++i)
                 {
+                    var file = fileInfo[i];
                     if (file.Extension != ".asset")
                         continue;
-                    string name = path + file.Name;
-                    ScriptableObject a = AssetDatabase.LoadAssetAtPath(name, type) as ScriptableObject;
+                    var name = path + file.Name;
+                    var a = AssetDatabase.LoadAssetAtPath(name, type) as ScriptableObject;
                     if (a != null)
                         assets.Add(a);
                 }
@@ -413,10 +414,11 @@ namespace Unity.Cinemachine.Editor
                         && typeof(MonoBehaviour).IsAssignableFrom(t)
                         && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 var s = string.Empty;
-                foreach (var t in allSources)
+                var iter = allSources.GetEnumerator();
+                while (iter.MoveNext())
                 {
                     var sep = (s.Length == 0) ? string.Empty : ", ";
-                    s += sep + t.Name;
+                    s += sep + iter.Current.Name;
                 }
                 if (s.Length == 0)
                     s = s_NoneString;

--- a/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
+++ b/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -11,7 +10,7 @@ namespace Unity.Cinemachine
 {
     /// <summary>An ad-hoc collection of helpers for reflection, used by Cinemachine
     /// or its editor tools in various places</summary>
-     static class ReflectionHelpers
+    static class ReflectionHelpers
     {
         /// <summary>Copy the fields from one object to another</summary>
         /// <param name="src">The source object to copy from</param>
@@ -19,11 +18,8 @@ namespace Unity.Cinemachine
         /// <param name="bindingAttr">The mask to filter the attributes.
         /// Only those fields that get caught in the filter will be copied</param>
         public static void CopyFields(
-            System.Object src, System.Object dst,
-            System.Reflection.BindingFlags bindingAttr 
-                = System.Reflection.BindingFlags.Public 
-                | System.Reflection.BindingFlags.NonPublic 
-                | System.Reflection.BindingFlags.Instance)
+            object src, object dst,
+            BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
         {
             if (src != null && dst != null)
             {
@@ -42,22 +38,25 @@ namespace Unity.Cinemachine
         public static IEnumerable<Type> GetTypesInAssembly(
             Assembly assembly, Predicate<Type> predicate)
         {
-            if (assembly == null)
-                return null;
-
-            Type[] types = new Type[0];
-            try
+            var list = new List<Type>();
+            if (assembly != null)
             {
-                types = assembly.GetTypes();
+                try 
+                { 
+                    var allTypes = assembly.GetTypes(); 
+                    if (allTypes != null)
+                    {
+                        for (int i = 0; i < allTypes.Length; ++i)
+                        {
+                            var t = allTypes[i];
+                            if (t != null && predicate(t))
+                                list.Add(t);
+                        }
+                    }
+                }
+                catch (Exception) {} // Can't load the types in this assembly
             }
-            catch (Exception)
-            {
-                // Can't load the types in this assembly
-            }
-            types = (from t in types
-                     where t != null && predicate(t)
-                     select t).ToArray();
-            return types;
+            return list;
         }
 
         /// <summary>Get a type from a name</summary>
@@ -75,15 +74,26 @@ namespace Unity.Cinemachine
         /// <returns>A list of types found in the assembly that inherit from the predicate</returns>
         public static IEnumerable<Type> GetTypesInAllDependentAssemblies(Predicate<Type> predicate)
         {
-            List<Type> foundTypes = new List<Type>(100);
+            List<Type> foundTypes = new(100);
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
             string definedIn = typeof(CinemachineComponentBase).Assembly.GetName().Name;
             foreach (Assembly assembly in assemblies)
             {
+                if (assembly.GlobalAssemblyCache)
+                    continue;
+
                 // Note that we have to call GetName().Name.  Just GetName() will not work.  
-                if ((!assembly.GlobalAssemblyCache) 
-                    && ((assembly.GetName().Name == definedIn) 
-                        || assembly.GetReferencedAssemblies().Any(a => a.Name == definedIn)))
+                bool skip = assembly.GetName().Name != definedIn;
+                if (skip)
+                {
+                    var referencedAssemblies = assembly.GetReferencedAssemblies();
+                    for (int j = 0; skip && j < referencedAssemblies.Length; ++j)
+                        if (referencedAssemblies[j].Name == definedIn)
+                            skip = false;
+                }
+                if (skip)
+                    continue;
+
                 try
                 {
                     foreach (Type foundType in GetTypesInAssembly(assembly, predicate))
@@ -93,47 +103,7 @@ namespace Unity.Cinemachine
             }
             return foundTypes;
         }
-#if false
-        /// <summary>call GetTypesInAssembly() for all assemblies that match a predicate</summary>
-        /// <param name="assemblyPredicate">Which assemblies to search</param>
-        /// <param name="predicate">What type to look for</param>
-        public static IEnumerable<Type> GetTypesInLoadedAssemblies(
-            Predicate<Assembly> assemblyPredicate, Predicate<Type> predicate)
-        {
-            Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
-            assemblies = assemblies.Where((Assembly assembly)
-                    => { return assemblyPredicate(assembly); }).OrderBy((Assembly ass)
-                    => { return ass.FullName; }).ToArray();
 
-            List<Type> foundTypes = new List<Type>(100);
-            foreach (Assembly assembly in assemblies)
-            {
-                foreach (Type foundType in GetTypesInAssembly(assembly, predicate))
-                    foundTypes.Add(foundType);
-            }
-
-            return foundTypes;
-        }
-
-        /// <summary>Is a type defined and visible</summary>
-        /// <param name="fullname">Fullly-qualified type name</param>
-        /// <returns>true if the type exists</returns>
-        public static bool TypeIsDefined(string fullname)
-        {
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (Assembly assembly in assemblies)
-            {
-                try 
-                {
-                    foreach (var type in assembly.GetTypes())
-                        if (type.FullName == fullname)
-                            return true;
-                }
-                catch (System.Exception) {} // Just skip uncooperative assemblies
-            }
-            return false;
-        }
-#endif
         /// <summary>Cheater extension to access internal field of an object</summary>
         /// <typeparam name="T">The field type</typeparam>
         /// <param name="type">The type of the field</param>
@@ -143,46 +113,19 @@ namespace Unity.Cinemachine
         public static T AccessInternalField<T>(this Type type, object obj, string memberName)
         {
             if (string.IsNullOrEmpty(memberName) || (type == null))
-                return default(T);
+                return default;
 
-            System.Reflection.BindingFlags bindingFlags = System.Reflection.BindingFlags.NonPublic;
+            BindingFlags bindingFlags = BindingFlags.NonPublic;
             if (obj != null)
-                bindingFlags |= System.Reflection.BindingFlags.Instance;
+                bindingFlags |= BindingFlags.Instance;
             else
-                bindingFlags |= System.Reflection.BindingFlags.Static;
+                bindingFlags |= BindingFlags.Static;
 
             FieldInfo field = type.GetField(memberName, bindingFlags);
             if ((field != null) && (field.FieldType == typeof(T)))
                 return (T)field.GetValue(obj);
-            else
-                return default(T);
+            return default;
         }
-
-#if false
-        /// <summary>Cheater extension to access internal property of an object</summary>
-        /// <typeparam name="T">The field type</typeparam>
-        /// <param name="type">The type of the field</param>
-        /// <param name="obj">The object to access</param>
-        /// <param name="memberName">The string name of the field to access</param>
-        /// <returns>The value of the field in the objects</returns>
-        public static T AccessInternalProperty<T>(this Type type, object obj, string memberName)
-        {
-            if (string.IsNullOrEmpty(memberName) || (type == null))
-                return default(T);
-
-            System.Reflection.BindingFlags bindingFlags = System.Reflection.BindingFlags.NonPublic;
-            if (obj != null)
-                bindingFlags |= System.Reflection.BindingFlags.Instance;
-            else
-                bindingFlags |= System.Reflection.BindingFlags.Static;
-
-            PropertyInfo pi = type.GetProperty(memberName, bindingFlags);
-            if ((pi != null) && (pi.PropertyType == typeof(T)))
-                return (T)pi.GetValue(obj, null);
-            else
-                return default(T);
-        }
-#endif
 
         /// <summary>Get the object owner of a field.  This method processes
         /// the '.' separator to get from the object that owns the compound field
@@ -222,10 +165,7 @@ namespace Unity.Cinemachine
             }
             else
             {
-                var info = type.GetField(
-                        fields[0], System.Reflection.BindingFlags.Public 
-                            | System.Reflection.BindingFlags.NonPublic 
-                            | System.Reflection.BindingFlags.Instance);
+                var info = type.GetField(fields[0], BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                 obj = info.GetValue(obj);
             }
             return GetParentObject(string.Join(".", fields, 1, fields.Length - 1), obj);

--- a/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
+++ b/com.unity.cinemachine/Editor/Utility/ReflectionHelpers.cs
@@ -64,8 +64,9 @@ namespace Unity.Cinemachine
         /// <returns>The type matching the name, or null if not found</returns>
         public static Type GetTypeInAllDependentAssemblies(string typeName)
         {
-            foreach (Type type in GetTypesInAllDependentAssemblies(t => t.Name == typeName))
-                return type;
+            var iter = GetTypesInAllDependentAssemblies(t => t.Name == typeName).GetEnumerator();
+            if (iter.MoveNext())
+                return iter.Current;
             return null;
         }
 
@@ -75,10 +76,11 @@ namespace Unity.Cinemachine
         public static IEnumerable<Type> GetTypesInAllDependentAssemblies(Predicate<Type> predicate)
         {
             List<Type> foundTypes = new(100);
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            string definedIn = typeof(CinemachineComponentBase).Assembly.GetName().Name;
-            foreach (Assembly assembly in assemblies)
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var definedIn = typeof(CinemachineComponentBase).Assembly.GetName().Name;
+            for (int i = 0; i < assemblies.Length; ++i)
             {
+                var assembly = assemblies[i];
                 if (assembly.GlobalAssemblyCache)
                     continue;
 
@@ -96,8 +98,9 @@ namespace Unity.Cinemachine
 
                 try
                 {
-                    foreach (Type foundType in GetTypesInAssembly(assembly, predicate))
-                        foundTypes.Add(foundType);
+                    var iter = GetTypesInAssembly(assembly, predicate).GetEnumerator();
+                    while (iter.MoveNext())
+                        foundTypes.Add(iter.Current);
                 }
                 catch (Exception) {} // Just skip uncooperative assemblies
             }
@@ -214,8 +217,9 @@ namespace Unity.Cinemachine
         {
             bool doneSomething = false;
             var components = go.GetComponentsInChildren<MonoBehaviour>(true);
-            foreach (var c in components)
+            for (int i = 0; i < components.Length; ++i)
             {
+                var c = components[i];
                 var obj = c as object;
                 if (ScanFields(ref obj, updater))
                 {
@@ -239,8 +243,10 @@ namespace Unity.Cinemachine
                     bindingFlags |= BindingFlags.NonPublic; // you can inspect non-public fields if thy have the attribute
 
                 var fields = obj.GetType().GetFields(bindingFlags);
-                foreach (var f in fields)
+                for (int j = 0; j < fields.Length; ++j)
                 {
+                    var f = fields[j];
+
                     if (!f.IsPublic && f.GetCustomAttribute(typeof(SerializeField)) == null)
                         continue;
 

--- a/com.unity.cinemachine/Editor/Utility/ScriptableObjectUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/ScriptableObjectUtility.cs
@@ -52,11 +52,9 @@ namespace Unity.Cinemachine.Editor
 
             if (trimName)
             {
-                string[] standardNames = new string[] { "Asset", "Attributes", "Container" };
-                foreach (string standardName in standardNames)
-                {
-                    assetName = assetName.Replace(standardName, "");
-                }
+                var standardNames = new string[] { "Asset", "Attributes", "Container" };
+                for (int i = 0; i < standardNames.Length; ++i)
+                    assetName = assetName.Replace(standardNames[i], "");
             }
 
             if (prependFolderName)
@@ -70,7 +68,7 @@ namespace Unity.Cinemachine.Editor
 
         private static ScriptableObject Create(string className, string assetName, string folder)
         {
-            ScriptableObject asset = ScriptableObject.CreateInstance(className);
+            var asset = ScriptableObject.CreateInstance(className);
             if (asset == null)
             {
                 Debug.LogError("failed to create instance of " + className);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -199,6 +199,7 @@ namespace Unity.Cinemachine
         void OnEnable()
         {
             m_BlendManager.OnEnable();
+            m_BlendManager.LookupBlendDelegate = LookupBlend;
 
             s_ActiveBrains.Add(this);
 #if UNITY_EDITOR && CINEMACHINE_UIELEMENTS
@@ -508,8 +509,7 @@ namespace Unity.Cinemachine
 
             float deltaTime = GetEffectiveDeltaTime(false);
             if (!Application.isPlaying || BlendUpdateMethod != BrainUpdateMethods.FixedUpdate)
-                m_BlendManager.UpdateRootFrame(
-                    TopCameraFromPriorityQueue(), DefaultWorldUp, deltaTime, LookupBlend);
+                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), DefaultWorldUp, deltaTime);
 
             m_BlendManager.ComputeCurrentBlend();
 
@@ -560,8 +560,7 @@ namespace Unity.Cinemachine
             // Choose the active vcam and apply it to the Unity camera
             if (BlendUpdateMethod == BrainUpdateMethods.FixedUpdate)
             {
-                m_BlendManager.UpdateRootFrame(
-                    TopCameraFromPriorityQueue(), DefaultWorldUp, Time.fixedDeltaTime, LookupBlend);
+                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), DefaultWorldUp, Time.fixedDeltaTime);
                 ProcessActiveCamera(Time.fixedDeltaTime);
             }
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -170,8 +170,9 @@ namespace Unity.Cinemachine
         {
             m_ExtraStateCache ??= new();
             GetAllExtraStates(m_ExtraStateCache);
-            foreach (var extra in m_ExtraStateCache)
+            for (int i = 0; i < m_ExtraStateCache.Count; ++i)
             {
+                var extra = m_ExtraStateCache[i];
                 if (extra.Vcam != null)
                 {
                     extra.BakedSolution = null;
@@ -509,9 +510,12 @@ namespace Unity.Cinemachine
             currentPath.Clear();
             m_ExtraStateCache ??= new();
             GetAllExtraStates(m_ExtraStateCache);
-            foreach (var e in m_ExtraStateCache)
+            for (int i = 0; i < m_ExtraStateCache.Count; ++i)
+            {
+                var e = m_ExtraStateCache[i];
                 if (e.Vcam != null && e.BakedSolution != null)
                     currentPath.AddRange(e.BakedSolution.GetBakedPath());
+            }
             return originalPath != null;
         }
 
@@ -532,8 +536,9 @@ namespace Unity.Cinemachine
             
             m_ExtraStateCache ??= new();
             GetAllExtraStates(m_ExtraStateCache);
-            foreach (var extra in m_ExtraStateCache)
+            for (int i = 0; i < m_ExtraStateCache.Count; ++i)
             {
+                var extra = m_ExtraStateCache[i];
                 if (extra.Vcam != null && extra.BakedSolution != null)
                 {
                     var solution = extra.BakedSolution.m_Solution;
@@ -550,8 +555,9 @@ namespace Unity.Cinemachine
         {
             m_ExtraStateCache ??= new();
             GetAllExtraStates(m_ExtraStateCache);
-            foreach (var extra in m_ExtraStateCache)
+            for (int i = 0; i < m_ExtraStateCache.Count; ++i)
             {
+                var extra = m_ExtraStateCache[i];
                 if (extra.Vcam != null)
                 {
                     var state = extra.Vcam.State;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -295,13 +295,15 @@ namespace Unity.Cinemachine
         {
             get
             {
-                List<List<Vector3>> list = new List<List<Vector3>>();
-
+                List<List<Vector3>> list = new ();
                 m_extraStateCache ??= new();
                 GetAllExtraStates(m_extraStateCache);
-                foreach (var e in m_extraStateCache)
+                for (int i = 0; i < m_extraStateCache.Count; ++i)
+                {
+                    var e = m_extraStateCache[i];
                     if (e.DebugResolutionPath != null && e.DebugResolutionPath.Count > 0)
                         list.Add(e.DebugResolutionPath);
+                }
                 return list;
             }
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineMixingCamera.cs
@@ -231,7 +231,7 @@ namespace Unity.Cinemachine
                 }
             }
             m_LiveChildPercent = totalWeight > 0.001f ? (highestWeight * 100 / totalWeight) : 0;
-            SetLiveChild(liveChild, worldUp, deltaTime, null);
+            SetLiveChild(liveChild, worldUp, deltaTime);
             InvokePostPipelineStageCallback(this, CinemachineCore.Stage.Finalize, ref m_CameraState, deltaTime);
             PreviousStateIsValid = true;
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -173,9 +173,8 @@ namespace Unity.Cinemachine
 
             // Create the parent lookup
             m_StateParentLookup = new Dictionary<int, int>();
-            if (HashOfParent != null)
-                foreach (var i in HashOfParent)
-                    m_StateParentLookup[i.Hash] = i.HashOfParent;
+            for (int i = 0; HashOfParent != null && i < HashOfParent.Length; ++i)
+                m_StateParentLookup[HashOfParent[i].Hash] = HashOfParent[i].HashOfParent;
 
             // Zap the cached current instructions
             m_HashCache = null;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -1,5 +1,5 @@
-﻿using UnityEngine;
-#if CINEMACHINE_UGUI
+﻿#if CINEMACHINE_UGUI
+using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.Serialization;
 
@@ -410,22 +410,21 @@ namespace Unity.Cinemachine
                 if (s_CanvasesAndTheirOwners != null)
                 {
                     List<UnityEngine.Object> toDestroy = null;
-                    foreach (var v in s_CanvasesAndTheirOwners)
+                    var iter = s_CanvasesAndTheirOwners.GetEnumerator();
+                    while (iter.MoveNext())
                     {
+                        var v = iter.Current;
                         if (v.Value == null)
                         {
-                            if (toDestroy == null)
-                                toDestroy = new List<UnityEngine.Object>();
+                            toDestroy ??= new List<UnityEngine.Object>();
                             toDestroy.Add(v.Key);
                         }
                     }
-                    if (toDestroy != null)
+                    for (int i = 0; toDestroy != null && i < toDestroy.Count; ++i)
                     {
-                        foreach (var o in toDestroy)
-                        {
-                            RemoveCanvas(o);
-                            RuntimeUtility.DestroyObject(o);
-                        }
+                        var o = toDestroy[i];
+                        RemoveCanvas(o);
+                        RuntimeUtility.DestroyObject(o);
                     }
                 }
             }
@@ -436,24 +435,11 @@ namespace Unity.Cinemachine
             }
             public static void AddCanvas(UnityEngine.Object canvas, UnityEngine.Object owner)
             {
-                if (s_CanvasesAndTheirOwners == null)
-                    s_CanvasesAndTheirOwners = new Dictionary<UnityEngine.Object, UnityEngine.Object>();
+                s_CanvasesAndTheirOwners ??= new ();
                 s_CanvasesAndTheirOwners.Add(canvas, owner);
             }
         }
 #endif
     }
 }
-#else
-// We need this dummy MonoBehaviour for Unity to properly recognize this script asset.
-namespace Unity.Cinemachine
-{
-    /// <summary>
-    /// An add-on module for CinemachineCamera that places an image in screen space
-    /// over the camera's output.
-    /// </summary>
-    [AddComponentMenu("")] // Hide in menu
-    public class CinemachineStoryboard : MonoBehaviour {}
-}
 #endif
-

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -174,6 +174,10 @@ namespace Unity.Cinemachine
         /// <summary>Has OnEnable been called?</summary>
         public bool IsInitialized => m_FrameStack.Count > 0;
 
+        /// <summary>This holds the function that performs a blend lookup.
+        /// This is used to find a blend definition, when a blend is being created.</summary>
+        public CinemachineBlendDefinition.LookupBlendDelegate LookupBlendDelegate { get; set; }
+
         /// <summary>Clear the state of the root frame: no current camera, no blend.</summary>
         public void ResetRootFrame()
         {
@@ -194,10 +198,8 @@ namespace Unity.Cinemachine
         /// <param name="activeCamera">Current active camera (pre-override)</param>
         /// <param name="up">Current world up</param>
         /// <param name="deltaTime">How much time has elapsed, for computing blends</param>
-        /// <param name="lookupBlend">Delegate to use to find a blend definition, when a blend is being created</param>
         public void UpdateRootFrame(
-            ICinemachineCamera activeCamera, Vector3 up, float deltaTime, 
-            CinemachineBlendDefinition.LookupBlendDelegate lookupBlend)
+            ICinemachineCamera activeCamera, Vector3 up, float deltaTime)
         {
             // Make sure there is a first stack frame
             if (m_FrameStack.Count == 0)
@@ -211,11 +213,11 @@ namespace Unity.Cinemachine
                 bool backingOutOfBlend = false;
 
                 // Do we need to create a game-play blend?
-                if (lookupBlend != null && activeCamera != null && activeCamera.IsValid
+                if (LookupBlendDelegate != null && activeCamera != null && activeCamera.IsValid
                     && outgoingCamera != null && outgoingCamera.IsValid && deltaTime >= 0)
                 {
                     // Create a blend (curve will be null if a cut)
-                    var blendDef = lookupBlend(outgoingCamera, activeCamera);
+                    var blendDef = LookupBlendDelegate(outgoingCamera, activeCamera);
                     if (blendDef.BlendCurve != null && blendDef.BlendTime > kEpsilon)
                     {
                         // Are we backing out of a blend-in-progress?

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -218,8 +218,8 @@ namespace Unity.Cinemachine
         public override void OnTargetObjectWarped(Transform target, Vector3 positionDelta)
         {
             UpdateCameraCache();
-            foreach (var vcam in m_ChildCameras)
-                vcam.OnTargetObjectWarped(target, positionDelta);
+            for (int i = 0; i < m_ChildCameras.Count; ++i)
+                m_ChildCameras[i].OnTargetObjectWarped(target, positionDelta);
             base.OnTargetObjectWarped(target, positionDelta);
         }
 
@@ -231,8 +231,8 @@ namespace Unity.Cinemachine
         public override void ForceCameraPosition(Vector3 pos, Quaternion rot)
         {
             UpdateCameraCache();
-            foreach (var vcam in m_ChildCameras)
-                vcam.ForceCameraPosition(pos, rot);
+            for (int i = 0; i < m_ChildCameras.Count; ++i)
+                m_ChildCameras[i].ForceCameraPosition(pos, rot);
             base.ForceCameraPosition(pos, rot);
         }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -70,6 +70,7 @@ namespace Unity.Cinemachine
         {
             base.OnEnable();
             m_BlendManager.OnEnable();
+            m_BlendManager.LookupBlendDelegate = LookupBlend;
             InvalidateCameraCache();
         }
 
@@ -170,7 +171,7 @@ namespace Unity.Cinemachine
                 best.gameObject.SetActive(true);
                 best.UpdateCameraState(worldUp, deltaTime);
             }
-            SetLiveChild(best, worldUp, deltaTime, LookupBlend);
+            SetLiveChild(best, worldUp, deltaTime);
 
             // Special case to handle being called from OnTransitionFromCamera() - GML todo: fix this
             if (m_TransitioningFrom != null && !IsBlending && LiveChild != null)
@@ -196,7 +197,9 @@ namespace Unity.Cinemachine
         /// <param name="incoming">The camera we're blending to.</param>
         /// <returns>The blend to use for this camera transition.</returns>
         protected virtual CinemachineBlendDefinition LookupBlend(ICinemachineCamera outgoing, ICinemachineCamera incoming)
-            => CinemachineBlenderSettings.LookupBlend(outgoing, incoming, DefaultBlend, CustomBlends, this);
+        {
+            return CinemachineBlenderSettings.LookupBlend(outgoing, incoming, DefaultBlend, CustomBlends, this);
+        }
             
         /// <summary>
         /// Choose the appropriate current camera from among the ChildCameras, based on current state.
@@ -278,12 +281,10 @@ namespace Unity.Cinemachine
         /// <param name="activeCamera">Current active camera</param>
         /// <param name="worldUp">Current world up</param>
         /// <param name="deltaTime">Current deltaTime applicable for this frame</param>
-        /// <param name="lookupBlend">Delegate to use to find a blend definition, when a blend is being created</param>
         protected void SetLiveChild(
-            ICinemachineCamera activeCamera, Vector3 worldUp, float deltaTime,
-            CinemachineBlendDefinition.LookupBlendDelegate lookupBlend)
+            ICinemachineCamera activeCamera, Vector3 worldUp, float deltaTime)
         {
-            m_BlendManager.UpdateRootFrame(activeCamera, worldUp, deltaTime, lookupBlend);
+            m_BlendManager.UpdateRootFrame(activeCamera, worldUp, deltaTime);
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(this, worldUp, deltaTime);
         }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineExtension.cs
@@ -59,8 +59,8 @@ namespace Unity.Cinemachine
             System.Array.Sort(extensions, (x, y) => 
                 UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(y)) 
                     - UnityEditor.MonoImporter.GetExecutionOrder(UnityEditor.MonoScript.FromMonoBehaviour(x)));
-            foreach (var e in extensions)
-                e.ConnectToVcam(true);
+            for (int i = 0; i < extensions.Length; ++i)
+                extensions[i].ConnectToVcam(true);
         }
 #endif
         internal void EnsureStarted() => ConnectToVcam(true);
@@ -169,8 +169,11 @@ namespace Unity.Cinemachine
         {
             list.Clear();
             if (m_ExtraState != null)
-                foreach (var v in m_ExtraState)
-                    list.Add(v.Value as T);
+            {
+                var iter = m_ExtraState.GetEnumerator();
+                while (iter.MoveNext())
+                    list.Add(iter.Current.Value as T);
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -502,8 +502,8 @@ namespace Unity.Cinemachine
         {
             var vcams = Resources.FindObjectsOfTypeAll(
                 typeof(CinemachineVirtualCameraBase)) as CinemachineVirtualCameraBase[];
-            foreach (var vcam in vcams)
-                vcam.LookAtTargetChanged = vcam.FollowTargetChanged = true;
+            for (int i = 0; i < vcams.Length; ++i)
+                vcams[i].LookAtTargetChanged = vcams[i].FollowTargetChanged = true;
         }
 #endif
 
@@ -705,8 +705,8 @@ namespace Unity.Cinemachine
 #else
                 var vcams = FindObjectsOfType<CinemachineVirtualCameraBase>(true);
 #endif
-                foreach (var vcam in vcams)
-                    vcam.InvalidateCachedTargets();
+                for (int i = 0; i < vcams.Length; ++i)
+                    vcams[i].InvalidateCachedTargets();
             }
         }
 #endif

--- a/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
+++ b/com.unity.cinemachine/Runtime/Core/ConfinerOven.cs
@@ -134,8 +134,9 @@ namespace Unity.Cinemachine
                 
                 bool DoesIntersectOriginal(IntPoint l1, IntPoint l2)
                 {
-                    foreach (var original in m_OriginalPolygon)
+                    for (int p = 0; p < m_OriginalPolygon.Count; ++p)
                     {
+                        var original = m_OriginalPolygon[p];
                         var numPoints = original.Count;
                         for (var i = 0; i < numPoints; ++i)
                             if (FindIntersection(l1, l2, original[i], original[(i + 1) % numPoints]) == 2)

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -35,6 +35,7 @@ namespace Unity.Cinemachine
     [Serializable]
     internal class InputAxisControllerManager<T> where T : IInputAxisReader, new ()
     {
+        [NonReorderable]
         public List<InputAxisControllerBase<T>.Controller> Controllers = new ();
 
         /// Axes are dynamically discovered by querying behaviours implementing <see cref="IInputAxisOwner"/>

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -123,8 +123,9 @@ namespace Unity.Cinemachine
 
             // Rebuild the controller list, recycling existing ones to preserve the settings
             List<InputAxisControllerBase<T>.Controller> newControllers = new();
-            foreach (var t in m_AxisOwners)
+            for (int j = 0; j < m_AxisOwners.Count; ++j)
             {
+                var t = m_AxisOwners[j];
                 var startIndex = m_Axes.Count;
                 t.GetInputAxes(m_Axes);
                 for (int i = startIndex; i < m_Axes.Count; ++i)

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineInputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineInputAxisController.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 #if CINEMACHINE_UNITY_INPUTSYSTEM
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Users;
-using System.Linq;
 #endif
 
 namespace Unity.Cinemachine
@@ -179,8 +178,14 @@ namespace Unity.Cinemachine
                         m_CachedAction.Enable();
 
                     // local function to wrap the lambda which otherwise causes a tiny gc
-                    InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) => 
-                        user.actions.First(x => x.id == aRef.action.id);
+                    static InputAction GetFirstMatch(in InputUser user, InputActionReference aRef) 
+                    {
+                        var iter = user.actions.GetEnumerator();
+                        while (iter.MoveNext())
+                            if (iter.Current.id == aRef.action.id)
+                                return iter.Current;
+                        return null;
+                    }
                 }
 
                 // Update enabled status

--- a/com.unity.cinemachine/Runtime/Impulse/CinemachineImpulseDefinition.cs
+++ b/com.unity.cinemachine/Runtime/Impulse/CinemachineImpulseDefinition.cs
@@ -225,8 +225,9 @@ namespace Unity.Cinemachine
         static void CreateStandardShapes()
         {
             int max = 0;
-            foreach (var value in Enum.GetValues(typeof(ImpulseShapes)))
-                max = Mathf.Max(max, (int)value);
+            var iter = Enum.GetValues(typeof(ImpulseShapes)).GetEnumerator();
+            while (iter.MoveNext())
+                max = Mathf.Max(max, (int)iter.Current);
             s_StandardShapes = new AnimationCurve[max + 1];
 
             s_StandardShapes[(int)ImpulseShapes.Recoil] = new AnimationCurve(new Keyframe[] 

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -93,14 +93,11 @@ namespace Unity.Cinemachine
             public void CreateProfileCopy(PostProcessProfile source)
             {
                 DestroyProfileCopy();
-                PostProcessProfile profile = ScriptableObject.CreateInstance<PostProcessProfile>();
-                if (source != null)
+                var profile = ScriptableObject.CreateInstance<PostProcessProfile>();
+                for (int i = 0; source != null && i < source.settings.Count; ++i)
                 {
-                    foreach (var item in source.settings)
-                    {
-                        var itemCopy = Instantiate(item);
-                        profile.settings.Add(itemCopy);
-                    }
+                    var itemCopy = Instantiate(source.settings[i]);
+                    profile.settings.Add(itemCopy);
                 }
                 ProfileCopy = profile;
             }

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -100,14 +100,11 @@ namespace Unity.Cinemachine
             {
                 DestroyProfileCopy();
                 VolumeProfile profile = ScriptableObject.CreateInstance<VolumeProfile>();
-                if (source != null)
+                for (int i = 0; source != null && i < source.components.Count; ++i)
                 {
-                    foreach (var item in source.components)
-                    {
-                        var itemCopy = Instantiate(item);
-                        profile.components.Add(itemCopy);
-                        profile.isDirty = true;
-                    }
+                    var itemCopy = Instantiate(source.components[i]);
+                    profile.components.Add(itemCopy);
+                    profile.isDirty = true;
                 }
                 ProfileCopy = profile;
             }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/HelpUI.prefab
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/HelpUI.prefab
@@ -11,6 +11,8 @@ GameObject:
   - component: {fileID: 2451271811042757136}
   - component: {fileID: 6712450386776849522}
   - component: {fileID: 6668015293666917239}
+  - component: {fileID: 8124552956113825472}
+  - component: {fileID: 5485381422717872303}
   m_Layer: 5
   m_Name: HelpUI
   m_TagString: Untagged
@@ -63,4 +65,52 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   VisibleAtStart: 0
   HelpTitle: 
-  HelpText: Put your help text here.
+  HelpText: 
+  OnHelpDismissed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8124552956113825472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9138370430051789472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &5485381422717872303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9138370430051789472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/ReduceGroupWeightWhenBelowFloor.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/ReduceGroupWeightWhenBelowFloor.cs
@@ -27,8 +27,10 @@ namespace Unity.Cinemachine.Samples
         {
             // iterate through each target in the targetGroup
             var floor = Floor.position.y;
-            foreach (var target in m_TargetGroup.Targets)
+            for (int i = 0; i < m_TargetGroup.Targets.Count; ++i)
             {
+                var target = m_TargetGroup.Targets[i];
+
                 // calculate the distance between target and the Floor along the Y axis
                 var distanceBelow = floor - target.Object.position.y;
 

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SamplesDynamicUI.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SamplesDynamicUI.cs
@@ -53,9 +53,9 @@ namespace Unity.Cinemachine.Samples
                 Debug.LogError("Cannot find TogglesAndButtons.  Is the source asset set in the UIDocument?");
                 return;
             }
-            
-            foreach (var item in Buttons)
+            for (int i = 0; i < Buttons.Count; ++i)
             {
+                var item = Buttons[i];
                 if (item.IsToggle.Enabled)
                 {
                     var toggle = new Toggle
@@ -87,8 +87,8 @@ namespace Unity.Cinemachine.Samples
 
         void OnDisable()
         {
-            foreach (var element in m_DynamicElements)
-                m_Root.Remove(element);
+            for (int i = 0; i < m_DynamicElements.Count; ++i)
+                m_Root.Remove(m_DynamicElements[i]);
             m_DynamicElements.Clear();
         }
     }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Shaders.meta
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98181ffecbfb10b4a985bc5c8296d94d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Samples~/Shared Assets/Timelines.meta
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Timelines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 847c9dd7235bcd94d9f751f9ad2fa589
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
+++ b/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
@@ -55,8 +55,7 @@ namespace Unity.Cinemachine.Tests.Editor
 
         void ProcessFrame(ICinemachineCamera cam, float deltaTime)
         {
-            m_BlendManager.UpdateRootFrame(cam, Vector3.up, deltaTime, (outgoing, incoming)
-                => new (CinemachineBlendDefinition.Styles.EaseInOut, 1)); // constant blend time of 1
+            m_BlendManager.UpdateRootFrame(cam, Vector3.up, deltaTime);
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(m_Mixer, Vector3.up, deltaTime);
         }
@@ -64,6 +63,9 @@ namespace Unity.Cinemachine.Tests.Editor
         [Test]
         public void TestEvents()
         {
+            m_BlendManager.LookupBlendDelegate = (outgoing, incoming)
+                => new (CinemachineBlendDefinition.Styles.EaseInOut, 1); // constant blend time of 1
+
             ResetCounters();
             m_BlendManager.ResetRootFrame();
 


### PR DESCRIPTION
### Purpose of this PR

Optimization.
CMCL-1446.

Notes:
- left some Linq and foreach in upgrader and samples importer.  Not worth the effort to optimize that.
- clipper has lots of suboptimal foreach usage.  Left it alone.
- did not optimize obsolete or deprecated code.
- also found and fixed a GC alloc problem introduced by brain refactor

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

