### PR TITLE
CMCL-1474: customizable blends

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 
 ### Changed
-- Improve handling of nested blends
+- Improve handling of nested blends.
 
 - ### Added
-- Added CinemachineCore.GetCustomBlender
+- Added CinemachineCore.GetCustomBlender and BlendCreatedEvent to allow custom blend behaviour.
 
 
 ## [3.0.0-pre.5] - 2023-04-25

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Improve handling of nested blends
 
+- ### Added
+- Added CinemachineCore.GetCustomBlender
+
 
 ## [3.0.0-pre.5] - 2023-04-25
 

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Improve handling of nested blends
+
+
 ## [3.0.0-pre.5] - 2023-04-25
 
 ### Fixed

--- a/com.unity.cinemachine/Documentation~/CinemachineBrainEvents.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineBrainEvents.md
@@ -14,7 +14,8 @@ If you are looking for events that fire for a specific CinemachineCamera, see [C
 |:---|:---|
 | __Camera Activated Event__ | This is called at the beginning of a blend, when a camera becomes live.  Parameters are: brain, incoming camera. A cut is considered to be a blend of length zero. |
 | __Camera Deactivated Event__ | This event will fire whenever a Cinemachine Camera stops being live.  If a blend is involved, then the event will fire after the last frame of the blend. |
-| __Camera Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
+| __Blend Created Event__ | This event will fire whenever a new Cinemachine blend is created. Handlers can modify the settings of the blend (but not the cameras).  Note: BlendCreatedEvents are NOT sent for timeline blends, as those are expected to be controlled 100% by timeline. To modify the blend algorithm for timeline blends, you can install a handler for CinemachineCore.GetCustomBlender. |
+| __Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
 | __Camera Cut Event__ | This is called when a zero-length blend happens. |
 | __Brain Updated Event__ | This event is sent immediately after the brain has processed all the CinemachineCameras, and has updated the main Camera.  Code that depends on the main camera position or that wants to modify it can be executed from this event handler. |
 

--- a/com.unity.cinemachine/Documentation~/CinemachineCameraEvents.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineCameraEvents.md
@@ -14,6 +14,6 @@ If you want to attach events to a CinemachineBrain, please see [Cinemachine Brai
 |:---|:---|
 | __Camera Activated Event__ | This is called at the beginning of a blend, when a camera becomes live.  Parameters are: brain, incoming camera. A cut is considered to be a blend of length zero. |
 | __Camera Deactivated Event__ | This event will fire whenever a Cinemachine Camera stops being live.  If a blend is involved, then the event will fire after the last frame of the blend. |
-| __Blend Created Event__ | This event will fire whenever a a new Cinemachine blend is created. Handlers can modify the settings of the blend (but not the cameras).  Note: BlendCreatedEvents are NOT sent for timeline blends, as those are expected to be controlled 100% by timeline. To modify the blend algorithm for timeline blends, you can install a handler for CinemachineCore.GetCustomBlender. |
+| __Blend Created Event__ | This event will fire whenever a new Cinemachine blend is created. Handlers can modify the settings of the blend (but not the cameras).  Note: BlendCreatedEvents are NOT sent for timeline blends, as those are expected to be controlled 100% by timeline. To modify the blend algorithm for timeline blends, you can install a handler for CinemachineCore.GetCustomBlender. |
 | __Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
 

--- a/com.unity.cinemachine/Documentation~/CinemachineCameraEvents.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineCameraEvents.md
@@ -14,5 +14,6 @@ If you want to attach events to a CinemachineBrain, please see [Cinemachine Brai
 |:---|:---|
 | __Camera Activated Event__ | This is called at the beginning of a blend, when a camera becomes live.  Parameters are: brain, incoming camera. A cut is considered to be a blend of length zero. |
 | __Camera Deactivated Event__ | This event will fire whenever a Cinemachine Camera stops being live.  If a blend is involved, then the event will fire after the last frame of the blend. |
-| __Camera Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
+| __Blend Created Event__ | This event will fire whenever a a new Cinemachine blend is created. Handlers can modify the settings of the blend (but not the cameras).  Note: BlendCreatedEvents are NOT sent for timeline blends, as those are expected to be controlled 100% by timeline. To modify the blend algorithm for timeline blends, you can install a handler for CinemachineCore.GetCustomBlender. |
+| __Blend Finished Event__ | This event will fire whenever a Cinemachine Camera finishes blending in.  It will not fire if the blend length is zero. |
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEventsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEventsEditor.cs
@@ -21,7 +21,8 @@ namespace Unity.Cinemachine.Editor
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDeactivatedEvent)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraBlendFinishedEvent)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.BlendCreatedEvent)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.BlendFinishedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraCutEvent)));
             var brainEvent = ux.AddChild(
                 new PropertyField(serializedObject.FindProperty(() => Target.BrainUpdatedEvent)));

--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraEventsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraEventsEditor.cs
@@ -21,7 +21,8 @@ namespace Unity.Cinemachine.Editor
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraActivatedEvent)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraDeactivatedEvent)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CameraBlendFinishedEvent)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.BlendCreatedEvent)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.BlendFinishedEvent)));
 
             // Update state
             ux.TrackAnyUserActivity(() =>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -518,7 +518,7 @@ namespace Unity.Cinemachine
 
             float deltaTime = GetEffectiveDeltaTime(false);
             if (!Application.isPlaying || BlendUpdateMethod != BrainUpdateMethods.FixedUpdate)
-                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), DefaultWorldUp, deltaTime);
+                m_BlendManager.UpdateRootFrame(this, TopCameraFromPriorityQueue(), DefaultWorldUp, deltaTime);
 
             m_BlendManager.ComputeCurrentBlend();
 
@@ -569,7 +569,7 @@ namespace Unity.Cinemachine
             // Choose the active vcam and apply it to the Unity camera
             if (BlendUpdateMethod == BrainUpdateMethods.FixedUpdate)
             {
-                m_BlendManager.UpdateRootFrame(TopCameraFromPriorityQueue(), DefaultWorldUp, Time.fixedDeltaTime);
+                m_BlendManager.UpdateRootFrame(this, TopCameraFromPriorityQueue(), DefaultWorldUp, Time.fixedDeltaTime);
                 ProcessActiveCamera(Time.fixedDeltaTime);
             }
         }

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -8,7 +8,7 @@ namespace Unity.Cinemachine
     /// It takes care of looking up BlendDefinitions when blends need to be created,
     /// and it generates ActivationEvents for camweras when necessary.
     /// </summary>
-    internal class BlendManager : CameraBlendStack
+    class BlendManager : CameraBlendStack
     {
         // Current Brain State - result of all frames.  Blend camB is "current" camera always
         CinemachineBlend m_CurrentLiveCameras = new (null, null, null, 0, 0);
@@ -25,7 +25,7 @@ namespace Unity.Cinemachine
         static ICinemachineCamera DeepCamBFromBlend(CinemachineBlend blend)
         {
             var cam = blend?.CamB;
-            while (cam is BlendSourceVirtualCamera bs)
+            while (cam is NestedBlendSource bs)
                 cam = bs.Blend.CamB;
             if (cam != null && cam.IsValid)
                 return cam;
@@ -82,7 +82,7 @@ namespace Unity.Cinemachine
             {
                 if (cam == m_CurrentLiveCameras.CamA)
                     return true;
-                if (m_CurrentLiveCameras.CamA is BlendSourceVirtualCamera b && b.Blend.Uses(cam))
+                if (m_CurrentLiveCameras.CamA is NestedBlendSource b && b.Blend.Uses(cam))
                     return true;
             }
             return false;
@@ -175,12 +175,12 @@ namespace Unity.Cinemachine
             // local method - find all the live cameras in a blend
             static void CollectLiveCameras(CinemachineBlend blend, ref List<ICinemachineCamera> cams)
             {
-                if (blend.CamA is BlendSourceVirtualCamera a && a.Blend != null)
+                if (blend.CamA is NestedBlendSource a && a.Blend != null)
                     CollectLiveCameras(a.Blend, ref cams);
                 else if (blend.CamA != null)
                     cams.Add(blend.CamA);
 
-                if (blend.CamB is BlendSourceVirtualCamera b && b.Blend != null)
+                if (blend.CamB is NestedBlendSource b && b.Blend != null)
                     CollectLiveCameras(b.Blend, ref cams);
                 else if (blend.CamB != null)
                     cams.Add(blend.CamB);

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -10,11 +10,11 @@ namespace Unity.Cinemachine
     /// </summary>
     class BlendManager : CameraBlendStack
     {
-        // Current Brain State - result of all frames.  Blend camB is "current" camera always
-        CinemachineBlend m_CurrentLiveCameras = new (null, null, null, 0, 0);
+        // Current blend State - result of all frames.  Blend camB is "current" camera always
+        CinemachineBlend m_CurrentLiveCameras = new ();
 
-        // Current cameras last frame, used for computing deltas
-        CinemachineBlend m_PreviousLiveCameras = new (null, null, null, 0, 0);
+        // Blend state last frame, used for computing deltas
+        CinemachineBlend m_PreviousLiveCameras = new ();
 
         // This is to control GC allocs when generating camera deactivated events
         List<ICinemachineCamera> m_CameraCache = new();

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -55,11 +55,11 @@ namespace Unity.Cinemachine
     /// <summary>
     /// Implements an overridable stack of blend states.
     /// </summary>
-    internal class CameraBlendStack : ICameraOverrideStack
+    class CameraBlendStack : ICameraOverrideStack
     {
         const float kEpsilon = UnityVectorExtensions.Epsilon;
 
-        class StackFrame : BlendSourceVirtualCamera
+        class StackFrame : NestedBlendSource
         {
             public int Id;
             public int Priority;
@@ -67,8 +67,7 @@ namespace Unity.Cinemachine
             public float DeltaTimeOverride;
 
             // If blending in from a snapshot, this holds the source state
-            readonly StaticStateVirtualCamera m_Snapshot = new (CameraState.Default, string.Empty);
-            ICinemachineCamera m_SnapshotSource;
+            readonly SnapshotBlendSource m_Snapshot = new ();
             float m_SnapshotBlendWeight;
 
             public StackFrame() : base(new (null, null, null, 0, 0)) {}
@@ -81,17 +80,15 @@ namespace Unity.Cinemachine
                 if (cam == null || (cam.State.BlendHint & CameraState.BlendHints.FreezeWhenBlendingOut) == 0)
                 {
                     // No snapshot required - reset it
-                    m_SnapshotSource = null;
+                    m_Snapshot.TakeSnapshot(null);
                     return cam;
                 }
                 // A snapshot is needed
-                if (m_SnapshotSource != cam || m_SnapshotBlendWeight > weight)
+                if (m_Snapshot.Source != cam || m_SnapshotBlendWeight > weight)
                 {
                     // At this point we're pretty sure this is a new blend,
                     // so we take a new snapshot of the camera state
-                    m_Snapshot.Name = cam.Name;
-                    m_Snapshot.State = cam.State;
-                    m_SnapshotSource = cam;
+                    m_Snapshot.TakeSnapshot(cam);
                     m_SnapshotBlendWeight = weight;
                 }
                 // Use the most recent snapshot
@@ -259,6 +256,8 @@ namespace Unity.Cinemachine
                         && frame.Blend.Uses(activeCamera))
                         snapshot = true;
 
+                    var nbs = frame.Blend.CamA as NestedBlendSource;
+
                     // Special case: if backing out of a blend-in-progress
                     // with the same blend in reverse, adjust the blend time
                     // to cancel out the progress made in the opposite direction
@@ -266,12 +265,20 @@ namespace Unity.Cinemachine
                     {
                         snapshot = true; // always use a snapshot for this to prevent pops
                         duration = frame.Blend.TimeInBlend;
+                        if (nbs != null)
+                            duration += nbs.Blend.Duration - nbs.Blend.TimeInBlend;
+                        else if (frame.Blend.CamA is SnapshotBlendSource sbs)
+                            duration += sbs.RemainingTimeInBlend;
                     }
+
+                    // Avoid nesting too deeply
+                    if (!snapshot && nbs != null && nbs.Blend.CamA is NestedBlendSource nbs2)
+                        nbs2.Blend.CamA = new SnapshotBlendSource(nbs2.Blend.CamA);
 
                     // Chain to existing blend
                     frame.Blend.CamA = snapshot 
-                        ? new StaticStateVirtualCamera(frame.Blend.State, outgoingCamera.Name)
-                        : new BlendSourceVirtualCamera(new CinemachineBlend(frame.Blend));
+                        ? new SnapshotBlendSource(frame, frame.Blend.Duration - frame.Blend.TimeInBlend)
+                        : new NestedBlendSource(new CinemachineBlend(frame.Blend));
                 }
                 frame.Blend.CamB = activeCamera;
                 frame.Blend.BlendCurve = frame.Source.BlendCurve;
@@ -280,19 +287,27 @@ namespace Unity.Cinemachine
             }
 
             // Advance the working blend
-            if (frame.Blend.CamA != null)
+            AdvanceBlend(frame.Blend, deltaTime);
+            frame.UpdateCameraState(up, deltaTime);
+
+            // local function
+            static void AdvanceBlend(CinemachineBlend blend, float deltaTime)
             {
-                frame.Blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : frame.Blend.Duration;
-                if (frame.Blend.IsComplete)
+                if (blend.CamA != null)
                 {
-                    // No more blend
-                    frame.Blend.CamA = null;
-                    frame.Blend.BlendCurve = null;
-                    frame.Blend.Duration = 0;
-                    frame.Blend.TimeInBlend = 0;
+                    blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : blend.Duration;
+                    if (blend.IsComplete)
+                    {
+                        // No more blend
+                        blend.CamA = null;
+                        blend.BlendCurve = null;
+                        blend.Duration = 0;
+                        blend.TimeInBlend = 0;
+                    }
+                    else if (blend.CamA is NestedBlendSource bs)
+                        AdvanceBlend(bs.Blend, deltaTime);
                 }
             }
-            frame.UpdateCameraState(up, deltaTime);
         }
 
         /// <summary>
@@ -364,6 +379,38 @@ namespace Unity.Cinemachine
                     return frame.DeltaTimeOverride;
             }
             return -1;
+        }
+
+        /// <summary>
+        /// Static source for blending. It's not really a virtual camera, but takes
+        /// a CameraState and exposes it as a virtual camera for the purposes of blending.
+        /// </summary>
+        class SnapshotBlendSource : ICinemachineCamera
+        {
+            CameraState m_State;
+            public ICinemachineCamera Source { get; private set; }
+            public float RemainingTimeInBlend { get; set; }
+
+            public SnapshotBlendSource(ICinemachineCamera source = null, float remainingTimeInBlend = 0)
+            {
+                TakeSnapshot(source);
+                RemainingTimeInBlend = remainingTimeInBlend;
+            }
+
+            public string Name => Source == null ? "(null)" : Source.Name;
+            public string Description => "snapshot";
+            public CameraState State => m_State;
+            public bool IsValid => Source != null;
+            public ICinemachineMixer ParentCamera => null;
+            public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
+            public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
+
+            public void TakeSnapshot(ICinemachineCamera source)
+            {
+                Source = source;
+                m_State = source != null ? source.State : CameraState.Default; 
+                m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -63,14 +63,14 @@ namespace Unity.Cinemachine
         {
             public int Id;
             public int Priority;
-            public readonly CinemachineBlend Source = new (null, null, null, 1, 0);
+            public readonly CinemachineBlend Source = new ();
             public float DeltaTimeOverride;
 
             // If blending in from a snapshot, this holds the source state
             readonly SnapshotBlendSource m_Snapshot = new ();
             float m_SnapshotBlendWeight;
 
-            public StackFrame() : base(new (null, null, null, 0, 0)) {}
+            public StackFrame() : base(new ()) {}
             public bool Active => Source.IsValid;
 
             // This is a little tricky, because we only want to take a new snapshot at the start 
@@ -119,18 +119,20 @@ namespace Unity.Cinemachine
 
             var frame = m_FrameStack[FindFrame(overrideId, priority)];
             frame.DeltaTimeOverride = deltaTime;
-            frame.Source.CamA = camA;
-            frame.Source.CamB = camB;
-            frame.Source.Duration = 1;
-            frame.Source.BlendCurve = s_DefaultLinearAnimationCurve;
             frame.Source.TimeInBlend = weightB;
 
-            // In case vcams are inactive game objects, make sure they get initialized properly
-            if (camA is CinemachineVirtualCameraBase vcamA)
-                vcamA.EnsureStarted();
-            if (camB is CinemachineVirtualCameraBase vcamB)
-                vcamB.EnsureStarted();
+            if (frame.Source.CamA != camA || frame.Source.CamB != camB)
+            {
+                frame.Source.CustomBlender = CinemachineCore.GetCustomBlender?.Invoke(camA, camB);
+                frame.Source.CamA = camA;
+                frame.Source.CamB = camB;
 
+                // In case vcams are inactive game objects, make sure they get initialized properly
+                if (camA is CinemachineVirtualCameraBase vcamA)
+                    vcamA.EnsureStarted();
+                if (camB is CinemachineVirtualCameraBase vcamB)
+                    vcamB.EnsureStarted();
+            }
             return overrideId;
             
             // local function to get the frame index corresponding to the ID
@@ -146,7 +148,10 @@ namespace Unity.Cinemachine
                 for (index = 1; index < count; ++index)
                     if (m_FrameStack[index].Priority > priority)
                         break;
-                m_FrameStack.Insert(index, new StackFrame { Id = withId, Priority = priority });
+                var frame = new StackFrame { Id = withId, Priority = priority };
+                frame.Source.Duration = 1;
+                frame.Source.BlendCurve = s_DefaultLinearAnimationCurve;
+                m_FrameStack.Insert(index, frame);
                 return index;
             }
         }
@@ -195,18 +200,22 @@ namespace Unity.Cinemachine
             else
             {
                 var frame = m_FrameStack[0];
-                frame.Blend.CamA = frame.Blend.CamB = null;
-                frame.Source.CamA = frame.Source.CamB = null;
+                frame.Blend.ClearBlend();
+                frame.Blend.CamB = null;
+                frame.Source.ClearBlend();
+                frame.Source.CamB = null;
             }
         }
 
         /// <summary>
         /// Call this every frame with the current active camera of the root frame.
         /// </summary>
+        /// <param name="context">The mixer context in which this blend stack exists</param>
         /// <param name="activeCamera">Current active camera (pre-override)</param>
         /// <param name="up">Current world up</param>
         /// <param name="deltaTime">How much time has elapsed, for computing blends</param>
         public void UpdateRootFrame(
+            ICinemachineMixer context,
             ICinemachineCamera activeCamera, Vector3 up, float deltaTime)
         {
             // Make sure there is a first stack frame
@@ -219,6 +228,7 @@ namespace Unity.Cinemachine
             if (activeCamera != outgoingCamera)
             {
                 bool backingOutOfBlend = false;
+                float duration = 0;
 
                 // Do we need to create a game-play blend?
                 if (LookupBlendDelegate != null && activeCamera != null && activeCamera.IsValid
@@ -233,18 +243,24 @@ namespace Unity.Cinemachine
 
                         frame.Source.CamA = outgoingCamera;
                         frame.Source.BlendCurve = blendDef.BlendCurve;
+                        duration = blendDef.BlendTime;
                     }
-                    frame.Source.Duration = blendDef.BlendTime;
+                    frame.Source.Duration = duration;
                     frame.Source.TimeInBlend = 0;
+                    frame.Source.CustomBlender = null;
                 }
                 frame.Source.CamB = activeCamera;
+
+                // Get custom blender, if any
+                if (duration > 0)
+                    frame.Source.CustomBlender = CinemachineCore.GetCustomBlender?.Invoke(outgoingCamera, activeCamera);
 
                 // Update the working blend:
                 // Check the status of the working blend.  If not blending, no problem.
                 // Otherwise, we need to do some work to chain the blends.
-                var duration = frame.Source.Duration;
+                ICinemachineCamera camA;
                 if (frame.Blend.IsComplete)
-                    frame.Blend.CamA = frame.GetSnapshotIfAppropriate(outgoingCamera, 0); // new blend
+                    camA = frame.GetSnapshotIfAppropriate(outgoingCamera, 0); // new blend
                 else
                 {
                     bool snapshot = (frame.Blend.State.BlendHint & CameraState.BlendHints.FreezeWhenBlendingOut) != 0;
@@ -256,7 +272,10 @@ namespace Unity.Cinemachine
                         && frame.Blend.Uses(activeCamera))
                         snapshot = true;
 
+                    // Avoid nesting too deeply
                     var nbs = frame.Blend.CamA as NestedBlendSource;
+                    if (!snapshot && nbs != null && nbs.Blend.CamA is NestedBlendSource nbs2)
+                        nbs2.Blend.CamA = new SnapshotBlendSource(nbs2.Blend.CamA);
 
                     // Special case: if backing out of a blend-in-progress
                     // with the same blend in reverse, adjust the blend time
@@ -271,42 +290,55 @@ namespace Unity.Cinemachine
                             duration += sbs.RemainingTimeInBlend;
                     }
 
-                    // Avoid nesting too deeply
-                    if (!snapshot && nbs != null && nbs.Blend.CamA is NestedBlendSource nbs2)
-                        nbs2.Blend.CamA = new SnapshotBlendSource(nbs2.Blend.CamA);
-
                     // Chain to existing blend
-                    frame.Blend.CamA = snapshot 
-                        ? new SnapshotBlendSource(frame, frame.Blend.Duration - frame.Blend.TimeInBlend)
-                        : new NestedBlendSource(new CinemachineBlend(frame.Blend));
+                    if (snapshot)
+                        camA = new SnapshotBlendSource(frame, frame.Blend.Duration - frame.Blend.TimeInBlend);
+                    else
+                    {
+                        var blendCopy = new CinemachineBlend();
+                        blendCopy.CopyFrom(frame.Blend);
+                        camA = new NestedBlendSource(blendCopy);
+                    }
                 }
+                // For the event, we use the raw outgoing camera, not the blend source
+                frame.Blend.CamA = outgoingCamera;
                 frame.Blend.CamB = activeCamera;
                 frame.Blend.BlendCurve = frame.Source.BlendCurve;
                 frame.Blend.Duration = duration;
                 frame.Blend.TimeInBlend = 0;
+                frame.Blend.CustomBlender = frame.Source.CustomBlender;
+
+                // Allow the client to modify the blend
+                if (duration > 0)
+                    CinemachineCore.BlendCreatedEvent.Invoke(new () { Origin = context, Blend = frame.Blend });
+
+                // In case the event handler tried to change the cameras, put them back
+                frame.Blend.CamA = camA;
+                frame.Blend.CamB = activeCamera;
             }
 
             // Advance the working blend
-            AdvanceBlend(frame.Blend, deltaTime);
+            if (AdvanceBlend(frame.Blend, deltaTime))
+                frame.Source.ClearBlend();
             frame.UpdateCameraState(up, deltaTime);
 
             // local function
-            static void AdvanceBlend(CinemachineBlend blend, float deltaTime)
+            static bool AdvanceBlend(CinemachineBlend blend, float deltaTime)
             {
+                bool blendCompleted = false;
                 if (blend.CamA != null)
                 {
                     blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : blend.Duration;
                     if (blend.IsComplete)
                     {
                         // No more blend
-                        blend.CamA = null;
-                        blend.BlendCurve = null;
-                        blend.Duration = 0;
-                        blend.TimeInBlend = 0;
+                        blend.ClearBlend();
+                        blendCompleted = true;
                     }
                     else if (blend.CamA is NestedBlendSource bs)
                         AdvanceBlend(bs.Blend, deltaTime);
                 }
+                return blendCompleted;
             }
         }
 
@@ -341,9 +373,19 @@ namespace Unity.Cinemachine
                     // Handle cases where we're blending into or out of nothing
                     if (!frame.Blend.IsComplete)
                     {
-                        frame.Blend.CamA ??= frame.GetSnapshotIfAppropriate(
-                            m_FrameStack[lastActive], frame.Blend.TimeInBlend);
-                        frame.Blend.CamB ??= m_FrameStack[lastActive];
+                        if (frame.Blend.CamA == null)
+                        {
+                            frame.Blend.CamA = frame.GetSnapshotIfAppropriate(
+                                m_FrameStack[lastActive], frame.Blend.TimeInBlend);
+                            frame.Blend.CustomBlender = CinemachineCore.GetCustomBlender?.Invoke(
+                                frame.Blend.CamA, frame.Blend.CamB);
+                        }
+                        if (frame.Blend.CamB == null)
+                        {
+                            frame.Blend.CamB = m_FrameStack[lastActive];
+                            frame.Blend.CustomBlender = CinemachineCore.GetCustomBlender?.Invoke(
+                                frame.Blend.CamA, frame.Blend.CamB);
+                        }
                     }
                     lastActive = i;
                 }
@@ -353,7 +395,8 @@ namespace Unity.Cinemachine
 
         /// <summary>
         /// Set the current root blend.  Can be used to modify the root blend state.
-        /// <param name="blend">The new blend.  If null, current blend will be force-completed.</param>
+        /// <param name="blend">The new blend.  CamA and CamB will be ignored, but the other fields 
+        /// will be taken.  If null, current blend will be force-completed.</param>
         /// </summary>
         public void SetRootBlend(CinemachineBlend blend)
         {
@@ -362,7 +405,12 @@ namespace Unity.Cinemachine
                 if (blend == null)
                     m_FrameStack[0].Blend.Duration = 0;
                 else
-                    m_FrameStack[0].Blend.CopyFrom(blend);
+                {
+                    m_FrameStack[0].Blend.BlendCurve = blend.BlendCurve;
+                    m_FrameStack[0].Blend.TimeInBlend = blend.TimeInBlend;
+                    m_FrameStack[0].Blend.Duration = blend.Duration;
+                    m_FrameStack[0].Blend.CustomBlender = blend.CustomBlender;
+                }
             }
         }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -78,9 +78,9 @@ namespace Unity.Cinemachine
                 return false;
             if (cam == CamA || cam == CamB)
                 return true;
-            if (CamA is BlendSourceVirtualCamera b && b.Blend.Uses(cam))
+            if (CamA is NestedBlendSource b && b.Blend.Uses(cam))
                 return true;
-            b = CamB as BlendSourceVirtualCamera;
+            b = CamB as NestedBlendSource;
             return b != null && b.Blend.Uses(cam);
         }
 
@@ -272,44 +272,13 @@ namespace Unity.Cinemachine
     }
 
     /// <summary>
-    /// Static source for blending. It's not really a virtual camera, but takes
-    /// a CameraState and exposes it as a virtual camera for the purposes of blending.
-    /// </summary>
-    internal class StaticStateVirtualCamera : ICinemachineCamera
-    {
-        string m_Name;
-        CameraState m_State;
-
-        public StaticStateVirtualCamera(CameraState state, string name) 
-        {
-            m_State = state;
-            m_Name = name;
-        }
-        public string Name { get => m_Name; set => m_Name = value; }
-        public string Description => "snapshot";
-        public CameraState State 
-        {
-            get => m_State; 
-            set 
-            {
-                m_State = value; 
-                m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
-            }
-        }
-        public bool IsValid => true;
-        public ICinemachineMixer ParentCamera => null;
-        public void UpdateCameraState(Vector3 worldUp, float deltaTime) {}
-        public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
-    }
-
-    /// <summary>
     /// Blend result source for blending.   This exposes a CinemachineBlend object
     /// as an ersatz virtual camera for the purposes of blending.  This achieves the purpose
     /// of blending the result oif a blend.
     /// </summary>
-    internal class BlendSourceVirtualCamera : ICinemachineCamera
+    class NestedBlendSource : ICinemachineCamera
     {
-        public BlendSourceVirtualCamera(CinemachineBlend blend) { Blend = blend; }
+        public NestedBlendSource(CinemachineBlend blend) { Blend = blend; }
         public CinemachineBlend Blend { get; set; }
 
         public string Name => (Blend == null || Blend.CamB == null)? "(null)" : Blend.CamB.Name;

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCameraManagerBase.cs
@@ -297,7 +297,7 @@ namespace Unity.Cinemachine
         protected void SetLiveChild(
             ICinemachineCamera activeCamera, Vector3 worldUp, float deltaTime)
         {
-            m_BlendManager.UpdateRootFrame(activeCamera, worldUp, deltaTime);
+            m_BlendManager.UpdateRootFrame(this, activeCamera, worldUp, deltaTime);
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(this, worldUp, deltaTime);
         }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -198,7 +198,12 @@ namespace Unity.Cinemachine
         public static CameraEvent CameraDeactivatedEvent = new ();
 
         /// <summary>This event will fire when a blend is created.  
-        /// Handler can modify the settings of the blend (but not the cameras).</summary>
+        /// Handler can modify the settings of the blend (but not the cameras).
+        /// 
+        /// Note: BlendCreatedEvents are NOT sent for timeline blends, as those are expected 
+        /// to be controlled 100% by timeline. To modify the blend algorithm for timeline blends, 
+        /// you can install a handler for CinemachineCore.GetCustomBlender.
+        /// </summary>
         public static BlendEvent BlendCreatedEvent = new ();
 
         /// <summary>This event will fire when the current camera completes a blend-in.</summary>

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -127,8 +127,8 @@ namespace Unity.Cinemachine
         
         /// <summary>
         /// Delegate for overriding a blend that is about to be applied to a transition.
-        /// A handler can either return the default blend, or a new blend specific to
-        /// current conditions.
+        /// A handler can either return the default blend, or a new blend definition 
+        /// specific to current conditions.
         /// </summary>
         /// <param name="fromVcam">The outgoing virtual camera</param>
         /// <param name="toVcam">Yhe incoming virtual camera</param>
@@ -149,6 +149,22 @@ namespace Unity.Cinemachine
         /// </summary>
         public static GetBlendOverrideDelegate GetBlendOverride;
 
+        /// <summary>
+        /// Delegate for replacing a standard CinemachineBlend with a custom blender class.
+        /// Return a new instance of a custom blender, or null to use the default blender.
+        /// </summary>
+        /// <param name="fromCam">The outgoing camera</param>
+        /// <param name="toCam">The incoming camera</param>
+        /// <returns>A new instance of a custom blender, or null to use the default blender</returns>
+        public delegate CinemachineBlend.IBlender GetCustomBlenderDelegate(
+            ICinemachineCamera fromCam, ICinemachineCamera toCam);
+
+        /// <summary>
+        /// Delegate for replacing a standard CinemachineBlend with a custom blender class.
+        /// Returns a new instance of a custom blender, or null to use the default blender.
+        /// </summary>
+        public static GetCustomBlenderDelegate GetCustomBlender;
+
         /// <summary>An event with ICinemachineMixer and ICinemachineCamera parameters.</summary>
         [Serializable]
         public class CameraEvent : UnityEvent<ICinemachineMixer, ICinemachineCamera> {}
@@ -160,6 +176,19 @@ namespace Unity.Cinemachine
         /// <summary>This event will fire after a brain updates its Camera</summary>
         public static BrainEvent CameraUpdatedEvent = new ();
 
+        /// <summary>This is sent with BlendEvent</summary>
+        public struct BlendEventParams
+        {
+            /// <summary>The context in which this blend is ocurring</summary>
+            public ICinemachineMixer Origin;
+            /// <summary>The blend that in question</summary>
+            public CinemachineBlend Blend;
+        }
+
+        /// <summary>An Event with BlendEventParams as parameter.</summary>
+        [Serializable]
+        public class BlendEvent : UnityEvent<BlendEventParams> {}
+
         /// <summary>This event will fire when the current camera changes, 
         /// at the start of a blend</summary>
         public static ICinemachineCamera.ActivationEvent CameraActivatedEvent = new ();
@@ -167,6 +196,10 @@ namespace Unity.Cinemachine
         /// <summary>This event will fire immediately after a camera that is 
         /// live in some context stops being live.</summary>
         public static CameraEvent CameraDeactivatedEvent = new ();
+
+        /// <summary>This event will fire when a blend is created.  
+        /// Handler can modify the settings of the blend (but not the cameras).</summary>
+        public static BlendEvent BlendCreatedEvent = new ();
 
         /// <summary>This event will fire when the current camera completes a blend-in.</summary>
         public static CameraEvent BlendFinishedEvent = new ();

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -722,8 +722,8 @@ namespace Unity.Cinemachine
                 }
 
                 // Create the blend objects
-                mBlendA = new CinemachineBlend(m_Rigs[1], m_Rigs[0], AnimationCurve.Linear(0, 0, 1, 1), 1, 0);
-                mBlendB = new CinemachineBlend(m_Rigs[2], m_Rigs[1], AnimationCurve.Linear(0, 0, 1, 1), 1, 0);
+                mBlendA = new CinemachineBlend { CamA = m_Rigs[1], CamB = m_Rigs[0], BlendCurve = AnimationCurve.Linear(0, 0, 1, 1), Duration = 1 };
+                mBlendB = new CinemachineBlend { CamA = m_Rigs[2], CamB = m_Rigs[1], BlendCurve = AnimationCurve.Linear(0, 0, 1, 1), Duration = 1 };
 
                 return true;
             }

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineBrainEvents.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineBrainEvents.cs
@@ -29,12 +29,22 @@ namespace Unity.Cinemachine
         public CinemachineCore.CameraEvent CameraDeactivatedEvent = new ();
 
         /// <summary>
+        /// This event will fire whenever a blend is created in the root frame of this Brain.  
+        /// The handler can modify any settings in the blend, except the cameras themselves.
+        /// Note: timeline tracks will not generate these events.
+        /// </summary>
+        [Tooltip("This event will fire whenever a blend is created in the root frame of this Brain.  "
+            + "The handler can modify any settings in the blend, except the cameras themselves.  "
+            + "Note: timeline tracks will not generate these events.")]
+        public CinemachineCore.BlendEvent BlendCreatedEvent = new ();
+
+        /// <summary>
         /// This event will fire whenever a virtual camera finishes blending in.  
         /// It will not fire if the blend length is zero.
         /// </summary>
         [Tooltip("This event will fire whenever a virtual camera finishes blending in.  "
             + "It will not fire if the blend length is zero.")]
-        public CinemachineCore.CameraEvent CameraBlendFinishedEvent = new ();
+        public CinemachineCore.CameraEvent BlendFinishedEvent = new ();
 
         /// <summary>
         /// This event is fired when there is a camera cut.  A camera cut is a camera 
@@ -58,6 +68,7 @@ namespace Unity.Cinemachine
             {
                 CinemachineCore.CameraActivatedEvent.AddListener(OnCameraActivated);
                 CinemachineCore.CameraDeactivatedEvent.AddListener(OnCameraDeactivated);
+                CinemachineCore.BlendCreatedEvent.AddListener(OnBlendCreated);
                 CinemachineCore.BlendFinishedEvent.AddListener(OnBlendFinished);
                 CinemachineCore.CameraUpdatedEvent.AddListener(OnCameraUpdated);
             }
@@ -67,6 +78,7 @@ namespace Unity.Cinemachine
         {
             CinemachineCore.CameraActivatedEvent.RemoveListener(OnCameraActivated);
             CinemachineCore.CameraDeactivatedEvent.RemoveListener(OnCameraDeactivated);
+            CinemachineCore.BlendCreatedEvent.RemoveListener(OnBlendCreated);
             CinemachineCore.BlendFinishedEvent.RemoveListener(OnBlendFinished);
             CinemachineCore.CameraUpdatedEvent.RemoveListener(OnCameraUpdated);
         }
@@ -87,10 +99,16 @@ namespace Unity.Cinemachine
                 CameraDeactivatedEvent.Invoke(mixer, cam);
         }
 
+        void OnBlendCreated(CinemachineCore.BlendEventParams evt)
+        {
+            if (evt.Origin == m_Mixer)
+                BlendCreatedEvent.Invoke(evt);
+        }
+
         void OnBlendFinished(ICinemachineMixer mixer, ICinemachineCamera cam)
         {
             if (mixer == m_Mixer)
-                CameraBlendFinishedEvent.Invoke(m_Mixer, cam);
+                BlendFinishedEvent.Invoke(m_Mixer, cam);
         }
 
         void OnCameraUpdated(CinemachineBrain brain)

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineCameraEvents.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineCameraEvents.cs
@@ -28,12 +28,20 @@ namespace Unity.Cinemachine
         public CinemachineCore.CameraEvent CameraDeactivatedEvent = new ();
 
         /// <summary>
+        /// This event will fire whenever a blend is created that involves this camera.  
+        /// The handler can modify any settings in the blend, except the cameras themselves.
+        /// </summary>
+        [Tooltip("This event will fire whenever a blend is created that involves this camera.  "
+            + "The handler can modify any settings in the blend, except the cameras themselves.")]
+        public CinemachineCore.BlendEvent BlendCreatedEvent = new ();
+
+        /// <summary>
         /// This event will fire whenever a virtual camera finishes blending in.  
         /// It will not fire if the blend length is zero.
         /// </summary>
         [Tooltip("This event will fire whenever a virtual camera finishes blending in.  "
             + "It will not fire if the blend length is zero.")]
-        public CinemachineCore.CameraEvent CameraBlendFinishedEvent = new ();
+        public CinemachineCore.CameraEvent BlendFinishedEvent = new ();
         
         CinemachineVirtualCameraBase m_Vcam;
 
@@ -44,6 +52,7 @@ namespace Unity.Cinemachine
             {
                 CinemachineCore.CameraActivatedEvent.AddListener(OnCameraActivated);
                 CinemachineCore.CameraDeactivatedEvent.AddListener(OnCameraDeactivated);
+                CinemachineCore.BlendCreatedEvent.AddListener(OnBlendCreated);
                 CinemachineCore.BlendFinishedEvent.AddListener(OnBlendFinished);
             }
         }
@@ -52,6 +61,7 @@ namespace Unity.Cinemachine
         {
             CinemachineCore.CameraActivatedEvent.RemoveListener(OnCameraActivated);
             CinemachineCore.CameraDeactivatedEvent.RemoveListener(OnCameraDeactivated);
+            CinemachineCore.BlendCreatedEvent.RemoveListener(OnBlendCreated);
             CinemachineCore.BlendFinishedEvent.RemoveListener(OnBlendFinished);
         }
 
@@ -61,10 +71,16 @@ namespace Unity.Cinemachine
                 CameraActivatedEvent.Invoke(evt.Origin, evt.IncomingCamera);
         }
 
+        void OnBlendCreated(CinemachineCore.BlendEventParams evt)
+        {
+            if (evt.Blend.CamA == (ICinemachineCamera)m_Vcam || evt.Blend.CamB == (ICinemachineCamera)m_Vcam)
+                BlendCreatedEvent.Invoke(evt);
+        }
+
         void OnBlendFinished(ICinemachineMixer mixer, ICinemachineCamera cam)
         {
             if (cam == (ICinemachineCamera)m_Vcam)
-                CameraBlendFinishedEvent.Invoke(mixer, cam);
+                BlendFinishedEvent.Invoke(mixer, cam);
         }
 
         void OnCameraDeactivated(ICinemachineMixer mixer, ICinemachineCamera cam)

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends.meta
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15666cb7409cfe544b467a00e568a453
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace Unity.Cinemachine.Samples
+{
+    public class BlendStyleManager : MonoBehaviour
+    {
+        class LookAtFirstBlender : CinemachineBlend.IBlender
+        {
+            // This method is free to blend the states any way it likes.
+            // In this case, we do a default blend then override the rotation to make
+            // it happen at the beginning of the blend.
+            public CameraState GetIntermediateState(ICinemachineCamera CamA, ICinemachineCamera CamB, float t)
+            {
+                var stateA = CamA.State;
+                var stateB = CamB.State;
+
+                // Standard blend - first we disable cylidrical position 
+                stateA.BlendHint &= ~CameraState.BlendHints.CylindricalPositionBlend;
+                stateB.BlendHint &= ~CameraState.BlendHints.CylindricalPositionBlend;
+                var state = CameraState.Lerp(stateA, stateB, t);
+
+                // Override the rotation blend: look directly at the new target at the beginning
+                const float kThreshold = 0.1f;
+                var rotB = Quaternion.LookRotation(stateB.ReferenceLookAt - state.RawPosition, state.ReferenceUp);
+                t = Bias(Mathf.Lerp(0, 1, t / kThreshold), 0.9f);
+                state.RawOrientation = Quaternion.Slerp(stateA.RawOrientation, rotB, t);
+
+                return state;
+            }
+
+            static float Bias(float t, float b) 
+                => (Mathf.Clamp(t, 0, 1) / ((((1f/Mathf.Clamp(b, 0, 1)) - 2f) * (1f - t)) + 1f));
+        }
+
+        LookAtFirstBlender m_CustomBlender = new ();
+
+        bool m_UseCustomBlend;
+
+        public void OnBlendCreated(CinemachineCore.BlendEventParams evt)
+        {
+            // Override the blender with a custom blender
+            if (m_UseCustomBlend)
+                evt.Blend.CustomBlender = m_CustomBlender;
+        }
+
+        public void SetDefaultBlend()
+        {
+            m_UseCustomBlend = false;
+            ChangeCamera();
+        }
+
+        public void SetCustomBlend1()
+        {
+            m_UseCustomBlend = true;
+            ChangeCamera();
+        }
+
+        void ChangeCamera()
+        {
+            // Cycle through all the virtual cameras, assuming that they all have the same priority.
+            // Prioritize the least-recently used one.
+            int numCameras = CinemachineCore.VirtualCameraCount;
+            CinemachineCore.GetVirtualCamera(numCameras - 1).Prioritize();
+        }
+    }
+}

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs
@@ -14,7 +14,7 @@ namespace Unity.Cinemachine.Samples
                 var stateA = CamA.State;
                 var stateB = CamB.State;
 
-                // Standard blend - first we disable cylidrical position 
+                // Standard blend - first we disable cylindrical position 
                 stateA.BlendHint &= ~CameraState.BlendHints.CylindricalPositionBlend;
                 stateB.BlendHint &= ~CameraState.BlendHints.CylindricalPositionBlend;
                 var state = CameraState.Lerp(stateA, stateB, t);

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs.meta
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/BlendStyleManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16eca234a25d87f4e9a54ac550e684e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
@@ -194,7 +194,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3521509573382385251, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
       propertyPath: m_Name
-      value: Player (1)
+      value: Green Player
       objectReference: {fileID: 0}
     - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
       propertyPath: m_RootOrder
@@ -373,7 +373,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 614925373}
-  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalRotation: {x: 1e-45, y: 1e-45, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -394,7 +394,7 @@ GameObject:
   - component: {fileID: 970848198}
   - component: {fileID: 970848197}
   m_Layer: 0
-  m_Name: CinemachineCamera (1)
+  m_Name: CinemachineCamera Green
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -562,21 +562,21 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6668015293666917239, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
       propertyPath: HelpText
-      value: 'This scene shows how to customize the camera blending algorithm.  Use
-        WASD to move the players.
-
-        
-
-        The main camera has a custom
-        BlendStyleManager script that listens for BlendCreated events and assigns
-        a custom blend object to the blend in cases where a custom blend is desired
-        - that is, when the uses presses the <i>Custom Blend</i> button.
+      value: 'This scene shows how to customize the camera blending algorithm.  There
+        are two players, each with a follow camera.  Use WASD to move the players.
 
         
 
         The
-        CinemachineBrainEvents script is used to listen for the event.  It is attached
-        to the main camera.
+        main camera has a custom BlendStyleManager script that listens for BlendCreated
+        events and assigns a custom blender to the blend in cases where a custom
+        blend is desired - that is, when the user presses the <i>Custom Blend</i>
+        button.
+
+        
+
+        The CinemachineBrainEvents script is used to
+        listen for the event.  It is attached to the main camera.
 
 '
       objectReference: {fileID: 0}
@@ -809,7 +809,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1990246953}
-  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalRotation: {x: 1e-45, y: 1e-45, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
@@ -1,0 +1,905 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &95774409
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916665, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436525663902916670, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+      propertyPath: m_Name
+      value: Checkerboard Stage
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c97e1248c10cd3549b3d18c1eb1c3722, type: 3}
+--- !u!1001 &493586491
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3521509573382385251, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_Name
+      value: Player (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157490968562004111, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 2125c72c59dd24bbfa7687d45ac370de, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+--- !u!4 &493586492 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_PrefabInstance: {fileID: 493586491}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &614925373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 614925377}
+  - component: {fileID: 614925376}
+  - component: {fileID: 614925375}
+  - component: {fileID: 614925374}
+  m_Layer: 0
+  m_Name: CinemachineCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &614925374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 614925373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TargetOffset: {x: 0, y: 1, z: 0}
+  Lookahead:
+    Enabled: 0
+    Time: 0
+    Smoothing: 0
+    IgnoreY: 0
+  Damping: {x: 0.5, y: 0.5}
+  Composition:
+    ScreenPosition: {x: 0, y: 0}
+    DeadZone:
+      Enabled: 0
+      Size: {x: 0.2, y: 0.2}
+    HardLimits:
+      Enabled: 0
+      Size: {x: 0.8, y: 0.8}
+      Offset: {x: 0, y: 0}
+  CenterOnActivate: 1
+--- !u!114 &614925375
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 614925373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b617507da6d07e749b7efdb34e1173e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FollowOffset: {x: 0, y: 1, z: -3}
+  TrackerSettings:
+    BindingMode: 5
+    PositionDamping: {x: 1, y: 1, z: 1}
+    AngularDampingMode: 0
+    RotationDamping: {x: 1, y: 1, z: 1}
+    QuaternionDamping: 1
+--- !u!114 &614925376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 614925373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 0
+    m_Value: 0
+  OutputChannel:
+    Enabled: 0
+    m_Value: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 0
+  m_LegacyPriority: 10
+  Target:
+    TrackingTarget: {fileID: 1475538426}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 73.97209
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 10
+--- !u!4 &614925377
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 614925373}
+  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &970848196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 970848200}
+  - component: {fileID: 970848199}
+  - component: {fileID: 970848198}
+  - component: {fileID: 970848197}
+  m_Layer: 0
+  m_Name: CinemachineCamera (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &970848197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 970848196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TargetOffset: {x: 0, y: 1, z: 0}
+  Lookahead:
+    Enabled: 0
+    Time: 0
+    Smoothing: 0
+    IgnoreY: 0
+  Damping: {x: 0.5, y: 0.5}
+  Composition:
+    ScreenPosition: {x: 0, y: 0}
+    DeadZone:
+      Enabled: 0
+      Size: {x: 0.2, y: 0.2}
+    HardLimits:
+      Enabled: 0
+      Size: {x: 0.8, y: 0.8}
+      Offset: {x: 0, y: 0}
+  CenterOnActivate: 1
+--- !u!114 &970848198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 970848196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b617507da6d07e749b7efdb34e1173e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FollowOffset: {x: 0, y: 1, z: -3}
+  TrackerSettings:
+    BindingMode: 5
+    PositionDamping: {x: 1, y: 1, z: 1}
+    AngularDampingMode: 0
+    RotationDamping: {x: 1, y: 1, z: 1}
+    QuaternionDamping: 1
+--- !u!114 &970848199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 970848196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 0
+    m_Value: 0
+  OutputChannel:
+    Enabled: 0
+    m_Value: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 0
+  m_LegacyPriority: 10
+  Target:
+    TrackingTarget: {fileID: 493586492}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 73.97209
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 10
+--- !u!4 &970848200
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 970848196}
+  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalPosition: {x: 30, y: 1, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &996105182
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451271811042757136, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6668015293666917239, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: HelpText
+      value: 'This scene shows how to customize the camera blending algorithm.  Use
+        WASD to move the players.
+
+        
+
+        The main camera has a custom
+        BlendStyleManager script that listens for BlendCreated events and assigns
+        a custom blend object to the blend in cases where a custom blend is desired
+        - that is, when the uses presses the <i>Custom Blend</i> button.
+
+        
+
+        The
+        CinemachineBrainEvents script is used to listen for the event.  It is attached
+        to the main camera.
+
+'
+      objectReference: {fileID: 0}
+    - target: {fileID: 9138370430051789472, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      propertyPath: m_Name
+      value: HelpUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 9138370430051789472, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 996105184}
+  m_SourcePrefab: {fileID: 100100000, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+--- !u!1 &996105183 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9138370430051789472, guid: d7425ed2047e64d8ea6ff79f20bd46f6, type: 3}
+  m_PrefabInstance: {fileID: 996105182}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &996105184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996105183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7950c6f52d74a4772bb69c03fe19a19b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Buttons:
+  - Name: Default Blend
+    IsToggle:
+      Enabled: 0
+      Value: 0
+      OnValueChanged:
+        m_PersistentCalls:
+          m_Calls: []
+    OnClick:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 1990246958}
+          m_TargetAssemblyTypeName: Unity.Cinemachine.Samples.BlendStyleManager,
+            Assembly-CSharp
+          m_MethodName: SetDefaultBlend
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - Name: Custom Blend
+    IsToggle:
+      Enabled: 0
+      Value: 0
+      OnValueChanged:
+        m_PersistentCalls:
+          m_Calls: []
+    OnClick:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 1990246958}
+          m_TargetAssemblyTypeName: Unity.Cinemachine.Samples.BlendStyleManager,
+            Assembly-CSharp
+          m_MethodName: SetCustomBlend1
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!1001 &1475538425
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3521509573382385251, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+--- !u!4 &1475538426 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4293402553517372633, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_PrefabInstance: {fileID: 1475538425}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1990246953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1990246956}
+  - component: {fileID: 1990246955}
+  - component: {fileID: 1990246954}
+  - component: {fileID: 1990246957}
+  - component: {fileID: 1990246959}
+  - component: {fileID: 1990246958}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1990246954
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_Enabled: 1
+--- !u!20 &1990246955
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 73.97209
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1990246956
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1990246957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowDebugText: 0
+  ShowCameraFrustum: 1
+  IgnoreTimeScale: 0
+  WorldUpOverride: {fileID: 0}
+  ChannelMask: -1
+  UpdateMethod: 2
+  BlendUpdateMethod: 1
+  LensModeOverride:
+    Enabled: 0
+    DefaultMode: 2
+  DefaultBlend:
+    Style: 1
+    Time: 2
+    CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  CustomBlends: {fileID: 0}
+--- !u!114 &1990246958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16eca234a25d87f4e9a54ac550e684e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1990246959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990246953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33a510488cc26384ea9c0600441770b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  CameraDeactivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  BlendCreatedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1990246958}
+        m_TargetAssemblyTypeName: Unity.Cinemachine.Samples.BlendStyleManager, Assembly-CSharp
+        m_MethodName: OnBlendCreated
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  BlendFinishedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  BrainUpdatedEvent:
+    m_PersistentCalls:
+      m_Calls: []

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity
@@ -500,7 +500,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 970848196}
-  m_LocalRotation: {x: -3e-45, y: 1e-45, z: 0, w: 1}
+  m_LocalRotation: {x: 1e-45, y: 1e-45, z: -0, w: 1}
   m_LocalPosition: {x: 30, y: 1, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -623,7 +623,7 @@ MonoBehaviour:
         - m_Target: {fileID: 1990246958}
           m_TargetAssemblyTypeName: Unity.Cinemachine.Samples.BlendStyleManager,
             Assembly-CSharp
-          m_MethodName: SetDefaultBlend
+          m_MethodName: DefaultBlend
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -646,7 +646,7 @@ MonoBehaviour:
         - m_Target: {fileID: 1990246958}
           m_TargetAssemblyTypeName: Unity.Cinemachine.Samples.BlendStyleManager,
             Assembly-CSharp
-          m_MethodName: SetCustomBlend1
+          m_MethodName: CustomBlend
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}

--- a/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity.meta
+++ b/com.unity.cinemachine/Samples~/3D Samples/Custom Blends/Custom Blends.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 22ec0824fa2148c4a998c6a40d8d6a81
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
+++ b/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
@@ -32,30 +32,34 @@ namespace Unity.Cinemachine.Tests.Editor
 
         int m_ActivatedEventCount;
         int m_DeactivatedEventCount;
+        int m_BlendCreatedCount;
         int m_BlendFinishedCount;
 
         void ActivatedEventHandler(ICinemachineCamera.ActivationEventParams evt) => ++m_ActivatedEventCount;
         void DeactivateEventHandler(ICinemachineMixer mixer, ICinemachineCamera cam) => ++m_DeactivatedEventCount;
+        void BlendCreatedEventHandler(CinemachineCore.BlendEventParams evt) => ++m_BlendCreatedCount;
         void BlendFinishedEventHandler(ICinemachineMixer mixer, ICinemachineCamera cam) => ++m_BlendFinishedCount;
 
         [SetUp] public void Setup() 
         { 
             CinemachineCore.CameraActivatedEvent.AddListener(ActivatedEventHandler);
             CinemachineCore.CameraDeactivatedEvent.AddListener(DeactivateEventHandler);
+            CinemachineCore.BlendCreatedEvent.AddListener(BlendCreatedEventHandler);
             CinemachineCore.BlendFinishedEvent.AddListener(BlendFinishedEventHandler);
         }
         [TearDown] public void TearDown() 
         { 
             CinemachineCore.CameraActivatedEvent.RemoveListener(ActivatedEventHandler);
             CinemachineCore.CameraDeactivatedEvent.RemoveListener(DeactivateEventHandler);
+            CinemachineCore.BlendCreatedEvent.RemoveListener(BlendCreatedEventHandler);
             CinemachineCore.BlendFinishedEvent.RemoveListener(BlendFinishedEventHandler);
         }
 
-        void ResetCounters() => m_ActivatedEventCount = m_DeactivatedEventCount = m_BlendFinishedCount = 0;
+        void ResetCounters() => m_ActivatedEventCount = m_DeactivatedEventCount = m_BlendCreatedCount = m_BlendFinishedCount = 0;
 
         void ProcessFrame(ICinemachineCamera cam, float deltaTime)
         {
-            m_BlendManager.UpdateRootFrame(cam, Vector3.up, deltaTime);
+            m_BlendManager.UpdateRootFrame(m_Mixer, cam, Vector3.up, deltaTime);
             m_BlendManager.ComputeCurrentBlend();
             m_BlendManager.ProcessActiveCamera(m_Mixer, Vector3.up, deltaTime);
         }
@@ -74,11 +78,13 @@ namespace Unity.Cinemachine.Tests.Editor
             Assert.AreEqual(1, m_ActivatedEventCount);
             Assert.AreEqual(0, m_DeactivatedEventCount);
             Assert.AreEqual(0, m_BlendFinishedCount);
+            Assert.AreEqual(0, m_BlendCreatedCount);
             Assert.That(m_BlendManager.IsBlending, Is.False);
 
             ProcessFrame(m_Cam1, 0.1f);
             Assert.AreEqual(1, m_ActivatedEventCount);
             Assert.AreEqual(0, m_DeactivatedEventCount);
+            Assert.AreEqual(0, m_BlendCreatedCount);
             Assert.AreEqual(0, m_BlendFinishedCount);
             Assert.That(m_BlendManager.IsBlending, Is.False);
 
@@ -86,18 +92,21 @@ namespace Unity.Cinemachine.Tests.Editor
             ProcessFrame(m_Cam2, 0.1f);
             Assert.AreEqual(2, m_ActivatedEventCount);
             Assert.AreEqual(0, m_DeactivatedEventCount);
+            Assert.AreEqual(1, m_BlendCreatedCount);
             Assert.AreEqual(0, m_BlendFinishedCount);
             Assert.That(m_BlendManager.IsBlending, Is.True);
 
             ProcessFrame(m_Cam2, 0.5f);
             Assert.AreEqual(2, m_ActivatedEventCount);
             Assert.AreEqual(0, m_DeactivatedEventCount);
+            Assert.AreEqual(1, m_BlendCreatedCount);
             Assert.AreEqual(0, m_BlendFinishedCount);
             Assert.That(m_BlendManager.IsBlending, Is.True);
 
             ProcessFrame(m_Cam2, 0.5f);
             Assert.AreEqual(2, m_ActivatedEventCount);
             Assert.AreEqual(1, m_DeactivatedEventCount);
+            Assert.AreEqual(1, m_BlendCreatedCount);
             Assert.AreEqual(1, m_BlendFinishedCount);
             Assert.That(m_BlendManager.IsBlending, Is.False);
         }

--- a/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
@@ -153,7 +153,7 @@ namespace Unity.Cinemachine.Tests
             yield return UpdateCinemachine();
             
             // finish blend
-            while (CurrentTime - startTime < k_BlendingTime * 0.1f)
+            while (CurrentTime - startTime < k_BlendingTime * 0.2f)
             {
                 Assert.That(ReferenceEquals(m_Brain.ActiveVirtualCamera, m_Target));
                 Assert.That(m_Brain.IsBlending, Is.True);


### PR DESCRIPTION
### Purpose of this PR

It is now possible to customize blends - both the timing and the algorithm - via events.

New event: CinemachineCore.BlendCreatedEvent.  Listeners can use this to customize the blend when it is created.  Entries were added to CinemachineBrainEvents and CinemachineCameraEvents for this.

Event handler can modify the BlendTime, BlendCurve, BlendStyle.
Event handler can optionally install a custom Blender (inherits CinemachineBlend.IBlender) to do the actual blending.

A sample scene demonstrating this was added (3D Samples/Custom Blends)

Note: BlendCreated events are NOT sent for timeline blends, as those are expected to be controlled 100% by timeline.  To modify the blend algorithm for timeline blends, client can install a handler for CinemachineCore.GetCustomBlender.

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

Surprisingly low.

