### PR TITLE
CMCL-1511: nans in cinemachine collider 2.9

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Occasional precision issue when camera rotation is exactly 180 degress, causing roitational flickering.
 - Bugfix: CinemachineCollider was causing a pop when OnTargetObjectWarped was called.
 - Bugfix: In some circumstances, FramingTransposer was using the wrong FOV or Ortho size for framing.
+- Regression fix: CinemachineCollider generated NaN positions if no target was set.
 - Improved OrbitalFollow's ForceCameraPosition algorithm.
 - Removed CinemachineTollSettings overlay.
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCollider.cs
@@ -322,7 +322,7 @@ namespace Cinemachine
 
                     // Apply distance smoothing - this can artificially hold the camera closer
                     // to the target for a while, to reduce popping in and out on bumpy objects
-                    if (m_SmoothingTime > Epsilon)
+                    if (m_SmoothingTime > Epsilon && state.HasLookAt)
                     {
                         Vector3 pos = initialCamPos + displacement;
                         Vector3 dir = pos - state.ReferenceLookAt;
@@ -342,7 +342,8 @@ namespace Cinemachine
 
                     // Apply additional correction due to camera radius
                     var cameraPos = initialCamPos + displacement;
-                    displacement += RespectCameraRadius(cameraPos, state.HasLookAt ? state.ReferenceLookAt : cameraPos);
+                    var lookAt = state.HasLookAt ? state.ReferenceLookAt : cameraPos;
+                    displacement += RespectCameraRadius(cameraPos, lookAt);
 
                     // Apply damping
                     float dampTime = m_DampingWhenOccluded;
@@ -364,7 +365,7 @@ namespace Cinemachine
                             }
 
                             var prevDisplacement = bodyAfterAim ? extra.previousDisplacement
-                                : state.ReferenceLookAt + dampingBypass * extra.previousCameraOffset - initialCamPos;
+                                : lookAt + dampingBypass * extra.previousCameraOffset - initialCamPos;
                             displacement = prevDisplacement + Damper.Damp(displacement - prevDisplacement, dampTime, deltaTime);
                         }
                     }
@@ -381,7 +382,7 @@ namespace Cinemachine
                                 dir0, dir1, state.ReferenceUp).eulerAngles;
                     }
                     extra.previousDisplacement = displacement;
-                    extra.previousCameraOffset = cameraPos - state.ReferenceLookAt;
+                    extra.previousCameraOffset = cameraPos - lookAt;
                     extra.previousCameraPosition = cameraPos;
                     extra.previousDampTime = dampTime;
                 }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -448,8 +448,8 @@ namespace Cinemachine
         float SteepestDescent(Vector3 cameraOffset)
         {
             const int maxIteration = 10;
-            const float epsilon = 0.00005f;
-            var x = InitialGuess(cameraOffset);
+            const float epsilon = 0.005f;
+            var x = InitialGuess();
             for (var i = 0; i < maxIteration; ++i)
             {
                 var angle = AngleFunction(x);

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -485,13 +485,14 @@ namespace Cinemachine
                     var t = j * step;
                     ChooseBestAngle(0.5f + t);
                     ChooseBestAngle(0.5f - t);
-                    void ChooseBestAngle(float x)
+
+                    void ChooseBestAngle(float referenceAngle)
                     {
-                        var a = AngleFunction(x);
+                        var a = AngleFunction(referenceAngle);
                         if (a < bestAngle)
                         {
                             bestAngle = a;
-                            best = x;
+                            best = referenceAngle;
                         }
                     }
                 }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1511: NaNs generated by CM Collider if no vcam targets

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

