### PR TITLE
CMCL-1506: group framing fixes

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -12,14 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineDeoccluder was causing a pop when OnTargetObjectWarped was called.
 - Bugfix: Spurious camera cut events were being issued, especially in HDRP.
 - Bugfix: Mull reference exceptions when inspector is hidden behind another tab.
-- Bugfix: Group Framing inspector was displaying incorrect warning when LookAt target is a group.
-- Group Framing: Added a setting to control framing offset, allowing groups to be not centered on the screen.
-- Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow
+- Bugfix: GroupFraming inspector was displaying incorrect warning when LookAt target is a group.
+- Bugfix: GroupFraming displays more accurate group size indicator in the game view.
+- Bugfix: nullrefs in log when target group was deleted but was still being referenced by vcams.
+- Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow.
 - Deoccluder accommodates camera radius in all modes.
 - StateDrivenCamera: child camera enabled status and priority are now taken into account when choosing the current active camera.
 - Renamed CinemachineSplineDolly.CameraUp to CameraRotation, which more accurately reflects what it does.
 - Renamed InputAxis.DoRecentering() to InputAxis.UpdateRecentering()
 - Added API in Deoccluder and ThirdPersonFollow to access which collision objects are impacting the camera position.
+- Added ICinemachineTargetGroup.IsValid property to detect deleted groups.
 - Removed CinemachineToolSettings overlay.
 
 

--- a/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
@@ -20,7 +20,6 @@ For this to work, the CinemachineCamera's Tracking Target must be a CinemachineT
 | | _Change Position_ | Camera is moved horizontally and vertically until the desired framing is achieved. |
 | | _Change Rotation_ | Camera is rotated to achieve the desired framing. |
 | __Framing Size__ || The screen-space bounding box that the targets should occupy. Use 1 to fill the whole screen, 0.5 to fill half the screen, and so on. |
-| __Framing Offset__ || How to offset the group's bounding shape on the screen, so that the group is not necessarily presented at screen center.  0 is screen center, 1 and -1 are the edges of the screen. |
 | __Damping__ || How gradually to make the framing adjustment. A larger number gives a slower response, smaller numbers a snappier one. |
 | __Dolly Range__ || The allowable range that the camera may be moved in order to achieve the desired framing. A negative distance is towards the target, and a positive distance is away from the target. |
 | __FOV Range__ || If adjusting FOV, it will be clamped to this range.  |

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -27,26 +27,24 @@ namespace Unity.Cinemachine.Editor
 
         public override VisualElement CreateInspectorGUI()
         {
-            var serializedTarget = new SerializedObject(Target);
             var ux = new VisualElement();
             this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.Group);
             var groupSizeIsZeroHelp = ux.AddChild(new HelpBox("Group size is zero, cannot frame.", HelpBoxMessageType.Warning));
 
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingMode)));
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingSize)));
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.Damping)));
-            ux.Add(new PropertyField(serializedTarget.FindProperty(() => Target.FramingOffset)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingMode)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingSize)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
             var perspectiveControls = ux.AddChild(new VisualElement());
 
-            var sizeAdjustmentProperty = serializedTarget.FindProperty(() => Target.SizeAdjustment);
+            var sizeAdjustmentProperty = serializedObject.FindProperty(() => Target.SizeAdjustment);
             perspectiveControls.Add(new PropertyField(sizeAdjustmentProperty));
-            perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.LateralAdjustment)));
-            var fovRange = perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.FovRange)));
-            var dollyRange = perspectiveControls.AddChild(new PropertyField(serializedTarget.FindProperty(() => Target.DollyRange)));
+            perspectiveControls.AddChild(new PropertyField(serializedObject.FindProperty(() => Target.LateralAdjustment)));
+            var fovRange = perspectiveControls.AddChild(new PropertyField(serializedObject.FindProperty(() => Target.FovRange)));
+            var dollyRange = perspectiveControls.AddChild(new PropertyField(serializedObject.FindProperty(() => Target.DollyRange)));
 
             var orthoControls = ux.AddChild(new VisualElement());
-            orthoControls.Add(new PropertyField(serializedTarget.FindProperty(() => Target.OrthoSizeRange)));
+            orthoControls.Add(new PropertyField(serializedObject.FindProperty(() => Target.OrthoSizeRange)));
 
             ux.TrackPropertyValue(sizeAdjustmentProperty, (prop) =>
             {
@@ -67,7 +65,11 @@ namespace Unity.Cinemachine.Editor
                 {
                     var vcam = (targets[i] as CinemachineGroupFraming).ComponentOwner;
                     if (vcam != null)
+                    {
                         group = vcam.FollowTargetAsGroup;
+                        if (group != null && !group.IsValid)
+                            group = null;
+                    }
                 }
                 groupSizeIsZeroHelp.SetVisible(group != null && group.Sphere.radius < 0.01f);
 
@@ -88,23 +90,28 @@ namespace Unity.Cinemachine.Editor
                 return;
 
             var vcam = Target.ComponentOwner;
-            if (!brain.IsValidChannel(vcam))
+            if (!brain.IsValidChannel(vcam) || !brain.IsLiveChild(vcam))
                 return;
 
             var group = vcam.LookAtTargetAsGroup;
-            if (group == null)
+            group ??= vcam.FollowTargetAsGroup;
+            if (group == null || !group.IsValid)
                 return;
 
             CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
-                group, group.Sphere.position, 
-                vcam.State.GetFinalOrientation(), brain.OutputCamera);
+                group.Sphere.position, brain.OutputCamera);
+            CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenGroupSizeMarker(
+                Target.GroupBounds, Target.GroupBoundsMatrix, brain.OutputCamera);
         }
         
         [DrawGizmo(GizmoType.Active | GizmoType.InSelectionHierarchy, typeof(CinemachineGroupFraming))]
         static void DrawGroupComposerGizmos(CinemachineGroupFraming target, GizmoType selectionType)
         {
             // Show the group bounding box, as viewed from the camera position
-            if (target.enabled && target.ComponentOwner != null && target.ComponentOwner.FollowTargetAsGroup != null)
+            var vcam = target.ComponentOwner;
+            if (!target.enabled && vcam != null 
+                && (vcam.FollowTargetAsGroup != null && vcam.FollowTargetAsGroup.IsValid)
+                || (vcam.LookAtTargetAsGroup != null && vcam.LookAtTargetAsGroup.IsValid))
             {
                 var oldM = Gizmos.matrix;
                 var oldC = Gizmos.color;
@@ -112,7 +119,7 @@ namespace Unity.Cinemachine.Editor
                 Gizmos.matrix = target.GroupBoundsMatrix;
                 Bounds b = target.GroupBounds;
                 Gizmos.color = Color.yellow;
-                if (target.ComponentOwner.State.Lens.Orthographic)
+                if (vcam.State.Lens.Orthographic)
                     Gizmos.DrawWireCube(b.center, b.size);
                 else
                 {

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -76,11 +76,8 @@ namespace Unity.Cinemachine.Editor
 
             // Draw an on-screen gizmo for the target
             if (Target.FollowTarget != null && isLive)
-            {
                 CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
-                    null, Target.TrackedPoint, 
-                    vcam.State.GetFinalOrientation(), brain.OutputCamera);
-            }
+                    Target.TrackedPoint, brain.OutputCamera);
         }
 
         void OnSceneGUI()

--- a/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
@@ -74,11 +74,8 @@ namespace Unity.Cinemachine.Editor
 
             // Draw an on-screen gizmo for the target
             if (Target.LookAtTarget != null && isLive)
-            {
                 CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
-                    null, Target.TrackedPoint, 
-                    vcam.State.GetFinalOrientation(), brain.OutputCamera);
-            }
+                    Target.TrackedPoint, brain.OutputCamera);
         }
 
         void OnSceneGUI()

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineComposerEditor.cs
@@ -74,11 +74,8 @@ namespace Unity.Cinemachine.Editor
 
             // Draw an on-screen gizmo for the target
             if (Target.LookAtTarget != null && isLive)
-            {
                 CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
-                    Target.LookAtTargetAsGroup, Target.TrackedPoint, 
-                    vcam.State.GetFinalOrientation(), brain.OutputCamera);
-            }
+                    Target.TrackedPoint, brain.OutputCamera);
         }
 
         void OnSceneGUI()

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineFramingTransposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineFramingTransposerEditor.cs
@@ -25,7 +25,7 @@ namespace Unity.Cinemachine.Editor
                 excluded.Add(FieldPath(x => x.m_BiasY));
             }
             ICinemachineTargetGroup group = Target.FollowTargetAsGroup;
-            if (group == null || Target.m_GroupFramingMode == CinemachineFramingTransposer.FramingMode.None)
+            if (group == null || !group.IsValid || Target.m_GroupFramingMode == CinemachineFramingTransposer.FramingMode.None)
             {
                 excluded.Add(FieldPath(x => x.m_GroupFramingSize));
                 excluded.Add(FieldPath(x => x.m_AdjustmentMode));
@@ -37,7 +37,7 @@ namespace Unity.Cinemachine.Editor
                 excluded.Add(FieldPath(x => x.m_MaximumFOV));
                 excluded.Add(FieldPath(x => x.m_MinimumOrthoSize));
                 excluded.Add(FieldPath(x => x.m_MaximumOrthoSize));
-                if (group == null)
+                if (group == null || !group.IsValid)
                     excluded.Add(FieldPath(x => x.m_GroupFramingMode));
             }
             else
@@ -143,18 +143,15 @@ namespace Unity.Cinemachine.Editor
             
             // Draw an on-screen gizmo for the target
             if (Target.FollowTarget != null && isLive)
-            {
                 CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
-                    Target.LookAtTargetAsGroup, Target.TrackedPoint, 
-                    vcam.State.GetFinalOrientation(), brain.OutputCamera);
-            }
+                    Target.TrackedPoint, brain.OutputCamera);
         }
 
         [DrawGizmo(GizmoType.Active | GizmoType.InSelectionHierarchy, typeof(CinemachineFramingTransposer))]
         private static void DrawGroupComposerGizmos(CinemachineFramingTransposer target, GizmoType selectionType)
         {
             // Show the group bounding box, as viewed from the camera position
-            if (target.FollowTargetAsGroup != null
+            if (target.FollowTargetAsGroup != null && target.FollowTargetAsGroup.IsValid
                 && target.m_GroupFramingMode != CinemachineFramingTransposer.FramingMode.None)
             {
                 Matrix4x4 m = Gizmos.matrix;

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineGroupComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineGroupComposerEditor.cs
@@ -60,7 +60,7 @@ namespace Unity.Cinemachine.Editor
 
         public override void OnInspectorGUI()
         {
-            if (MyTarget.IsValid && MyTarget.LookAtTargetAsGroup == null)
+            if (MyTarget.IsValid && (MyTarget.LookAtTargetAsGroup == null || !MyTarget.LookAtTargetAsGroup.IsValid))
                 EditorGUILayout.HelpBox(
                     "The Framing settings will be ignored because the LookAt target is not a kind of ICinemachineTargetGroup",
                     MessageType.Info);
@@ -72,7 +72,7 @@ namespace Unity.Cinemachine.Editor
         static void DrawGroupComposerGizmos(CinemachineGroupComposer target, GizmoType selectionType)
         {
             // Show the group bounding box, as viewed from the camera position
-            if (target.LookAtTargetAsGroup != null)
+            if (target.LookAtTargetAsGroup != null && target.LookAtTargetAsGroup.IsValid)
             {
                 Matrix4x4 m = Gizmos.matrix;
                 Bounds b = target.LastBounds;

--- a/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
+++ b/com.unity.cinemachine/Editor/Upgrader/UpgradeObjectToCm3.cs
@@ -78,7 +78,7 @@ namespace Unity.Cinemachine.Editor
                 {
                     var ft = go.GetComponent<CinemachineFramingTransposer>();
                     ft.UpgradeToCm3(go.GetComponent<CinemachinePositionComposer>());
-                    if (ft.FollowTargetAsGroup != null 
+                    if (ft.FollowTargetAsGroup != null && ft.FollowTargetAsGroup.IsValid
                         && ft.m_GroupFramingMode != CinemachineFramingTransposer.FramingMode.None
                         && !go.TryGetComponent<CinemachineGroupFraming>(out var _))
                     {

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -43,12 +43,6 @@ namespace Unity.Cinemachine
             + "rapidly adjusting the camera to keep the group in the frame.  Larger numbers give a heavier "
             + "more slowly responding camera.")]
         public float Damping = 2f;
-
-        /// <summary>
-        /// Offset from screen center at which to place the group center.  X is left/right, Y is up/down.
-        /// </summary>
-        [Tooltip("Offset from screen center at which to place the group center.  X is left/right, Y is up/down")]
-        public Vector2 FramingOffset = Vector2.zero;
         
         /// <summary>How to adjust the camera to get the desired framing size</summary>
         public enum SizeAdjustmentModes
@@ -117,7 +111,6 @@ namespace Unity.Cinemachine
             LateralAdjustment = LateralAdjustmentModes.ChangePosition;
             FramingSize = 0.8f;
             Damping = 2;
-            FramingOffset = Vector2.zero;
             DollyRange = new Vector2(-100, 100);
             FovRange = new Vector2(1, 100);
             OrthoSizeRange = new Vector2(1, 1000);
@@ -167,7 +160,7 @@ namespace Unity.Cinemachine
             
             var group = vcam.LookAtTargetAsGroup;
             group ??= vcam.FollowTargetAsGroup;
-            if (group == null)
+            if (group == null || !group.IsValid)
                 return;
 
             var extra = GetExtraState<VcamExtraState>(vcam);
@@ -204,10 +197,6 @@ namespace Unity.Cinemachine
             extra.FovAdjustment += vcam.DetachedFollowTargetDamp(deltaFov - extra.FovAdjustment, damping, deltaTime);
             lens.OrthographicSize += extra.FovAdjustment;
             state.Lens = lens;
-
-            // Apply framing offset
-            state.PositionCorrection -= state.RawOrientation * new Vector3(
-                lens.OrthographicSize * lens.Aspect * FramingOffset.x, lens.OrthographicSize * FramingOffset.y, 0);
         }
 
         void PerspectiveFraming(
@@ -260,20 +249,6 @@ namespace Unity.Cinemachine
             var deltaPos = Quaternion.Inverse(state.RawOrientation) * (camPos - state.RawPosition);
             extra.PosAdjustment += vcam.DetachedFollowTargetDamp(deltaPos - extra.PosAdjustment, damping, deltaTime);
             state.PositionCorrection += state.RawOrientation * extra.PosAdjustment;
-
-            // Apply framing offset
-            if (moveCamera)
-            {
-                var h = Mathf.Tan(Mathf.Deg2Rad * lens.FieldOfView * 0.5f) * GroupBounds.center.z;
-                state.PositionCorrection -= state.RawOrientation * new Vector3(
-                    h * lens.Aspect * FramingOffset.x, h * FramingOffset.y, 0);
-            }
-            else
-            {
-                state.OrientationCorrection = state.OrientationCorrection.ApplyCameraRotation(new Vector2(
-                    lens.FieldOfView * lens.Aspect * FramingOffset.y * 0.5f, 
-                    lens.FieldOfView * FramingOffset.x * -0.5f), Quaternion.Inverse(state.GetFinalOrientation()) * state.ReferenceUp);
-            }
         }
 
         void AdjustSize(

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -12,6 +12,11 @@ namespace Unity.Cinemachine
     public interface ICinemachineTargetGroup
     {
         /// <summary>
+        /// Returns true if object has not been deleted.
+        /// </summary>
+        bool IsValid { get; }
+
+        /// <summary>
         /// Get the MonoBehaviour's Transform
         /// </summary>
         Transform Transform { get; }
@@ -192,6 +197,9 @@ namespace Unity.Cinemachine
         /// Get the MonoBehaviour's Transform
         /// </summary>
         public Transform Transform => transform;
+
+        /// <inheritdoc />
+        public bool IsValid => this != null;
 
         /// <summary>The axis-aligned bounding box of the group, computed using the
         /// targets positions and radii</summary>

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -725,7 +725,7 @@ namespace Unity.Cinemachine
         /// targets and update the target cache.  This is needed for tracking
         /// when a target object changes.
         /// </summary>
-        protected void UpdateTargetCache()
+        public void UpdateTargetCache()
         {
             var target = ResolveFollow(Follow);
             FollowTargetChanged = target != m_CachedFollowTarget;

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -398,7 +398,7 @@ namespace Unity.Cinemachine
     {
         /// <summary>Inflate a rect</summary>
         /// <param name="r"></param>
-        /// <param name="delta">x and y are added/subtracted fto/from the edges of
+        /// <param name="delta">x and y are added/subtracted to/from the edges of
         /// the rect, inflating it in all directions</param>
         /// <returns>The inflated rect</returns>
         public static Rect Inflated(this Rect r, Vector2 delta)

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -439,7 +439,7 @@ namespace Unity.Cinemachine
 
             // Compute group bounds and adjust follow target for group framing
             ICinemachineTargetGroup group = FollowTargetAsGroup;
-            bool isGroupFraming = group != null && m_GroupFramingMode != FramingMode.None && !group.IsEmpty;
+            bool isGroupFraming = group != null && group.IsValid && m_GroupFramingMode != FramingMode.None && !group.IsEmpty;
             if (isGroupFraming)
                 followTargetPosition = ComputeGroupBounds(group, ref curState);
 

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineGroupComposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineGroupComposer.cs
@@ -146,7 +146,7 @@ namespace Unity.Cinemachine
         {
             // Can't do anything without a group to look at
             ICinemachineTargetGroup group = LookAtTargetAsGroup;
-            if (group == null)
+            if (group == null || !group.IsValid)
             {
                 base.MutateCameraState(ref curState, deltaTime);
                 return;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1506: 
- nullrefs in log when a referenced group is deleted
- nullrefs in group framing inspector when entering playmode
- group size gameview indicator was incorrect
- remove GroupFraming.FramingOffset setting - can use Recomposer for that.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
