### PR TITLE
CMCL-0000: 2.9 Back port of update image version to fix job failing on MacOS

### DIFF
--- a/.yamato/metadata.metafile
+++ b/.yamato/metadata.metafile
@@ -1,15 +1,15 @@
 all_platforms:
   - name: windows
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   - name: macOS
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-13:v4
     flavor: m1.mac
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.large
 
 all_tests:

--- a/.yamato/package-coverage.yml
+++ b/.yamato/package-coverage.yml
@@ -4,7 +4,7 @@ coverage_ubuntu_trunk:
   name: Coverage on ubuntu with trunk
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -4,7 +4,7 @@ pack:
   name: Pack package
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/package-promotion.yml
+++ b/.yamato/package-promotion.yml
@@ -4,7 +4,7 @@ promote:
   name: Promote to Production
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   variables:
     UPMCI_PROMOTION: 1

--- a/.yamato/package-publish.yml
+++ b/.yamato/package-publish.yml
@@ -4,7 +4,7 @@ publish:
   name: Publish to Internal Registry
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   variables:
     UPMCI_ENABLE_PACKAGE_SIGNING: 1

--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -4,7 +4,7 @@ pack:
   name: Pack project
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -6,7 +6,7 @@ test_ubuntu_{{editor}}_{{test_project.name}}:
   name : Test project ubuntu {{editor}} {{test_project.name}}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
@@ -22,7 +22,7 @@ test_windows_{{editor}}_{{test_project.name}}:
   name : Test project windows {{editor}} {{test_project.name}}
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
@@ -38,7 +38,7 @@ test_macos_{{editor}}_{{test_project.name}}:
   name : Test project macos {{editor}} {{test_project.name}}
   agent:
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-13:v4
     flavor: m1.mac
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm


### PR DESCRIPTION
See [package-ci/stable has been deprecated for all platforms. Updated images versions to fix the issue.](https://github.com/Unity-Technologies/com.unity.cinemachine/pull/916)