### PR TITLE
CMCL-1473: Improve handling of nested blends

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [Unreleased]
 
 ### Fixed
 

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Improve handling of nested blends
+
+
 ## [3.0.0-pre.5] - 2023-04-25
 
 ### Fixed

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -8,7 +8,7 @@ namespace Unity.Cinemachine
     /// It takes care of looking up BlendDefinitions when blends need to be created,
     /// and it generates ActivationEvents for camweras when necessary.
     /// </summary>
-    internal class BlendManager : CameraBlendStack
+    class BlendManager : CameraBlendStack
     {
         // Current Brain State - result of all frames.  Blend camB is "current" camera always
         CinemachineBlend m_CurrentLiveCameras = new (null, null, null, 0, 0);
@@ -25,7 +25,7 @@ namespace Unity.Cinemachine
         static ICinemachineCamera DeepCamBFromBlend(CinemachineBlend blend)
         {
             var cam = blend?.CamB;
-            while (cam is BlendSourceVirtualCamera bs)
+            while (cam is NestedBlendSource bs)
                 cam = bs.Blend.CamB;
             if (cam != null && cam.IsValid)
                 return cam;
@@ -82,7 +82,7 @@ namespace Unity.Cinemachine
             {
                 if (cam == m_CurrentLiveCameras.CamA)
                     return true;
-                if (m_CurrentLiveCameras.CamA is BlendSourceVirtualCamera b && b.Blend.Uses(cam))
+                if (m_CurrentLiveCameras.CamA is NestedBlendSource b && b.Blend.Uses(cam))
                     return true;
             }
             return false;
@@ -175,12 +175,12 @@ namespace Unity.Cinemachine
             // local method - find all the live cameras in a blend
             static void CollectLiveCameras(CinemachineBlend blend, ref List<ICinemachineCamera> cams)
             {
-                if (blend.CamA is BlendSourceVirtualCamera a && a.Blend != null)
+                if (blend.CamA is NestedBlendSource a && a.Blend != null)
                     CollectLiveCameras(a.Blend, ref cams);
                 else if (blend.CamA != null)
                     cams.Add(blend.CamA);
 
-                if (blend.CamB is BlendSourceVirtualCamera b && b.Blend != null)
+                if (blend.CamB is NestedBlendSource b && b.Blend != null)
                     CollectLiveCameras(b.Blend, ref cams);
                 else if (blend.CamB != null)
                     cams.Add(blend.CamB);

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -63,11 +63,12 @@ namespace Unity.Cinemachine
         {
             public int Id;
             public int Priority;
-            public readonly CinemachineBlend Source = new (null, null, null, 1, 0);
+            public readonly CinemachineBlend Source = new (null, null, null, 0, 0);
             public float DeltaTimeOverride;
 
             // If blending in from a snapshot, this holds the source state
             readonly SnapshotBlendSource m_Snapshot = new ();
+            ICinemachineCamera m_SnapshotSource;
             float m_SnapshotBlendWeight;
 
             public StackFrame() : base(new (null, null, null, 0, 0)) {}
@@ -84,11 +85,12 @@ namespace Unity.Cinemachine
                     return cam;
                 }
                 // A snapshot is needed
-                if (m_Snapshot.Source != cam || m_SnapshotBlendWeight > weight)
+                if (m_SnapshotSource != cam || m_SnapshotBlendWeight > weight)
                 {
                     // At this point we're pretty sure this is a new blend,
                     // so we take a new snapshot of the camera state
                     m_Snapshot.TakeSnapshot(cam);
+                    m_SnapshotSource = cam;
                     m_SnapshotBlendWeight = weight;
                 }
                 // Use the most recent snapshot
@@ -388,7 +390,8 @@ namespace Unity.Cinemachine
         class SnapshotBlendSource : ICinemachineCamera
         {
             CameraState m_State;
-            public ICinemachineCamera Source { get; private set; }
+            string m_Name;
+
             public float RemainingTimeInBlend { get; set; }
 
             public SnapshotBlendSource(ICinemachineCamera source = null, float remainingTimeInBlend = 0)
@@ -397,19 +400,19 @@ namespace Unity.Cinemachine
                 RemainingTimeInBlend = remainingTimeInBlend;
             }
 
-            public string Name => Source == null ? "(null)" : Source.Name;
-            public string Description => "snapshot";
+            public string Name => m_Name;
+            public string Description => Name;
             public CameraState State => m_State;
-            public bool IsValid => Source != null;
+            public bool IsValid => true;
             public ICinemachineMixer ParentCamera => null;
             public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
             public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
 
             public void TakeSnapshot(ICinemachineCamera source)
             {
-                Source = source;
                 m_State = source != null ? source.State : CameraState.Default; 
                 m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
+                m_Name ??= source == null ? "(null)" : "*" + source.Name;
             }
         }
     }

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -55,11 +55,11 @@ namespace Unity.Cinemachine
     /// <summary>
     /// Implements an overridable stack of blend states.
     /// </summary>
-    internal class CameraBlendStack : ICameraOverrideStack
+    class CameraBlendStack : ICameraOverrideStack
     {
         const float kEpsilon = UnityVectorExtensions.Epsilon;
 
-        class StackFrame : BlendSourceVirtualCamera
+        class StackFrame : NestedBlendSource
         {
             public int Id;
             public int Priority;
@@ -67,8 +67,7 @@ namespace Unity.Cinemachine
             public float DeltaTimeOverride;
 
             // If blending in from a snapshot, this holds the source state
-            readonly StaticStateVirtualCamera m_Snapshot = new (CameraState.Default, string.Empty);
-            ICinemachineCamera m_SnapshotSource;
+            readonly SnapshotBlendSource m_Snapshot = new ();
             float m_SnapshotBlendWeight;
 
             public StackFrame() : base(new (null, null, null, 0, 0)) {}
@@ -81,17 +80,15 @@ namespace Unity.Cinemachine
                 if (cam == null || (cam.State.BlendHint & CameraState.BlendHints.FreezeWhenBlendingOut) == 0)
                 {
                     // No snapshot required - reset it
-                    m_SnapshotSource = null;
+                    m_Snapshot.TakeSnapshot(null);
                     return cam;
                 }
                 // A snapshot is needed
-                if (m_SnapshotSource != cam || m_SnapshotBlendWeight > weight)
+                if (m_Snapshot.Source != cam || m_SnapshotBlendWeight > weight)
                 {
                     // At this point we're pretty sure this is a new blend,
                     // so we take a new snapshot of the camera state
-                    m_Snapshot.Name = cam.Name;
-                    m_Snapshot.State = cam.State;
-                    m_SnapshotSource = cam;
+                    m_Snapshot.TakeSnapshot(cam);
                     m_SnapshotBlendWeight = weight;
                 }
                 // Use the most recent snapshot
@@ -259,6 +256,8 @@ namespace Unity.Cinemachine
                         && frame.Blend.Uses(activeCamera))
                         snapshot = true;
 
+                    var nbs = frame.Blend.CamA as NestedBlendSource;
+
                     // Special case: if backing out of a blend-in-progress
                     // with the same blend in reverse, adjust the blend time
                     // to cancel out the progress made in the opposite direction
@@ -266,12 +265,20 @@ namespace Unity.Cinemachine
                     {
                         snapshot = true; // always use a snapshot for this to prevent pops
                         duration = frame.Blend.TimeInBlend;
+                        if (nbs != null)
+                            duration += nbs.Blend.Duration - nbs.Blend.TimeInBlend;
+                        else if (frame.Blend.CamA is SnapshotBlendSource sbs)
+                            duration += sbs.RemainingTimeInBlend;
                     }
+
+                    // Avoid nesting too deeply
+                    if (!snapshot && nbs != null && nbs.Blend.CamA is NestedBlendSource nbs2)
+                        nbs2.Blend.CamA = new SnapshotBlendSource(nbs2.Blend.CamA);
 
                     // Chain to existing blend
                     frame.Blend.CamA = snapshot 
-                        ? new StaticStateVirtualCamera(frame.Blend.State, outgoingCamera.Name)
-                        : new BlendSourceVirtualCamera(new CinemachineBlend(frame.Blend));
+                        ? new SnapshotBlendSource(frame, frame.Blend.Duration - frame.Blend.TimeInBlend)
+                        : new NestedBlendSource(new CinemachineBlend(frame.Blend));
                 }
                 frame.Blend.CamB = activeCamera;
                 frame.Blend.BlendCurve = frame.Source.BlendCurve;
@@ -280,19 +287,27 @@ namespace Unity.Cinemachine
             }
 
             // Advance the working blend
-            if (frame.Blend.CamA != null)
+            AdvanceBlend(frame.Blend, deltaTime);
+            frame.UpdateCameraState(up, deltaTime);
+
+            // local function
+            static void AdvanceBlend(CinemachineBlend blend, float deltaTime)
             {
-                frame.Blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : frame.Blend.Duration;
-                if (frame.Blend.IsComplete)
+                if (blend.CamA != null)
                 {
-                    // No more blend
-                    frame.Blend.CamA = null;
-                    frame.Blend.BlendCurve = null;
-                    frame.Blend.Duration = 0;
-                    frame.Blend.TimeInBlend = 0;
+                    blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : blend.Duration;
+                    if (blend.IsComplete)
+                    {
+                        // No more blend
+                        blend.CamA = null;
+                        blend.BlendCurve = null;
+                        blend.Duration = 0;
+                        blend.TimeInBlend = 0;
+                    }
+                    else if (blend.CamA is NestedBlendSource bs)
+                        AdvanceBlend(bs.Blend, deltaTime);
                 }
             }
-            frame.UpdateCameraState(up, deltaTime);
         }
 
         /// <summary>
@@ -364,6 +379,38 @@ namespace Unity.Cinemachine
                     return frame.DeltaTimeOverride;
             }
             return -1;
+        }
+
+        /// <summary>
+        /// Static source for blending. It's not really a virtual camera, but takes
+        /// a CameraState and exposes it as a virtual camera for the purposes of blending.
+        /// </summary>
+        class SnapshotBlendSource : ICinemachineCamera
+        {
+            CameraState m_State;
+            public ICinemachineCamera Source { get; private set; }
+            public float RemainingTimeInBlend { get; set; }
+
+            public SnapshotBlendSource(ICinemachineCamera source = null, float remainingTimeInBlend = 0)
+            {
+                TakeSnapshot(source);
+                RemainingTimeInBlend = remainingTimeInBlend;
+            }
+
+            public string Name => Source == null ? "(null)" : Source.Name;
+            public string Description => "snapshot";
+            public CameraState State => m_State;
+            public bool IsValid => Source != null;
+            public ICinemachineMixer ParentCamera => null;
+            public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
+            public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
+
+            public void TakeSnapshot(ICinemachineCamera source)
+            {
+                Source = source;
+                m_State = source != null ? source.State : CameraState.Default; 
+                m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -78,9 +78,9 @@ namespace Unity.Cinemachine
                 return false;
             if (cam == CamA || cam == CamB)
                 return true;
-            if (CamA is BlendSourceVirtualCamera b && b.Blend.Uses(cam))
+            if (CamA is NestedBlendSource b && b.Blend.Uses(cam))
                 return true;
-            b = CamB as BlendSourceVirtualCamera;
+            b = CamB as NestedBlendSource;
             return b != null && b.Blend.Uses(cam);
         }
 
@@ -272,44 +272,13 @@ namespace Unity.Cinemachine
     }
 
     /// <summary>
-    /// Static source for blending. It's not really a virtual camera, but takes
-    /// a CameraState and exposes it as a virtual camera for the purposes of blending.
-    /// </summary>
-    internal class StaticStateVirtualCamera : ICinemachineCamera
-    {
-        string m_Name;
-        CameraState m_State;
-
-        public StaticStateVirtualCamera(CameraState state, string name) 
-        {
-            m_State = state;
-            m_Name = name;
-        }
-        public string Name { get => m_Name; set => m_Name = value; }
-        public string Description => "snapshot";
-        public CameraState State 
-        {
-            get => m_State; 
-            set 
-            {
-                m_State = value; 
-                m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
-            }
-        }
-        public bool IsValid => true;
-        public ICinemachineMixer ParentCamera => null;
-        public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
-        public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
-    }
-
-    /// <summary>
     /// Blend result source for blending.   This exposes a CinemachineBlend object
     /// as an ersatz virtual camera for the purposes of blending.  This achieves the purpose
     /// of blending the result oif a blend.
     /// </summary>
-    internal class BlendSourceVirtualCamera : ICinemachineCamera
+    class NestedBlendSource : ICinemachineCamera
     {
-        public BlendSourceVirtualCamera(CinemachineBlend blend) { Blend = blend; }
+        public NestedBlendSource(CinemachineBlend blend) { Blend = blend; }
         public CinemachineBlend Blend { get; set; }
 
         public string Name => (Blend == null || Blend.CamB == null)? "(null)" : Blend.CamB.Name;

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -280,8 +280,17 @@ namespace Unity.Cinemachine
     {
         public NestedBlendSource(CinemachineBlend blend) { Blend = blend; }
         public CinemachineBlend Blend { get; set; }
+        string m_Name;
 
-        public string Name => (Blend == null || Blend.CamB == null)? "(null)" : Blend.CamB.Name;
+        public string Name 
+        { 
+            get
+            {
+                // Cache the name only if name is requested
+                m_Name ??= (Blend == null || Blend.CamB == null)? "(null)" : "mid-blend to " + Blend.CamB.Name;
+                return m_Name;
+            }
+        }
         public string Description => Blend == null ? "(null)" : Blend.Description;
         public CameraState State { get; private set; }
         public bool IsValid => Blend != null && Blend.IsValid; 

--- a/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
@@ -153,7 +153,7 @@ namespace Unity.Cinemachine.Tests
             yield return UpdateCinemachine();
             
             // finish blend
-            while (CurrentTime - startTime < k_BlendingTime * 0.1f)
+            while (CurrentTime - startTime < k_BlendingTime * 0.2f)
             {
                 Assert.That(ReferenceEquals(m_Brain.ActiveVirtualCamera, m_Target));
                 Assert.That(m_Brain.IsBlending, Is.True);


### PR DESCRIPTION
### Purpose of this PR

CMCL-1473: Improve handling of nested blends.

1. Blends ((A -> B) -> A) -> B have incorrect timing (can zip fast at end).  This should not happen.  Instead, blends should take the appropriate remaining blend time.
2. Nested blends should continue evaluating, so that (A -> B) -> C will move the camera in an arc instead of taking a segmented path.
3. Blends should not nest indefinitely, so that ((A -> B) -> C) -> D should take a snapshot of A -> B

See the attached scene in the jira ticket for a good test case.  Cycle between the 3 cameras to test blend chaining.

![image](https://user-images.githubusercontent.com/6424658/235309158-dc675dce-1208-442c-b5f2-393325b1fec9.png)


### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Note to reviewers: 

This PR is included in https://github.com/Unity-Technologies/com.unity.cinemachine/pull/871, which is built off of this branch