### PR TITLE
CMCL-0000:add some missing offsets

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added CinemachineVirtualCameraBase.CancelDamping() convenience method to snap camera to its target position.
 - Added CinemachineOrbitalFollow.TargetOffset to reposition orbit center.
+- Added CinemachineGroupFraming.CenterOffset to reposition group ceneter on the screen.
 - Added LookAtOffset to CinemachineHardLookAt behaviour.
 
 ### Changed

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added CinemachineVirtualCameraBase.CancelDamping() convenience method to snap camera to its target position.
 - Added CinemachineOrbitalFollow.TargetOffset to reposition orbit center.
-- SaveDuringPlay supports multi-scene editing.
+- Added LookAtOffset to CinemachineHardLookAt behaviour.
 
 ### Changed
 - RuntimeUtility.GetScratchCollider and RuntimeUtility.DestroyScratchCollider are now public, to allow custom extensions to use them.
+- SaveDuringPlay supports multi-scene editing.
 
 
 ## [3.0.0] - 2023-10-25

--- a/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineGroupFraming.md
@@ -20,6 +20,7 @@ For this to work, the CinemachineCamera's Tracking Target must be a CinemachineT
 | | _Change Position_ | Camera is moved horizontally and vertically until the desired framing is achieved. |
 | | _Change Rotation_ | Camera is rotated to achieve the desired framing. |
 | __Framing Size__ || The screen-space bounding box that the targets should occupy. Use 1 to fill the whole screen, 0.5 to fill half the screen, and so on. |
+| __Center Offset__ || A nonzero value will offset the group in the camera frame. |
 | __Damping__ || How gradually to make the framing adjustment. A larger number gives a slower response, smaller numbers a snappier one. |
 | __Dolly Range__ || The allowable range that the camera may be moved in order to achieve the desired framing. A negative distance is towards the target, and a positive distance is away from the target. |
 | __FOV Range__ || If adjusting FOV, it will be clamped to this range.  |

--- a/com.unity.cinemachine/Documentation~/CinemachineHardLookAt.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineHardLookAt.md
@@ -1,4 +1,12 @@
 # Hard Look At
 
-This CinemachineCamera __Rotation Control__ algorithm rotates the camera to keep the __Look At__ target in the center of the camera frame.
+This CinemachineCamera __Rotation Control__ behaviour rotates the camera to keep the __Look At__ target in the center of the camera's frame.  Optionally, an offset can be specified in order to look at a point that is offset from the LookAt target's origin.
+This is useful for looking at a character's head, or some other point of interest.
+
+### Properties
+
+| Property | Description |
+| --- | --- |				
+| __Look At Offset__ | Offset from the LookAt target's origin, in target's local space.  The camera will look at this point. |
+
 

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -33,6 +33,7 @@ namespace Unity.Cinemachine.Editor
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingMode)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingSize)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
             var perspectiveControls = ux.AddChild(new VisualElement());

--- a/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineGroupFramingEditor.cs
@@ -33,7 +33,7 @@ namespace Unity.Cinemachine.Editor
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingMode)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingSize)));
-            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.FramingOffset)));
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.CenterOffset)));
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.Damping)));
 
             var perspectiveControls = ux.AddChild(new VisualElement());

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
@@ -10,12 +10,70 @@ namespace Unity.Cinemachine.Editor
     {
         CinemachineHardLookAt Target => target as CinemachineHardLookAt;
 
+        protected virtual void OnEnable()
+        {
+            CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
+            CinemachineDebug.OnGUIHandlers += OnGuiHandler;
+            if (CinemachineCorePrefs.ShowInGameGuides.Value)
+                InspectorUtility.RepaintGameView();
+   
+            CinemachineSceneToolUtility.RegisterTool(typeof(TrackedObjectOffsetTool));
+        }
+
+        protected virtual void OnDisable()
+        {
+            CinemachineDebug.OnGUIHandlers -= OnGuiHandler;
+            if (CinemachineCorePrefs.ShowInGameGuides.Value)
+                InspectorUtility.RepaintGameView();
+  
+            CinemachineSceneToolUtility.UnregisterTool(typeof(TrackedObjectOffsetTool));
+        }
+        
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
             this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.LookAtOffset)));
             return ux;
+        }
+
+        protected virtual void OnGuiHandler(CinemachineBrain brain)
+        {
+            // Draw the camera guides
+            if (Target == null || !CinemachineCorePrefs.ShowInGameGuides.Value || !Target.isActiveAndEnabled)
+                return;
+
+            // Don't draw the guides if rendering to texture
+            if (brain == null || brain.OutputCamera == null
+                    || (brain.OutputCamera.activeTexture != null && CinemachineBrain.ActiveBrainCount > 1))
+                return;
+
+            var vcam = Target.VirtualCamera;
+            if (!brain.IsValidChannel(vcam))
+                return;
+
+            bool isLive = targets.Length <= 1 && brain.IsLiveChild(vcam, true);
+            var t = Target.LookAtTarget;
+            if (Target.LookAtTarget != null && isLive)
+            {
+                var point = t.position + t.rotation * Target.LookAtOffset;
+                CmPipelineComponentInspectorUtility.OnGUI_DrawOnscreenTargetMarker(
+                    point, brain.OutputCamera);
+            }
+        }
+
+        void OnSceneGUI()
+        {
+            if (Target == null || !Target.IsValid)
+                return;
+
+            if (CinemachineSceneToolUtility.IsToolActive(typeof(TrackedObjectOffsetTool)))
+            {
+                CinemachineSceneToolHelpers.TrackedObjectOffsetTool(
+                    Target.VirtualCamera, 
+                    new SerializedObject(Target).FindProperty(() => Target.LookAtOffset),
+                    CinemachineCore.Stage.Aim);
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineHardLookAtEditor.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
 namespace Unity.Cinemachine.Editor
@@ -7,10 +8,13 @@ namespace Unity.Cinemachine.Editor
     [CanEditMultipleObjects]
     class CinemachineHardLookAtEditor : UnityEditor.Editor
     {
+        CinemachineHardLookAt Target => target as CinemachineHardLookAt;
+
         public override VisualElement CreateInspectorGUI()
         {
             var ux = new VisualElement();
             this.AddMissingCmCameraHelpBox(ux, CmPipelineComponentInspectorUtility.RequiredTargets.LookAt);
+            ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.LookAtOffset)));
             return ux;
         }
     }

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -36,6 +36,10 @@ namespace Unity.Cinemachine
         [RangeSlider(0, 2)]
         public float FramingSize = 0.8f;
 
+        /// <summary>A nonzero value will offset the group in the camera frame.</summary>
+        [Tooltip("A nonzero value will offset the group in the camera frame.")]
+        public Vector2 FramingOffset = Vector2.zero;
+
         /// <summary>How aggressively the camera tries to frame the group.
         /// Small numbers are more responsive</summary>
         [RangeSlider(0, 20)]
@@ -110,6 +114,7 @@ namespace Unity.Cinemachine
             SizeAdjustment = SizeAdjustmentModes.DollyThenZoom;
             LateralAdjustment = LateralAdjustmentModes.ChangePosition;
             FramingSize = 0.8f;
+            FramingOffset = Vector2.zero;
             Damping = 2;
             DollyRange = new Vector2(-100, 100);
             FovRange = new Vector2(1, 100);
@@ -190,12 +195,13 @@ namespace Unity.Cinemachine
             var targetHeight = GetFrameHeight(GroupBounds.size / FramingSize, lens.Aspect) * 0.5f;
             targetHeight = Mathf.Clamp(targetHeight, OrthoSizeRange.x, OrthoSizeRange.y);
 
-            extra.PosAdjustment += vcam.DetachedFollowTargetDamp(camPos - extra.PosAdjustment, damping, deltaTime);
-            state.PositionCorrection += state.RawOrientation * extra.PosAdjustment;
-
             var deltaFov = targetHeight - lens.OrthographicSize;
             extra.FovAdjustment += vcam.DetachedFollowTargetDamp(deltaFov - extra.FovAdjustment, damping, deltaTime);
             lens.OrthographicSize += extra.FovAdjustment;
+
+            camPos += new Vector3(FramingOffset.x * lens.OrthographicSize / lens.Aspect, FramingOffset.y * lens.OrthographicSize, 0);
+            extra.PosAdjustment += vcam.DetachedFollowTargetDamp(camPos - extra.PosAdjustment, damping, deltaTime);
+            state.PositionCorrection += state.RawOrientation * extra.PosAdjustment;
             state.Lens = lens;
         }
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -38,7 +38,7 @@ namespace Unity.Cinemachine
 
         /// <summary>A nonzero value will offset the group in the camera frame.</summary>
         [Tooltip("A nonzero value will offset the group in the camera frame.")]
-        public Vector2 FramingOffset = Vector2.zero;
+        public Vector2 CenterOffset = Vector2.zero;
 
         /// <summary>How aggressively the camera tries to frame the group.
         /// Small numbers are more responsive</summary>
@@ -80,14 +80,14 @@ namespace Unity.Cinemachine
         /// <summary>Allowable FOV range, if adjusting FOV</summary>
         [Tooltip("Allowable FOV range, if adjusting FOV.")]
         [MinMaxRangeSlider(1, 179)]
-        public Vector2 FovRange = new Vector2(1, 100);
+        public Vector2 FovRange = new (1, 100);
 
         /// <summary>Allowable range for the camera to move. 0 is the undollied position.  
         /// Negative values move the camera closer to the target.</summary>
         [Tooltip("Allowable range for the camera to move.  0 is the undollied position.  "
             + "Negative values move the camera closer to the target.")]
         [Vector2AsRange]
-        public Vector2 DollyRange = new Vector2(-100, 100);
+        public Vector2 DollyRange = new (-100, 100);
 
         /// <summary>Allowable orthographic size range, if adjusting orthographic size</summary>
         [Tooltip("Allowable orthographic size range, if adjusting orthographic size.")]
@@ -114,7 +114,7 @@ namespace Unity.Cinemachine
             SizeAdjustment = SizeAdjustmentModes.DollyThenZoom;
             LateralAdjustment = LateralAdjustmentModes.ChangePosition;
             FramingSize = 0.8f;
-            FramingOffset = Vector2.zero;
+            CenterOffset = Vector2.zero;
             Damping = 2;
             DollyRange = new Vector2(-100, 100);
             FovRange = new Vector2(1, 100);
@@ -188,7 +188,7 @@ namespace Unity.Cinemachine
             GroupBoundsMatrix = Matrix4x4.TRS(state.RawPosition, state.RawOrientation, Vector3.one);
             GroupBounds = group.GetViewSpaceBoundingBox(GroupBoundsMatrix, true);
             var camPos = GroupBounds.center; 
-            camPos.z = 0; // don't change the camera's distance from the group
+            camPos.z = Mathf.Min(0, camPos.z - GroupBounds.extents.z);
 
             // Ortho size adjustment
             var lens = state.Lens;
@@ -199,7 +199,8 @@ namespace Unity.Cinemachine
             extra.FovAdjustment += vcam.DetachedFollowTargetDamp(deltaFov - extra.FovAdjustment, damping, deltaTime);
             lens.OrthographicSize += extra.FovAdjustment;
 
-            camPos += new Vector3(FramingOffset.x * lens.OrthographicSize / lens.Aspect, FramingOffset.y * lens.OrthographicSize, 0);
+            camPos.x -= CenterOffset.x * lens.OrthographicSize / lens.Aspect;
+            camPos.y -= CenterOffset.y * lens.OrthographicSize;
             extra.PosAdjustment += vcam.DetachedFollowTargetDamp(camPos - extra.PosAdjustment, damping, deltaTime);
             state.PositionCorrection += state.RawOrientation * extra.PosAdjustment;
             state.Lens = lens;
@@ -255,6 +256,25 @@ namespace Unity.Cinemachine
             var deltaPos = Quaternion.Inverse(state.RawOrientation) * (camPos - state.RawPosition);
             extra.PosAdjustment += vcam.DetachedFollowTargetDamp(deltaPos - extra.PosAdjustment, damping, deltaTime);
             state.PositionCorrection += state.RawOrientation * extra.PosAdjustment;
+
+            // Apply framing offset
+            if (Mathf.Abs(CenterOffset.x) > 0.01f ||Mathf.Abs(CenterOffset.y) > 0.01f)
+            {
+                var halfFov = 0.5f * state.Lens.FieldOfView;
+                if (moveCamera)
+                {
+                    var d = GroupBounds.center.z - GroupBounds.extents.z;
+                    state.PositionCorrection -= state.RawOrientation * new Vector3(
+                        CenterOffset.x * Mathf.Tan(halfFov * Mathf.Deg2Rad * state.Lens.Aspect) * d,
+                        CenterOffset.y * Mathf.Tan(halfFov * Mathf.Deg2Rad) * d,
+                        0);
+                }
+                else
+                {
+                    var rot = new Vector2(CenterOffset.y * halfFov, CenterOffset.x * halfFov / state.Lens.Aspect);
+                    state.OrientationCorrection *= Quaternion.identity.ApplyCameraRotation(rot, state.ReferenceUp);
+                }
+            }
         }
 
         void AdjustSize(
@@ -325,7 +345,7 @@ namespace Unity.Cinemachine
             else
             {
                 // Rotate to look at center - no parallax shift to worry about
-                camRot = camRot * adjustment;
+                camRot *= adjustment;
                 GroupBoundsMatrix = Matrix4x4.TRS(camPos, camRot, Vector3.one);
                 minAngles -= shift;
                 maxAngles -= shift;

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
@@ -21,6 +21,17 @@ namespace Unity.Cinemachine
         /// Always returns the Aim stage</summary>
         public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Aim; }
 
+        /// <summary>
+        /// Offset from the LookAt target's origin, in target's local space.  The camera will look at this point.
+        /// </summary>
+        [Tooltip("Offset from the LookAt target's origin, in target's local space.  The camera will look at this point.")]
+        public Vector3 LookAtOffset = Vector3.zero;
+
+        void Reset()
+        {
+            LookAtOffset = Vector3.zero;
+        }
+
         /// <summary>Applies the composer rules and orients the camera accordingly</summary>
         /// <param name="curState">The current camera state</param>
         /// <param name="deltaTime">Used for calculating damping.  If less than
@@ -29,7 +40,8 @@ namespace Unity.Cinemachine
         {
             if (IsValid && curState.HasLookAt())
             {
-                Vector3 dir = (curState.ReferenceLookAt - curState.GetCorrectedPosition());
+                var offset = LookAtTargetRotation * LookAtOffset;
+                Vector3 dir = ((curState.ReferenceLookAt + offset) - curState.GetCorrectedPosition());
                 if (dir.magnitude > Epsilon)
                 {
                     if (Vector3.Cross(dir.normalized, curState.ReferenceUp).magnitude < Epsilon)


### PR DESCRIPTION
### Purpose of this PR

HardLookAtTarget was missing a target offset - it always looked at target's root.
GroupFraming was missing a CenterOffset - it always centered the group on the screen.

Added these missing items.
