### PR TITLE
CMCL-0000: Fix evaluate local orientation returning global value

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] 
-- Bugfix: AxisState was not respecting timescale == 0
+- Bugfix: AxisState was not respecting timescale == 0.
 - Bugfix: Very occasional axis drift in SimpleFollow when viewing angle is +-90 degrees.
-- URP: add temporal effects reset on camera cut for URP 14.0.4 and up
-- Bugfix: MixingCamera calls OnTransitionFromCamera correctly for all its children
-- Bugfix: Passive vcams with noise were not respecting transform's z rotation during blends
+- URP: add temporal effects reset on camera cut for URP 14.0.4 and up.
+- Bugfix: MixingCamera calls OnTransitionFromCamera correctly for all its children.
+- Bugfix: Passive vcams with noise were not respecting transform's z rotation during blends.
+- Regression fix: CinemachineSmoothPath.GetLocalOrientation was returning global orientations.
 
 
 ## [2.9.5] - 2023-01-16

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -221,11 +221,9 @@ namespace Cinemachine
                         m_ControlPoints2[indexA].roll, m_Waypoints[indexB].roll);
                 }
 
-                Vector3 fwd = EvaluateTangent(pos);
+                Vector3 fwd = EvaluateLocalTangent(pos);
                 if (!fwd.AlmostZero())
                     result = Quaternion.LookRotation(fwd) * RollAroundForward(roll);
-                
-                result = Quaternion.Inverse(transform.rotation) * result;
             }
             return result;
         }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -161,9 +161,9 @@ namespace Cinemachine
             return pos;
         }
 
-        /// <summary>Get a worldspace position of a point along the path</summary>
+        /// <summary>Get a space position of a point along the path</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
-        /// <returns>World-space position of the point along at path at pos</returns>
+        /// <returns>Local position of the point along at path at pos</returns>
         public override Vector3 EvaluateLocalPosition(float pos)
         {
             var result = Vector3.zero;
@@ -183,7 +183,7 @@ namespace Cinemachine
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
-        /// <returns>World-space direction of the path tangent.
+        /// <returns>Local direction of the path tangent.
         /// Length of the vector represents the tangent strength</returns>
         public override Vector3 EvaluateLocalTangent(float pos)
         {
@@ -203,7 +203,7 @@ namespace Cinemachine
 
         /// <summary>Get the orientation the curve at a point along the path.</summary>
         /// <param name="pos">Position along the path.  Need not be normalized.</param>
-        /// <returns>World-space orientation of the path, as defined by tangent, up, and roll.</returns>
+        /// <returns>Local orientation of the path, as defined by tangent, up, and roll.</returns>
         public override Quaternion EvaluateLocalOrientation(float pos)
         {
             var result = Quaternion.identity;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -224,6 +224,8 @@ namespace Cinemachine
                 Vector3 fwd = EvaluateTangent(pos);
                 if (!fwd.AlmostZero())
                     result = Quaternion.LookRotation(fwd) * RollAroundForward(roll);
+                
+                result = Quaternion.Inverse(transform.rotation) * result;
             }
             return result;
         }

--- a/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachinePathBase.cs
@@ -63,13 +63,13 @@ namespace Cinemachine
         /// <returns>World-space position of the point along at path at pos</returns>
         public virtual Vector3 EvaluatePosition(float pos) => transform.TransformPoint(EvaluateLocalPosition(pos));
 
-        /// <summary>Get the tangent of the curve at a point along the path.</summary>
+        /// <summary>Get the world-space tangent of the curve at a point along the path.</summary>
         /// <param name="pos">Postion along the path.  Need not be standardized.</param>
         /// <returns>World-space direction of the path tangent.
         /// Length of the vector represents the tangent strength</returns>
         public virtual  Vector3 EvaluateTangent(float pos) => transform.TransformDirection(EvaluateLocalTangent(pos));
 
-        /// <summary>Get the orientation the curve at a point along the path.</summary>
+        /// <summary>Get the world-space orientation the curve at a point along the path.</summary>
         /// <param name="pos">Postion along the path.  Need not be standardized.</param>
         /// <returns>World-space orientation of the path</returns>
         public virtual Quaternion EvaluateOrientation(float pos) => transform.rotation * EvaluateLocalOrientation(pos);


### PR DESCRIPTION
Fix of evaluate local orientation returning a global value instead of a local one. 

Reported by a user.
https://forum.unity.com/threads/dolly-track-evaluate-orientation-is-incorrect-if-track-is-rotated-cm-2-9-5.1432078/#post-8987869