### PR TITLE
CMCL-0000: Backport efficiency note to CM2 for confiner 2d.

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: In some circumstances, FramingTransposer was using the wrong FOV or Ortho size for framing.
 - Regression fix: CinemachineCollider generated NaN positions if no target was set.
 - Improved OrbitalFollow's ForceCameraPosition algorithm.
+- Documented InvalidateLensCache in confiner2D.
 - Removed CinemachineTollSettings overlay.
 
 

--- a/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
@@ -18,7 +18,7 @@ In these cases, for efficiency reasons, Cinemachine does not automatically regen
 
 If the input polygon scales uniformly or translates or rotates, the cache remains valid.
 
-When the Orthographic Size or Field of View of the Cinemachine Camera's lens changes, Cinemachine will not automatically adjust the Confiner for efficiency reasons. To adjust the Confiner, call InvalidateLensCache() from script.
+When the Orthographic Size or Field of View of the Cinemachine Camera's lens changes, Cinemachine will not automatically adjust the Confiner for efficiency reasons. To adjust the Confiner, call InvalidateCache() from script.
 
 ## Oversize Windows
 If sections of the confining polygon are too small to fully contain the camera window, Cinemachine calculates a polygon skeleton for those regions. This is a shape with no area, that serves as a place to put the camera when it is confined to this region of the shape.

--- a/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
@@ -25,6 +25,9 @@ Skeleton computation is the most resource-heavy part of the cache calculation, s
 
 - To optimize the skeleton calculation, set the **Max Window Size** property to the largest size you expect the camera window to have. Cinemachine does not spend time calculating the skeleton for window sizes larger than that.
 
+## Efficiency
+It is much more efficient to have more Cinemachine Cameras with different input bounding shapes and blend between them instead of changing one Confiner2D's input bounding shape, because the initial cost of calculating the confiner shape is high.
+
 
 # Properties:
 

--- a/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineConfiner2D.md
@@ -16,7 +16,9 @@ In these cases, for efficiency reasons, Cinemachine does not automatically regen
 - the script by calling InvalidateCache, or 
 - the component inspector; to do so, press the **Invalidate Cache** button.
 
-If the input polygon scales uniformly or translates or rotates, the cache remains valid. 
+If the input polygon scales uniformly or translates or rotates, the cache remains valid.
+
+When the Orthographic Size or Field of View of the Cinemachine Camera's lens changes, Cinemachine will not automatically adjust the Confiner for efficiency reasons. To adjust the Confiner, call InvalidateLensCache() from script.
 
 ## Oversize Windows
 If sections of the confining polygon are too small to fully contain the camera window, Cinemachine calculates a polygon skeleton for those regions. This is a shape with no area, that serves as a place to put the camera when it is confined to this region of the shape.


### PR DESCRIPTION
### Purpose of this PR
Backport the efficiency doc on collider 2d
[forum](https://forum.unity.com/threads/unrelaible-results-using-cinemachine-confiner-with-group-framing-transposer.1490167/#post-9352016) 


### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
