### PR TITLE
CMCL-1496: CinemachineDeoccluder was causing a pop when OnTargetObjectWarp…

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Deceleration at the end of axis range was too aggressive.
 - Bugfix: Orbital recentering should not be forced when transitioning to a camera.
 - Bugfix: InheritPosition takes the actual camera position, so it works consistently if transitioning mid-blend.
+- Bugfix: CinemachineDeoccluder was causing a pop when OnTargetObjectWarped was called.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -329,6 +329,14 @@ namespace Unity.Cinemachine
                 : 0; 
         }
         
+        /// <inheritdoc />
+        public override void OnTargetObjectWarped(
+            CinemachineVirtualCameraBase vcam, Transform target, Vector3 positionDelta)
+        {
+            var extra = GetExtraState<VcamExtraState>(vcam);
+            extra.PreviousCameraPosition += positionDelta;
+        }
+        
         /// <summary>
         /// Callback to do the collision resolution and shot evaluation
         /// </summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1496

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

