### PR TITLE
CMCL-1499: Fix leaks in TrackAnyUserActivity

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: InheritPosition takes the actual camera position, so it works consistently if transitioning mid-blend.
 - Bugfix: CinemachineDeoccluder was causing a pop when OnTargetObjectWarped was called.
 - Bugfix: Spurious camera cut events were being issued, especially in HDRP.
+- Bugfix: Mull reference exceptions when inspector is hidden behind another tab.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -419,9 +419,12 @@ namespace Unity.Cinemachine.Editor
         public static void TrackAnyUserActivity(
             this VisualElement owner, EditorApplication.CallbackFunction callback)
         {
-            UserDidSomething += callback;
-            owner.OnInitialGeometry(callback); 
-            owner.RegisterCallback<DetachFromPanelEvent>(_ => UserDidSomething -= callback);
+            owner.RegisterCallback<AttachToPanelEvent>(_ =>
+            {
+                UserDidSomething += callback;
+                owner.OnInitialGeometry(callback); 
+                owner.RegisterCallback<DetachFromPanelEvent>(_ => UserDidSomething -= callback);
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1499: Incorrect TrackAnyUserActivity iplementation caused leaks and null reference exceptions when inspector panel was hidden under another tab

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

