### PR TITLE
CMCL-0000: 2D platformer fixes

### DIFF
--- a/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/2D Platformer.unity
+++ b/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/2D Platformer.unity
@@ -507,7 +507,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 234952069}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -14.543061, y: 5.6132784, z: -9.80871}
+  m_LocalPosition: {x: -14.536392, y: 5.6132784, z: -9.80871}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -692,7 +692,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 289220589}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -14.543061, y: 7.0932784, z: -9.80871}
+  m_LocalPosition: {x: -14.536392, y: 7.0932784, z: -9.80871}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -13448,7 +13448,7 @@ GameObject:
   - component: {fileID: 1074941660}
   - component: {fileID: 1074941662}
   m_Layer: 0
-  m_Name: 2D Camera
+  m_Name: Platformer Camera 2D
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -14112,7 +14112,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1620057287}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -14.543061, y: 5.6132784, z: -9.80871}
+  m_LocalPosition: {x: -14.536392, y: 5.6132784, z: -9.80871}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -14375,7 +14375,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1719199625}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -14.89387, y: 7.0932784, z: -9.80871}
+  m_LocalPosition: {x: -14.900539, y: 7.0932784, z: -9.80871}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -14562,7 +14562,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7726835707821803386}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.3245964, y: 5.6241198, z: -10}
+  m_LocalPosition: {x: -3.3179302, y: 5.6241198, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/GameControl.cs
+++ b/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/GameControl.cs
@@ -1,23 +1,25 @@
-using Unity.Cinemachine;
 using UnityEngine;
 
-public class GameControl : MonoBehaviour
+namespace Unity.Cinemachine.Samples
 {
-    public CinemachineVirtualCameraBase InitialCamera;
-    public Transform Player;
-    public Vector3 StartPosition;
-
-    public void RestartGame()
+    public class GameControl : MonoBehaviour
     {
-        // Move the plyer to its start position
-        Player.transform.SetLocalPositionAndRotation(StartPosition, Quaternion.identity);
+        public CinemachineVirtualCameraBase InitialCamera;
+        public Transform Player;
+        public Vector3 StartPosition;
 
-        // Reset the camera state, to cancel damping
-        CinemachineCore.ResetCameraState();
+        public void RestartGame()
+        {
+            // Move the plyer to its start position
+            Player.transform.SetLocalPositionAndRotation(StartPosition, Quaternion.identity);
 
-        // Activate the initial camera, deactivate the rest
-        for (int i = 0; i < CinemachineCore.VirtualCameraCount; ++i)
-            CinemachineCore.GetVirtualCamera(i).gameObject.SetActive(
-                CinemachineCore.GetVirtualCamera(i) == InitialCamera);
+            // Reset the camera state, to cancel damping
+            CinemachineCore.ResetCameraState();
+
+            // Activate the initial camera, deactivate the rest
+            for (int i = 0; i < CinemachineCore.VirtualCameraCount; ++i)
+                CinemachineCore.GetVirtualCamera(i).gameObject.SetActive(
+                    CinemachineCore.GetVirtualCamera(i) == InitialCamera);
+        }
     }
 }

--- a/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/Platformer Camera 2D.cs
+++ b/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/Platformer Camera 2D.cs
@@ -23,7 +23,7 @@ public class PlatformerCamera2D : CinemachineCameraManagerBase
     [Space]
     public float FallingSpeedThreshold = 0.1f;
 
-    // The cameras in these fields must be GameObject childen of the manager camera.
+    // The cameras in these fields must be GameObject children of the manager camera.
     [Header("State Cameras")]
     [ChildCameraProperty] public CinemachineVirtualCameraBase RightCamera;
     [ChildCameraProperty] public CinemachineVirtualCameraBase LeftCamera;

--- a/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/Platformer Camera 2D.cs
+++ b/com.unity.cinemachine/Samples~/2D Samples/2D Platformer/Platformer Camera 2D.cs
@@ -1,72 +1,79 @@
 using UnityEngine;
-using Unity.Cinemachine;
 
-/// <summary>
-/// This class inherits CinemachineCameraManagerBase, which is a convenient base class for
-/// making complex cameras by transitioning between a number of worker cameras, depending
-/// on some arbitrary game state.
-/// 
-/// In this case, we monitor the player's facing direction and motion, and select a camera
-/// with the appropriate settings.  CinemachineCameraManagerBase takes care of handling the blends.
-/// </summary>
-[ExecuteAlways]
-public class PlatformerCamera2D : CinemachineCameraManagerBase
+namespace Unity.Cinemachine.Samples
 {
-    public enum PlayerState
-    {
-        Right,
-        Left,
-        FallingRight,
-        FallingLeft
-    }
-
-    [Space]
-    public float FallingSpeedThreshold = 0.1f;
-
-    // The cameras in these fields must be GameObject children of the manager camera.
-    [Header("State Cameras")]
-    [ChildCameraProperty] public CinemachineVirtualCameraBase RightCamera;
-    [ChildCameraProperty] public CinemachineVirtualCameraBase LeftCamera;
-    [ChildCameraProperty] public CinemachineVirtualCameraBase FallingRightCamera;
-    [ChildCameraProperty] public CinemachineVirtualCameraBase FallingLeftCamera;
-
-    Rigidbody2D m_Player;
-
-    protected override void OnEnable()
-    {
-        base.OnEnable();
-        var target = DefaultTarget.Enabled ? DefaultTarget.Target.TrackingTarget : null;
-        if (target != null)
-            target.TryGetComponent(out m_Player);
-        if (m_Player == null)
-            Debug.LogError("PlatformerCamera2D: Default target must be set to Player with a Rigidbody2D");
-    }
-   
-    PlayerState GetPlayerState()
-    {
-        bool isLeft = false;
-        bool isFalling = false;
-        if (m_Player != null)
-        {
-            isLeft = Mathf.Abs(m_Player.transform.rotation.eulerAngles.y) > 90;
-            isFalling = m_Player.velocity.y < -FallingSpeedThreshold;
-        }
-        if (isFalling)
-            return isLeft ? PlayerState.FallingLeft : PlayerState.FallingRight;
-        return isLeft ? PlayerState.Left : PlayerState.Right;
-    }
-
     /// <summary>
-    /// Choose the appropriate child camera depending on player state.
+    /// This class inherits CinemachineCameraManagerBase, which is a convenient base class for
+    /// making complex cameras by transitioning between a number of worker cameras, depending
+    /// on some arbitrary game state.
+    /// 
+    /// In this case, we monitor the player's facing direction and motion, and select a camera
+    /// with the appropriate settings.  CinemachineCameraManagerBase takes care of handling the blends.
     /// </summary>
-    protected override CinemachineVirtualCameraBase ChooseCurrentCamera(Vector3 worldUp, float deltaTime)
+    [ExecuteAlways]
+    public class PlatformerCamera2D : CinemachineCameraManagerBase
     {
-        return GetPlayerState() switch
+        public enum PlayerState
         {
-            PlayerState.Left => LeftCamera,
-            PlayerState.FallingRight => FallingRightCamera,
-            PlayerState.FallingLeft => FallingLeftCamera,
-            _ => RightCamera,
-        };
+            Right,
+            Left,
+            FallingRight,
+            FallingLeft
+        }
+
+        [Space]
+        public float FallingSpeedThreshold = 0.1f;
+
+        // The cameras in these fields must be GameObject children of the manager camera.
+        [Header("State Cameras")]
+        [ChildCameraProperty] public CinemachineVirtualCameraBase RightCamera;
+        [ChildCameraProperty] public CinemachineVirtualCameraBase LeftCamera;
+        [ChildCameraProperty] public CinemachineVirtualCameraBase FallingRightCamera;
+        [ChildCameraProperty] public CinemachineVirtualCameraBase FallingLeftCamera;
+
+        Rigidbody2D m_Player;
+        SimplePlayerAnimator m_PlayerAnimator;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            var target = DefaultTarget.Enabled ? DefaultTarget.Target.TrackingTarget : null;
+            if (target != null)
+            {
+                target.TryGetComponent(out m_Player);
+                m_PlayerAnimator = target.GetComponentInChildren<SimplePlayerAnimator>();
+            }
+            if (m_Player == null)
+                Debug.LogError("PlatformerCamera2D: Default target must be set to Player with a Rigidbody2D");
+        }
+   
+        PlayerState GetPlayerState()
+        {
+            bool isLeft = false;
+            bool isFalling = false;
+            if (m_Player != null)
+            {
+                if (m_PlayerAnimator != null)
+                    isLeft = Mathf.Abs(m_PlayerAnimator.transform.rotation.eulerAngles.y) > 90;
+                isFalling = m_Player.velocity.y < -FallingSpeedThreshold;
+            }
+            if (isFalling)
+                return isLeft ? PlayerState.FallingLeft : PlayerState.FallingRight;
+            return isLeft ? PlayerState.Left : PlayerState.Right;
+        }
+
+        /// <summary>
+        /// Choose the appropriate child camera depending on player state.
+        /// </summary>
+        protected override CinemachineVirtualCameraBase ChooseCurrentCamera(Vector3 worldUp, float deltaTime)
+        {
+            return GetPlayerState() switch
+            {
+                PlayerState.Left => LeftCamera,
+                PlayerState.FallingRight => FallingRightCamera,
+                PlayerState.FallingLeft => FallingLeftCamera,
+                _ => RightCamera,
+            };
+        }
     }
 }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player 2D.prefab
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player 2D.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 2662089159087876488}
   - component: {fileID: 1278834370067618843}
   - component: {fileID: 9054663932804666460}
-  - component: {fileID: 3754672446329553397}
   - component: {fileID: 3080082640309192527}
   m_Layer: 0
   m_Name: Player 2D
@@ -125,7 +124,9 @@ MonoBehaviour:
   Landed:
     m_PersistentCalls:
       m_Calls: []
+  CameraOverride: {fileID: 0}
   PlayerGeometry: {fileID: 2474673035909645045}
+  MotionControlWhileInAir: 0
 --- !u!114 &1278834370067618843
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -146,8 +147,6 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
-        InputAction: {fileID: -1680190386980627800, guid: cb572737576f6df4182085d6bbea2294, type: 3}
-        Gain: 1
         LegacyInput: Horizontal
         LegacyGain: 1
       InputValue: 0
@@ -158,8 +157,6 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
-        InputAction: {fileID: -1680190386980627800, guid: cb572737576f6df4182085d6bbea2294, type: 3}
-        Gain: 1
         LegacyInput: Vertical
         LegacyGain: 1
       InputValue: 0
@@ -170,8 +167,6 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
-        InputAction: {fileID: -8322308610609176083, guid: cb572737576f6df4182085d6bbea2294, type: 3}
-        Gain: 1
         LegacyInput: Jump
         LegacyGain: 1
       InputValue: 0
@@ -182,16 +177,12 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
-        InputAction: {fileID: 7062761312785054794, guid: cb572737576f6df4182085d6bbea2294, type: 3}
-        Gain: 1
         LegacyInput: Fire3
         LegacyGain: 1
       InputValue: 0
       Driver:
         AccelTime: 0
         DecelTime: 0
-  PlayerIndex: -1
-  AutoEnableInputs: 1
 --- !u!70 &9054663932804666460
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -226,41 +217,6 @@ CapsuleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0.015956998, y: 0.450768}
   m_Size: {x: 0.18706203, y: 0.9190235}
-  m_Direction: 0
---- !u!70 &3754672446329553397
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7058214899331077284}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.015564799, y: 0.72890985}
-  m_Size: {x: 0.37782025, y: 0.37782025}
   m_Direction: 0
 --- !u!61 &3080082640309192527
 BoxCollider2D:

--- a/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player 2D.prefab
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player 2D.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2662089159087876488}
   - component: {fileID: 1278834370067618843}
   - component: {fileID: 9054663932804666460}
+  - component: {fileID: 3754672446329553397}
   - component: {fileID: 3080082640309192527}
   m_Layer: 0
   m_Name: Player 2D
@@ -124,9 +125,7 @@ MonoBehaviour:
   Landed:
     m_PersistentCalls:
       m_Calls: []
-  CameraOverride: {fileID: 0}
   PlayerGeometry: {fileID: 2474673035909645045}
-  MotionControlWhileInAir: 0
 --- !u!114 &1278834370067618843
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +146,8 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
+        InputAction: {fileID: -1680190386980627800, guid: cb572737576f6df4182085d6bbea2294, type: 3}
+        Gain: 1
         LegacyInput: Horizontal
         LegacyGain: 1
       InputValue: 0
@@ -157,6 +158,8 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
+        InputAction: {fileID: -1680190386980627800, guid: cb572737576f6df4182085d6bbea2294, type: 3}
+        Gain: 1
         LegacyInput: Vertical
         LegacyGain: 1
       InputValue: 0
@@ -167,6 +170,8 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
+        InputAction: {fileID: -8322308610609176083, guid: cb572737576f6df4182085d6bbea2294, type: 3}
+        Gain: 1
         LegacyInput: Jump
         LegacyGain: 1
       InputValue: 0
@@ -177,12 +182,16 @@ MonoBehaviour:
       Owner: {fileID: 2662089159087876488}
       Enabled: 1
       Input:
+        InputAction: {fileID: 7062761312785054794, guid: cb572737576f6df4182085d6bbea2294, type: 3}
+        Gain: 1
         LegacyInput: Fire3
         LegacyGain: 1
       InputValue: 0
       Driver:
         AccelTime: 0
         DecelTime: 0
+  PlayerIndex: -1
+  AutoEnableInputs: 1
 --- !u!70 &9054663932804666460
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -217,6 +226,41 @@ CapsuleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0.015956998, y: 0.450768}
   m_Size: {x: 0.18706203, y: 0.9190235}
+  m_Direction: 0
+--- !u!70 &3754672446329553397
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7058214899331077284}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.015564799, y: 0.72890985}
+  m_Size: {x: 0.37782025, y: 0.37782025}
   m_Direction: 0
 --- !u!61 &3080082640309192527
 BoxCollider2D:

--- a/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player.prefab.meta
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Prefabs/Player.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5031f047fb15c4d299e8802a9e36a5d6
+guid: 4d8d7a9a98d3f4ac2967d48094ea010f
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -64,9 +64,6 @@ namespace Unity.Cinemachine.Samples
         public enum UpModes { Player, World };
         public UpModes UpMode = UpModes.World;
 
-        [Tooltip("Override the main camera. Useful for split screen games.")]
-        public Camera CameraOverride;
-        
         Vector3 m_CurrentVelocityXZ;
         Vector3 m_LastInput;
         float m_CurrentVelocityY;

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -36,9 +36,6 @@ namespace Unity.Cinemachine.Samples
         [Tooltip("This event is sent when the player lands after a jump.")]
         public UnityEvent Landed = new ();
         
-        [Tooltip("Override the main camera. Useful for split screen games.")]
-        public Camera CameraOverride;
-
         public void EnableLockCursor(bool enable) => LockCursor = enable;
 
         /// Report the available input axes to the input axis controller.
@@ -64,6 +61,9 @@ namespace Unity.Cinemachine.Samples
         public enum UpModes { Player, World };
         public UpModes UpMode = UpModes.World;
 
+        [Tooltip("Override the main camera. Useful for split screen games.")]
+        public Camera CameraOverride;
+        
         Vector3 m_CurrentVelocityXZ;
         Vector3 m_LastInput;
         float m_CurrentVelocityY;


### PR DESCRIPTION
### Purpose of this PR
A couple of minor fixes:
- Warning caused by overriding parent classes CameraOverride property. -> Fix: remove in child and use parent's.
- Removed duplicate capsule collider from Player 2D prefab.

Found bug: Left camera is never activated, because it depends on the Follow Target's rotation and not on the PlayerGeometry (Animated Cameron's rotation).
Possible fix is to add a `Transform PlayerGeometry` property to `PlatformerCamera2D` like `SimplePlayerController2D`, and using that to determine left/right orientation.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested (in URP and built-in)

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk
### Comments to reviewers
### Package version