### PR TITLE
CMCL-1505: Incorrect warning in Group Framing inspector, and no way to set screen position

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineDeoccluder was causing a pop when OnTargetObjectWarped was called.
 - Bugfix: Spurious camera cut events were being issued, especially in HDRP.
 - Bugfix: Mull reference exceptions when inspector is hidden behind another tab.
+- Bugfix: Group Framing inspector was displaying incorrect warning when LookAt target is a group.
+- Group Framing: Added a setting to control framing offset, allowing groups to be not centered on the screen.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.

--- a/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
@@ -1,6 +1,6 @@
 # Group Framing
 
-This CinemachineCamera extension adds the ability to frame multiple targets when they are members of a CinemachineTargetGroup. It can be used to dynamically adjust the zoom or to move the camera closer to or farther from the targets, to keep them in the frame.
+This CinemachineCamera extension adds the ability to frame one or more targets when they are members of a CinemachineTargetGroup. It can be used to dynamically adjust the zoom or to move the camera closer to or farther from the targets, to keep them in the frame at the desired size.
 
 For this to work, the CinemachineCamera's Tracking Target must be a CinemachineTargetGroup, with at least one member, and having a nonzero size.
 
@@ -18,12 +18,13 @@ For this to work, the CinemachineCamera's Tracking Target must be a CinemachineT
 | | _Dolly Then Zoom_ | Move the camera as much as permitted by the ranges, then adjust the FOV if necessary to make the shot. |
 | __Lateral Adjustment__ || How to adjust the camera horizontally and vertically to get the desired framing. You can change position to reframe, or rotate the camera to reframe.  |
 | | _Change Position_ | Camera is moved horizontally and vertically until the desired framing is achieved. |
-| | _Dolly Only_ | Camera is rotated to achieve the desired framing. |
+| | _Change Rotation_ | Camera is rotated to achieve the desired framing. |
 | __Framing Size__ || The screen-space bounding box that the targets should occupy. Use 1 to fill the whole screen, 0.5 to fill half the screen, and so on. |
+| __Framing Offset__ || How to offset the group's bounding shape on the screen, so that the group is not necessarily presented at screen center.  0 is screen center, 1 and -1 are the edges of the screen. |
 | __Damping__ || How gradually to make the framing adjustment. A larger number gives a slower response, smaller numbers a snappier one. |
 | __Dolly Range__ || The allowable range that the camera may be moved in order to achieve the desired framing. A negative distance is towards the target, and a positive distance is away from the target. |
-| __FOV Range__ || If adjusting FOV, do not set the FOV outside of this range.  |
-| __Ortho Size Range__ || If adjusting Orthographic Size, do not set it outside of this range.  |
+| __FOV Range__ || If adjusting FOV, it will be clamped to this range.  |
+| __Ortho Size Range__ || If adjusting Orthographic Size, it will be clamped to this range.  |
 
 
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -35,6 +35,7 @@ namespace Unity.Cinemachine.Editor
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingMode)));
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingSize)));
             ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.Damping)));
+            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingOffset)));
 
             var perspectiveControls = ux.AddChild(new VisualElement());
 

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -17,7 +17,7 @@ namespace Unity.Cinemachine.Editor
 
         const string k_NeedTarget = "A Tracking Target is required in the CinemachineCamera.";
         const string k_NeedLookAt = "A LookAt Tracking Target is required in the CinemachineCamera.";
-        const string k_NeedGroup = "The Tracking Target in the CinemachineCamera must be a Target Group.";
+        const string k_NeedGroup = "The Tracking or LookAt Target in the CinemachineCamera must be a Target Group.";
         const string k_NeedCamera = "This component is intended to be used only with a CinemachineCamera.";
         const string k_AddCamera = "Add\nCinemachineCamera";
 
@@ -61,7 +61,7 @@ namespace Unity.Cinemachine.Editor
                         {
                             case RequiredTargets.Tracking: noTarget |= c.FollowTarget == null; break;
                             case RequiredTargets.LookAt: noTarget |= c.LookAtTarget == null; break;
-                            case RequiredTargets.Group: noTarget |= c.FollowTargetAsGroup == null; break;
+                            case RequiredTargets.Group: noTarget |= c.FollowTargetAsGroup == null && c.LookAtTargetAsGroup == null; break;
                         }
                     }
                     else if (targets[i] is CinemachineExtension x)
@@ -71,7 +71,8 @@ namespace Unity.Cinemachine.Editor
                         {
                             case RequiredTargets.Tracking: noTarget |= noCamera || x.ComponentOwner.Follow == null; break;
                             case RequiredTargets.LookAt: noTarget |= noCamera || x.ComponentOwner.LookAt == null; break;
-                            case RequiredTargets.Group: noTarget |= noCamera || x.ComponentOwner.FollowTargetAsGroup == null; break;
+                            case RequiredTargets.Group: noTarget |= noCamera 
+                                || (x.ComponentOwner.FollowTargetAsGroup == null && x.ComponentOwner.LookAtTargetAsGroup == null); break;
                         }
                     }
                     else if (targets[i] is MonoBehaviour b)


### PR DESCRIPTION
### Purpose of this PR

CMCL-1505: Group framing inspector was displaying incorrect warning when LookAt target was a group and not Tracking Target.
Also: added Size Framing setting to Grop Framing extension, to control the position of the group on-screen.
Aslo: corrected some errors in the doc

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low

