### PR TITLE
CMCL-1517: Fix ListView inspectors

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-pre.9] - 2023-10-31
+
+### Fixed
+- Regresion fix: Sequencer inspector child camera popups were not being populated.
+- Regresion fix: Manager Camera's child camera warning icons were not being updated correctly.
+- Bugfix: CinemachineInputAxisController editor was missing foldout arrows on the Driven Axis items.
+
+
 ## [3.0.0-pre.8] - 2023-09-22
 
 ### Fixed

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -68,27 +68,23 @@ namespace Unity.Cinemachine.Editor
                 list.RefreshItems();  // rebuild the list
             });
 
-            // Delay to work around a bug in ListView (UUM-27687 and UUM-27688)
-            list.OnInitialGeometry(() =>
+            list.makeItem = () => new BindableElement { style = { flexDirection = FlexDirection.Row }};
+            list.bindItem = (row, index) =>
             {
-                list.makeItem = () => new BindableElement { style = { flexDirection = FlexDirection.Row }};
-                list.bindItem = (row, index) =>
-                {
-                    // Remove children - items get recycled
-                    for (int i = row.childCount - 1; i >= 0; --i)
-                        row.RemoveAt(i);
+                // Remove children - items get recycled
+                for (int i = row.childCount - 1; i >= 0; --i)
+                    row.RemoveAt(i);
 
-                    var def = new CinemachineBlenderSettings.CustomBlend();
-                    var element = elements.GetArrayElementAtIndex(index);
+                var def = new CinemachineBlenderSettings.CustomBlend();
+                var element = elements.GetArrayElementAtIndex(index);
 
-                    var from = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.From)));
-                    var to = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.To)));
-                    var blend = row.AddChild(new PropertyField(element.FindPropertyRelative(() => def.Blend), ""));
-                    FormatElement(false, from, to, blend);
+                var from = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.From)));
+                var to = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.To)));
+                var blend = row.AddChild(new PropertyField(element.FindPropertyRelative(() => def.Blend), ""));
+                FormatElement(false, from, to, blend);
 
-                    ((BindableElement)row).BindProperty(element); // bind must be done at the end
-                };
-            });
+                ((BindableElement)row).BindProperty(element); // bind must be done at the end
+            };
 
             // Local function
             static void FormatElement(bool isHeader, VisualElement e1, VisualElement e2, VisualElement e3)

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -76,14 +76,16 @@ namespace Unity.Cinemachine.Editor
                     row.RemoveAt(i);
 
                 var def = new CinemachineBlenderSettings.CustomBlend();
-                var element = elements.GetArrayElementAtIndex(index);
+                var element = index < elements.arraySize ? elements.GetArrayElementAtIndex(index) : null;
+                if (!IsUnityNull(element))
+                {
+                    var from = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.From)));
+                    var to = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.To)));
+                    var blend = row.AddChild(new PropertyField(element.FindPropertyRelative(() => def.Blend), ""));
+                    FormatElement(false, from, to, blend);
 
-                var from = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.From)));
-                var to = row.AddChild(CreateCameraPopup(element.FindPropertyRelative(() => def.To)));
-                var blend = row.AddChild(new PropertyField(element.FindPropertyRelative(() => def.Blend), ""));
-                FormatElement(false, from, to, blend);
-
-                ((BindableElement)row).BindProperty(element); // bind must be done at the end
+                    ((BindableElement)row).BindProperty(element); // bind must be done at the end
+                }
             };
 
             // Local function
@@ -123,6 +125,13 @@ namespace Unity.Cinemachine.Editor
                 return row;
             }
 
+            // Local function
+            static bool IsUnityNull(object obj)
+            {
+                // Checks whether an object is null or Unity pseudo-null
+                // without having to cast to UnityEngine.Object manually
+                return obj == null || ((obj is UnityEngine.Object) && ((UnityEngine.Object)obj) == null);
+            }
             return ux;
         }
     }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineSequencerCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSequencerCameraEditor.cs
@@ -63,19 +63,9 @@ namespace Unity.Cinemachine.Editor
                 var element = instructions.GetArrayElementAtIndex(index);
 
                 var vcamSelProp = element.FindPropertyRelative(() => def.Camera);
-                var vcamSel = row.AddChild(new PopupField<Object>());
+                var vcamSel = row.AddChild(new PopupField<Object> { name = $"vcamSelector{index}" });
                 vcamSel.formatListItemCallback = (obj) => obj == null ? "(null)" : obj.name;
                 vcamSel.formatSelectedValueCallback = (obj) => obj == null ? "(null)" : obj.name;
-                vcamSel.TrackAnyUserActivity(() => 
-                {
-                    if (Target == null)
-                        return; // object deleted
-                    vcamSel.choices ??= new();
-                    vcamSel.choices.Clear();
-                    var children = Target.ChildCameras;
-                    for (int i = 0; i < children.Count; ++i)
-                        vcamSel.choices.Add(children[i]);
-                });
         
                 var blend = row.AddChild(
                     new PropertyField(element.FindPropertyRelative(() => def.Blend), ""));
@@ -89,6 +79,28 @@ namespace Unity.Cinemachine.Editor
                 ((BindableElement)row).BindProperty(element);
                 vcamSel.BindProperty(vcamSelProp);
             };
+
+            // Update the list items
+            list.TrackAnyUserActivity(() =>
+            {
+                int index = 0;
+                var iter = list.itemsSource.GetEnumerator();
+                while (iter.MoveNext())
+                {
+                    var vcamSel = list.Q<PopupField<Object>>($"vcamSelector{index}");
+                    if (vcamSel != null)
+                    {
+                        if (Target == null)
+                            return; // object deleted
+                        vcamSel.choices ??= new();
+                        vcamSel.choices.Clear();
+                        var children = Target.ChildCameras;
+                        for (int i = 0; i < children.Count; ++i)
+                            vcamSel.choices.Add(children[i]);
+                    }
+                    ++index;
+                }
+            });
 
             // Local function
             static void FormatInstructionElement(bool isHeader, VisualElement e1, VisualElement e2, VisualElement e3)

--- a/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/InputAxisControllerEditor.cs
@@ -136,7 +136,7 @@ namespace Unity.Cinemachine.Editor
                 foldout.Add(new PropertyField(childProperty));
                 childProperty.NextVisible(false);
             }
-            return new InspectorUtility.FoldoutWithOverlay(foldout, overlay, null);
+            return new InspectorUtility.FoldoutWithOverlay(foldout, overlay, null) { style = { marginLeft = 12 }};
         }
     }
 
@@ -158,12 +158,10 @@ namespace Unity.Cinemachine.Editor
                 showBorder = false,
                 showBoundCollectionSize = false,
                 showFoldoutHeader = false,
-                virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight
+                virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight,
+                style = { marginLeft = -12 }
             });
             list.BindProperty(property);
-
-            // Delay to work around a bug in ListView (UUM-33402)
-            list.OnInitialGeometry(() => list.reorderable = false);
 
             var isEmptyMessage = ux.AddChild(new HelpBox(
                 "No applicable components found.  Must have one of: "

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -507,7 +507,6 @@ namespace Unity.Cinemachine.Editor
                 for (int i = row.childCount - 1; i >= 0; --i)
                     row.RemoveAt(i);
 
-                var warningIcon = row.AddChild(InspectorUtility.MiniHelpIcon("Item is null"));
                 var element = list.itemsSource[index] as CinemachineVirtualCameraBase;
                 row.AddChild(new ObjectField 
                 { 
@@ -517,6 +516,11 @@ namespace Unity.Cinemachine.Editor
                 }).SetEnabled(false);
                 if (element == null)
                     return;
+
+                var warningIcon = row.AddChild(InspectorUtility.MiniHelpIcon("Item is null"));
+                var warningText = getChildWarning == null ? string.Empty : getChildWarning(element);
+                warningIcon.tooltip = warningText;
+                warningIcon.SetVisible(!string.IsNullOrEmpty(warningText));
 
                 var dragger = row.AddChild(new Label(" "));
                 dragger.AddToClassList("unity-base-field__label--with-dragger");
@@ -540,13 +544,6 @@ namespace Unity.Cinemachine.Editor
                 });
                 priorityField.TrackPropertyValue(priorityProp, (p) => priorityField.value = p.intValue);
                 priorityField.TrackPropertyValue(enabledProp, (p) => priorityField.value = p.boolValue ? priorityProp.intValue : 0);
-
-                warningIcon.TrackAnyUserActivity(() =>
-                {
-                    var warningText = (getChildWarning == null || element == null) ? string.Empty : getChildWarning(element);
-                    warningIcon.tooltip = warningText;
-                    warningIcon.SetVisible(!string.IsNullOrEmpty(warningText));
-                });
             };
 
             list.itemsAdded += (added) =>
@@ -585,10 +582,8 @@ namespace Unity.Cinemachine.Editor
                 // Update child list
                 if (!isMultiSelect)
                 {
-                    var rebuild = list.itemsSource != vcam.ChildCameras || list.itemsSource.Count != vcam.ChildCameras.Count;
                     list.itemsSource = vcam.ChildCameras;
-                    if (rebuild)
-                        list.Rebuild();
+                    list.Rebuild();
                 }
             });
         }

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,9 +1,8 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.0.0-pre.8",
+  "version": "3.0.0-pre.9",
   "unity": "2022.3",
-  "unityRelease": "9f1",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3.0 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [
     "camera",

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -2,8 +2,8 @@
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
   "version": "3.0.0-pre.8",
-  "unity": "2022.2",
-  "unityRelease": "16f1",
+  "unity": "2022.3",
+  "unityRelease": "9f1",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3.0 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [
     "camera",


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

ListView inspectors are broken on Unity 2022.3.9f1:

1. ClearShot child cameras have invalid warning icons in the inspector
2. SequencerCamera does not populate the camera drop-down in the instruction list
3. InputAxisController editor is missing foldout arrows on the Driven Axes items

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
