### PR TITLE
CMCL-1510: fix NaNs in CMCollider if no target

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: GroupFraming inspector was displaying incorrect warning when LookAt target is a group.
 - Bugfix: GroupFraming displays more accurate group size indicator in the game view.
 - Bugfix: nullrefs in log when target group was deleted but was still being referenced by vcams.
+- Regression fix: CinemachineCollider generated NaN positions if no target was set.
 - Added Recentering Target to OrbitalFollow.  Recentering is now possible with Lazy Follow.
 - Improved OrbitalFollow's ForceCameraPosition algorithm.
 - Deoccluder accommodates camera radius in all modes.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -424,9 +424,9 @@ namespace Unity.Cinemachine
                     cameraPos = state.GetCorrectedPosition();
 
                     // Adjust the damping bypass to account for the displacement
-                    if (vcam.PreviousStateIsValid)
+                    if (vcam.PreviousStateIsValid && state.HasLookAt())
                     {
-                        var dir0 = extra.PreviousCameraPosition - referenceLookAt;
+                        var dir0 = extra.PreviousCameraPosition - state.ReferenceLookAt;
                         var dir1 = cameraPos - state.ReferenceLookAt;
                         if (dir0.sqrMagnitude > Epsilon && dir1.sqrMagnitude > Epsilon)
                             state.RotationDampingBypass = UnityVectorExtensions.SafeFromToRotation(

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineCollider.cs
@@ -299,7 +299,7 @@ namespace Unity.Cinemachine
 
                     // Apply distance smoothing - this can artificially hold the camera closer
                     // to the target for a while, to reduce popping in and out on bumpy objects
-                    if (m_SmoothingTime > Epsilon)
+                    if (m_SmoothingTime > Epsilon && state.HasLookAt())
                     {
                         Vector3 pos = initialCamPos + displacement;
                         Vector3 dir = pos - state.ReferenceLookAt;
@@ -319,7 +319,8 @@ namespace Unity.Cinemachine
 
                     // Apply additional correction due to camera radius
                     var cameraPos = initialCamPos + displacement;
-                    displacement += RespectCameraRadius(cameraPos, state.HasLookAt() ? state.ReferenceLookAt : cameraPos);
+                    var lookAt = state.HasLookAt() ? state.ReferenceLookAt : cameraPos;
+                    displacement += RespectCameraRadius(cameraPos, lookAt);
 
                     // Apply damping
                     float dampTime = m_DampingWhenOccluded;
@@ -341,7 +342,7 @@ namespace Unity.Cinemachine
                             }
 
                             var prevDisplacement = bodyAfterAim ? extra.previousDisplacement
-                                : state.ReferenceLookAt + dampingBypass * extra.previousCameraOffset - initialCamPos;
+                                : lookAt + dampingBypass * extra.previousCameraOffset - initialCamPos;
                             displacement = prevDisplacement + Damper.Damp(displacement - prevDisplacement, dampTime, deltaTime);
                         }
                     }
@@ -358,7 +359,7 @@ namespace Unity.Cinemachine
                                 dir0, dir1, state.ReferenceUp);
                     }
                     extra.previousDisplacement = displacement;
-                    extra.previousCameraOffset = cameraPos - state.ReferenceLookAt;
+                    extra.previousCameraOffset = cameraPos - lookAt;
                     extra.previousCameraPosition = cameraPos;
                     extra.previousDampTime = dampTime;
                 }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1510: NaNs generated by CM Collider if no vcam targets

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

