### PR TITLE
CMCL-1258: Deoccluder uses spherecast everywhere, to accommodate camera radius

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.0.0-pre.8] - unreleased
 - Bugfix: Occasional precision issue when camera rotation is exactly 180 degress, causing roitational flickering.
 - Bugfix: Deceleration at the end of axis range was too aggressive.
+- Deoccluder accommodates camera radius in all modes.
 
 
 ## [3.0.0-pre.7] - 2023-05-04

--- a/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
@@ -333,7 +333,7 @@ namespace Unity.Cinemachine
             float desiredCorrection = 0;
 
             if (RuntimeUtility.SphereCastIgnoreTag(
-                root, cameraRadius, dir, out RaycastHit hitInfo, 
+                new Ray(root, dir), cameraRadius, out RaycastHit hitInfo, 
                 len, AvoidObstacles.CollisionFilter, AvoidObstacles.IgnoreTag))
             {
                 var desiredResult = hitInfo.point + hitInfo.normal * cameraRadius;

--- a/com.unity.cinemachine/Runtime/Core/RuntimeUtility.cs
+++ b/com.unity.cinemachine/Runtime/Core/RuntimeUtility.cs
@@ -86,19 +86,24 @@ namespace Unity.Cinemachine
         /// <summary>
         /// Perform a sphere cast, but pass through objects with a given tag
         /// </summary>
-        /// <param name="rayStart">Start of the ray</param>
+        /// <param name="ray">The ray to cast - this will be the center of the spherecast.</param>
         /// <param name="radius">Radius of the sphere cast</param>
-        /// <param name="dir">Normalized direction of the ray</param>
         /// <param name="hitInfo">Results go here</param>
         /// <param name="rayLength">Length of the ray</param>
         /// <param name="layerMask">Layers to include</param>
         /// <param name="ignoreTag">Tag to ignore</param>
         /// <returns>True if something is hit.  Results in hitInfo.</returns>
         public static bool SphereCastIgnoreTag(
-            Vector3 rayStart, float radius, Vector3 dir, 
+            Ray ray, float radius, 
             out RaycastHit hitInfo, float rayLength, 
             int layerMask, in string ignoreTag)
         {
+            if (radius < UnityVectorExtensions.Epsilon)
+                return RaycastIgnoreTag(ray, out hitInfo, rayLength, layerMask, ignoreTag);
+
+            Vector3 rayStart = ray.origin;
+            Vector3 dir = ray.direction;
+
             int closestHit = -1;
             int numPenetrations = 0;
             float penetrationDistanceSum = 0;

--- a/com.unity.cinemachine/Runtime/Deprecated/Cinemachine3rdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/Cinemachine3rdPersonFollow.cs
@@ -306,7 +306,7 @@ namespace Unity.Cinemachine
             float desiredCorrection = 0;
 
             if (RuntimeUtility.SphereCastIgnoreTag(
-                root, cameraRadius, dir, out RaycastHit hitInfo, 
+                new Ray(root, dir), cameraRadius, out RaycastHit hitInfo, 
                 len, CameraCollisionFilter, IgnoreTag))
             {
                 var desiredResult = hitInfo.point + hitInfo.normal * cameraRadius;

--- a/com.unity.cinemachine/Tests/Runtime/RuntimeUtilityTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/RuntimeUtilityTests.cs
@@ -60,11 +60,11 @@ namespace Unity.Cinemachine.Tests
             var sphereRadius = 1f;
             
             // check ray cast hit
-            Assert.True(RuntimeUtility.SphereCastIgnoreTag(Vector3.zero, sphereRadius, direction, out var hitInfo, rayLength, m_LayerMask, string.Empty));
+            Assert.True(RuntimeUtility.SphereCastIgnoreTag(new Ray(Vector3.zero, direction), sphereRadius, out var hitInfo, rayLength, m_LayerMask, string.Empty));
             Assert.That(hitInfo.distance, Is.EqualTo(boxPosition.z - (m_BoxCollider.size.z / 2f) - sphereRadius));
             
             // check that ray cast did not hit anything, because it ignores the box's tag
-            Assert.False(RuntimeUtility.SphereCastIgnoreTag(Vector3.zero, sphereRadius, direction, out hitInfo, rayLength, m_LayerMask, k_BoxTag));
+            Assert.False(RuntimeUtility.SphereCastIgnoreTag(new Ray(Vector3.zero, direction), sphereRadius, out hitInfo, rayLength, m_LayerMask, k_BoxTag));
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

This makes behaviour match PullCameraForward mode, and clears up camera jitter.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x ] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

