### PR TITLE
CMCL-0000: Added CancelDeltaTime option

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Renamed InputAxis.DoRecentering() to InputAxis.UpdateRecentering()
 - Added API in Deoccluder and ThirdPersonFollow to access which collision objects are impacting the camera position.
 - Added ICinemachineTargetGroup.IsValid property to detect deleted groups.
+- Added option to disable deltaTime scaling in CinemachineInputAxisProvider.
 - Removed CinemachineToolSettings overlay.
 - New sample: ThirdPersonWithAimMode showing how to implement a FreeLook camera with Aim mode.
 

--- a/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
@@ -30,6 +30,7 @@ This component makes it easy to control a `CinemachineCamera` in a single player
 | __Input Value__ | The input value read during this frame |
 | __Accel Time__ | The time it takes for the input value to accelerate to a larger value |
 | __Decel Time__ | The time it takes for the input value to decelerate to a smaller value |
+| __Cancel Delta Time__ | This will cancel the built-in deltaTime compensation done by the input axis.  Enable this if the input value is inherently dependent on frame time.  For example, mouse deltas will naturally be bigger for longer frames, so in this case the default deltaTime scaling should be canceled. |
 
 ## Creating your own Input Axis Controller
 

--- a/com.unity.cinemachine/Runtime/Helpers/CinemachineInputAxisController.cs
+++ b/com.unity.cinemachine/Runtime/Helpers/CinemachineInputAxisController.cs
@@ -136,6 +136,14 @@ namespace Unity.Cinemachine
             public float LegacyGain = 1;
 #endif
 
+            /// <summary>Enable this if the input value is inherently dependent on frame time.
+            /// For example, mouse deltas will naturally be bigger for longer frames, so 
+            /// should not normally be scaled by deltaTime.</summary>
+            [Tooltip("Enable this if the input value is inherently dependent on frame time.  "
+                + "For example, mouse deltas will naturally be bigger for longer frames, so "
+                + "in this case the default deltaTime scaling should be canceled.")]
+            public bool CancelDeltaTime = false;
+
             /// <inheritdoc />
             public float GetValue(
                 UnityEngine.Object context,
@@ -158,7 +166,7 @@ namespace Unity.Cinemachine
                     //catch (ArgumentException e) { Debug.LogError(e.ToString()); }
                 }
 #endif
-                return inputValue;
+                return CancelDeltaTime ? inputValue / Time.deltaTime : inputValue;
             }
 
 #if CINEMACHINE_UNITY_INPUTSYSTEM


### PR DESCRIPTION
### Purpose of this PR

Addressing this issue: https://forum.unity.com/threads/why-is-cinemachinefreelook-camera-framerate-dependant.1419530/#post-9256107

I don't love the name of the new parameter, but am having a hard time thinking of something better.  Open to ideas.

I don't have a good generic solution for CM2.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
