### PR TITLE
CMCL-1481: Bugfix: Orbital recentering should not be forced when transitioning t…

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Bugfix: Occasional precision issue when camera rotation is exactly 180 degress, causing rotational flickering.
 - Bugfix: Deceleration at the end of axis range was too aggressive.
+- Bugfix: Orbital recentering should not be forced when transitioning to a camera.
+- Bugfix: InheritPosition takes the actual camera position, so it works consistently if transitioning mid-blend.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -226,7 +226,7 @@ namespace Unity.Cinemachine
                 && !CinemachineCore.IsLiveInBlend(VirtualCamera))
             {
                 var state = fromCam.State;
-                ForceCameraPosition(state.RawPosition, state.RawOrientation);
+                ForceCameraPosition(state.GetFinalPosition(), state.GetFinalOrientation());
                 return true;
             }
             return false;
@@ -380,7 +380,9 @@ namespace Unity.Cinemachine
             if (!IsValid)
                 return;
 
-            if (deltaTime < 0 || !VirtualCamera.PreviousStateIsValid || !CinemachineCore.IsLive(VirtualCamera))
+            // Force a reset if enabled, but don't be too aggressive about it,
+            // because maybe we've just inherited a position
+            if (deltaTime < 0)// || !VirtualCamera.PreviousStateIsValid || !CinemachineCore.IsLive(VirtualCamera)
                 m_ResetHandler?.Invoke();
 
             Vector3 offset = GetCameraPoint();

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -153,10 +153,16 @@ namespace Unity.Cinemachine
                 else
                 {
                     // Generate ActivationEvents
+                    var eventOutgoing = outgoingCamera;
+                    if (IsBlending)
+                    {
+                        eventOutgoing = new NestedBlendSource(ActiveBlend);
+                        eventOutgoing.UpdateCameraState(up, deltaTime);
+                    }
                     var evt = new ICinemachineCamera.ActivationEventParams
                     {
                         Origin = mixer,
-                        OutgoingCamera = outgoingCamera,
+                        OutgoingCamera = eventOutgoing,
                         IncomingCamera = incomingCamera,
                         IsCut = !IsBlending || !IsLive(outgoingCamera),
                         WorldUp = up,

--- a/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineBlend.cs
@@ -292,12 +292,18 @@ namespace Unity.Cinemachine
     /// as an ersatz virtual camera for the purposes of blending.  This achieves the purpose
     /// of blending the result oif a blend.
     /// </summary>
-    class NestedBlendSource : ICinemachineCamera
+    public class NestedBlendSource : ICinemachineCamera
     {
-        public NestedBlendSource(CinemachineBlend blend) { Blend = blend; }
-        public CinemachineBlend Blend { get; set; }
         string m_Name;
 
+        /// <summary>Contructor to wrap a CinemachineBlend object</summary>
+        /// <param name="blend">The blend to wrap.</param>
+        public NestedBlendSource(CinemachineBlend blend) { Blend = blend; }
+
+        /// <summary>The CinemachineBlend object being wrapped.</summary>
+        public CinemachineBlend Blend { get; internal set; }
+
+        /// <inheritdoc />
         public string Name 
         { 
             get
@@ -307,10 +313,15 @@ namespace Unity.Cinemachine
                 return m_Name;
             }
         }
+        /// <inheritdoc />
         public string Description => Blend == null ? "(null)" : Blend.Description;
+        /// <inheritdoc />
         public CameraState State { get; private set; }
+        /// <inheritdoc />
         public bool IsValid => Blend != null && Blend.IsValid; 
+        /// <inheritdoc />
         public ICinemachineMixer ParentCamera => null;
+        /// <inheritdoc />
         public void UpdateCameraState(Vector3 worldUp, float deltaTime)
         {
             if (Blend != null)
@@ -319,6 +330,7 @@ namespace Unity.Cinemachine
                 State = Blend.State;
             }
         }
+        /// <inheritdoc />
         public void OnCameraActivated(ICinemachineCamera.ActivationEventParams evt) {}
     }
 }


### PR DESCRIPTION
…o a camera.

### Purpose of this PR

Forum thread: https://forum.unity.com/threads/possible-bug-or-just-confusion-with-multiple-binding-modes.1451560/#post-9105868

When an OrbitalFollow has recentering enabled, transitioning to it always forced a recentered state, breaking InheritPosition.

Now, recentering is no longer forced.

Also, the FromCamera can now be a mid-blend object, making InheritPosition accurate in those cases.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

