### PR TITLE
CMCL-1498: Spurious camera cut events were being issued, especially in HDRP

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Orbital recentering should not be forced when transitioning to a camera.
 - Bugfix: InheritPosition takes the actual camera position, so it works consistently if transitioning mid-blend.
 - Bugfix: CinemachineDeoccluder was causing a pop when OnTargetObjectWarped was called.
+- Bugfix: Spurious camera cut events were being issued, especially in HDRP.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.

--- a/com.unity.cinemachine/Runtime/Core/BlendManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/BlendManager.cs
@@ -164,7 +164,7 @@ namespace Unity.Cinemachine
                         Origin = mixer,
                         OutgoingCamera = eventOutgoing,
                         IncomingCamera = incomingCamera,
-                        IsCut = !IsBlending || !IsLive(outgoingCamera),
+                        IsCut = !IsBlending,// does not work with snapshots: || !IsLive(outgoingCamera),
                         WorldUp = up,
                         DeltaTime = deltaTime
                     };

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -214,12 +214,14 @@ namespace Unity.Cinemachine
 
         static void OnCameraCut(ICinemachineCamera.ActivationEventParams evt)
         {
+            if (!evt.IsCut)
+                return;
+
             var brain = evt.Origin as CinemachineBrain;
-            //Debug.Log($"Camera cut to {brain?.ActiveVirtualCamera.Name}");
+            var cam = brain == null ? null : brain.OutputCamera;
 
 #if CINEMACHINE_HDRP
             // Reset temporal effects
-            var cam = brain?.OutputCamera;
             if (cam != null)
             {
                 HDCamera hdCam = HDCamera.GetOrCreate(cam);
@@ -229,7 +231,6 @@ namespace Unity.Cinemachine
             }
 #elif CINEMACHINE_URP
             // Reset temporal effects
-            var cam = brain?.OutputCamera;
             if (cam != null && cam.TryGetComponent<UniversalAdditionalCameraData>(out var data))
                 data.resetHistory = true;
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-1498: 

There were 2 causes for this issue:

1. Camera Cut events were being generated sometimes when actually it was a blend.
2. CinemachineVolumeSettings was not checking evt.IsCut, and was always doing an HDRP temporal reset, causing text to flash.


### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

