### PR TITLE
CMCL-0000: PrioritySettings Casting/Type Conversion Operators

### DIFF
--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -56,9 +56,8 @@ namespace Unity.Cinemachine
             + "active simultaneously.  The most-recently-activated CinemachineCamera will take control, unless there "
             + "is another Cm Camera active with a higher priority.  In general, the most-recently-activated "
             + "highest-priority CinemachineCamera will control the main camera. \n\n"
-            + "The default priority is 0.  Often it is sufficient to leave the default setting.  "
-            + "In special cases where you want a CinemachineCamera to have a higher or lower priority than 0, "
-            + "the value can be set here.")]
+            + "The default priority is value 0.  Often it is sufficient to leave the default setting.  "
+            + "In special cases where you want a CinemachineCamera to have a higher or lower priority value than 0, you can set it here.")]
         [EnabledProperty(toggleText: "(using default)")]
         public PrioritySettings Priority = new ();
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -28,14 +28,28 @@ namespace Unity.Cinemachine
     [SaveDuringPlay]
     public abstract class CinemachineVirtualCameraBase : MonoBehaviour, ICinemachineCamera
     {
-        /// <summary>Priority can be used to control which Cm Camera is live when multiple CM Cameras are 
+        /// <summary>
+        /// Priority can be used to control which Cm Camera is live when multiple CM Cameras are 
         /// active simultaneously.  The most-recently-activated CinemachineCamera will take control, unless there 
         /// is another Cm Camera active with a higher priority.  In general, the most-recently-activated 
         /// highest-priority CinemachineCamera will control the main camera. 
         /// 
-        /// The default priority is 0.  Often it is sufficient to leave the default setting.  
-        /// In special cases where you want a CinemachineCamera to have a higher or lower priority than 0, 
-        /// the value can be set here.
+        /// The default priority value is 0. Often it is sufficient to leave the default setting.  
+        /// In special cases where you want a CinemachineCamera to have a higher or lower priority value than 0, you can set it here.
+        ///
+        /// <para>
+        /// <b>Example of setting priority value directly:</b>
+        /// <code>
+        /// cam.Priority.Value = 5;
+        /// </code>
+        /// </para>
+        /// 
+        /// <para>
+        /// <b>Example of using the implicit operator to set priority value:</b>
+        /// <code>
+        /// cam.Priority = 5;
+        /// </code>
+        /// </para>
         /// </summary>
         [NoSaveDuringPlay]
         [Tooltip("Priority can be used to control which Cm Camera is live when multiple CM Cameras are "

--- a/com.unity.cinemachine/Runtime/Core/PrioritySettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/PrioritySettings.cs
@@ -26,5 +26,15 @@ namespace Unity.Cinemachine
             get => Enabled ? m_Value : 0;
             set { m_Value = value; Enabled = true; }
         }
+        
+        /// <summary> Implicit conversion to int </summary>
+        /// <param name="prioritySettings"> The priority settings to convert. </param>
+        /// <returns> The value of the priority settings. </returns>
+        public static implicit operator int(PrioritySettings prioritySettings) => prioritySettings.Value;
+
+        /// <summary> Implicit conversion from int </summary>
+        /// <param name="priority"> The value to initialize the priority settings with. </param> 
+        /// <returns> A new priority settings with the given priority. </returns>
+        public static implicit operator PrioritySettings(int priority) => new PrioritySettings(){ Value = priority, Enabled = true };
     }
 }

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTestsImplicitCastingOperators.cs
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTestsImplicitCastingOperators.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Cinemachine.Tests
+{
+    [TestFixture]
+    public class PriorityTestsImplicitCastingOperators : CinemachineRuntimeFixtureBase
+    {
+       [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+        
+        static IEnumerable PriorityValues
+        {
+            get
+            {
+                yield return new TestCaseData(new[] {40, 30, 20, 10, 0, -10, -20, -30, -40}).SetName("Standard").Returns(null);
+                yield return new TestCaseData(new[] {int.MaxValue, int.MaxValue / 2, 0, int.MinValue / 2, int.MinValue}).SetName("Edge-case limits").Returns(null);
+            }
+        }
+        
+        [UnityTest, TestCaseSource(nameof(PriorityValues))]
+        public IEnumerator CheckPriorityOrder(int[] priorities)
+        {
+            var cmCameras = new List<CinemachineCamera>();
+            // Create vcams and set priorities using implicit conversion
+            for (var i = 0; i < priorities.Length; ++i)
+            {
+                cmCameras.Add(CreateGameObject("CM Vcam " + i, typeof(CinemachineCamera)).GetComponent<CinemachineCamera>());
+                cmCameras[i].Priority = priorities[i]; // Using implicit conversion
+            }
+            yield return null;
+
+            CinemachineCamera activeCamera;
+            // Check that activeCamera is equal to cmCamera.
+            // Then disable it and check that the next is now the active one.
+            foreach (var cmCamera in cmCameras)
+            {
+                activeCamera = m_Brain.ActiveVirtualCamera as CinemachineCamera;
+                Assert.NotNull(activeCamera);
+                Assert.That(activeCamera, Is.EqualTo(cmCamera));
+                activeCamera.enabled = false;
+                yield return null;
+            }
+
+            // Re-enable all cm cameras
+            foreach (var cmCamera in cmCameras)
+                cmCamera.enabled = true;
+            
+            yield return null;
+                
+            // Check that the first CinemachineCamera in the list is equal to activeCamera.
+            activeCamera = m_Brain.ActiveVirtualCamera as CinemachineCamera;
+            Assert.NotNull(activeCamera);
+            Assert.That(activeCamera, Is.EqualTo(cmCameras[0]));
+        }
+    }
+}

--- a/com.unity.cinemachine/Tests/Runtime/PriorityTestsImplicitCastingOperators.cs.meta
+++ b/com.unity.cinemachine/Tests/Runtime/PriorityTestsImplicitCastingOperators.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2c388c81a8e55a044a05717c67af3e45
+timeCreated: 1672443439


### PR DESCRIPTION
### Purpose of this PR

This PR addresses the issue I raised #922 regarding the `PrioritySettings` struct. 
The main purpose is to enhance the usability and clarity of the API, particularly in the context of the recent 3.X.X API changes. This PR introduces custom operators for casting to/from `int` for the `PrioritySettings` struct, and updates the XML documentation to better guide developers through the API changes.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]
I've made a modified copy of `PriorityTests.cs`, (`PriorityTestsImplicitCastingOperators.cs`) this is identical except it uses the custom operator instead. Let me know if more tests are required because this *doesn't* yet test casting to int, only from.

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated CHANGELOG
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

The technical risk is considered low. 
The changes are an addition to the PrioritySettings struct and do not alter the pre-existing functionality of Cinemachine. The addition of implicit operators enhances the existing API without introducing breaking changes.

### Comments to reviewers

Reviewers should focus on the correctness of the implemented implicit operators, their tests and the clarity of the updated comments. Feedback on the comprehensibility of the changes from a user's perspective would be valuable.

A note: Perhaps it should explained in the comments that `PrioritySettings.Enabled` has to be true for it to work as well, or would that become too cluttered? It's explained in the `PrioritySettings` comments as well.