### PR TITLE
CMCL-0000: Better filtering for vcam Navel Gazing warning

### DIFF
--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -75,8 +75,13 @@ namespace Unity.Cinemachine.Editor
                 // Is the camera navel-gazing?
                 CameraState state = target.State;
                 bool isNavelGazing = target.PreviousStateIsValid && state.HasLookAt() &&
-                    (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero() &&
-                    target.GetCinemachineComponent(CinemachineCore.Stage.Aim) != null;
+                    (state.ReferenceLookAt - state.GetCorrectedPosition()).AlmostZero();
+                if (isNavelGazing)
+                {
+                    var aim = target.GetCinemachineComponent(CinemachineCore.Stage.Aim);
+                    if (aim == null || !aim.CameraLooksAtTarget)
+                        isNavelGazing = false;
+                }
                 navelGazeMessage.SetVisible(isNavelGazing);
 
                 // Is the camera parenting incorrect?

--- a/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineHardLookAt.cs
@@ -22,6 +22,12 @@ namespace Unity.Cinemachine
         public override CinemachineCore.Stage Stage { get => CinemachineCore.Stage.Aim; }
 
         /// <summary>
+        /// True if this component tries to make the camera look at the Tracking Target.
+        /// Used by inspector to warn the user of potential improper setup.
+        /// </summary>
+        internal override bool CameraLooksAtTarget { get => true; }
+
+        /// <summary>
         /// Offset from the LookAt target's origin, in target's local space.  The camera will look at this point.
         /// </summary>
         [Tooltip("Offset from the LookAt target's origin, in target's local space.  The camera will look at this point.")]

--- a/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineRotationComposer.cs
@@ -78,6 +78,12 @@ namespace Unity.Cinemachine
         /// Always returns the Aim stage</summary>
         public override CinemachineCore.Stage Stage => CinemachineCore.Stage.Aim;
 
+        /// <summary>
+        /// True if this component tries to make the camera look at the Tracking Target.
+        /// Used by inspector to warn the user of potential improper setup.
+        /// </summary>
+        internal override bool CameraLooksAtTarget { get => true; }
+
         /// <summary>Internal API for inspector</summary>
         internal Vector3 TrackedPoint { get; private set; }
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineComponentBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineComponentBase.cs
@@ -210,5 +210,11 @@ namespace Unity.Cinemachine
         /// </summary>
         /// <returns>Highest damping setting in this component</returns>
         public virtual float GetMaxDampTime() => 0;
+
+        /// <summary>
+        /// True if this component tries to make the camera look at the Tracking Target.
+        /// Used by inspector to warn the user of potential improper setup.
+        /// </summary>
+        internal virtual bool CameraLooksAtTarget { get => false; }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

With this vcam setup, there should not be a "camera is looking at itself" warning, because the camera doesn't try to look at the LookAt target:

![image](https://github.com/Unity-Technologies/com.unity.cinemachine/assets/6424658/6a7a4ee7-cddd-4851-af41-a9297fd6af92)

This PR adds an internal API so the inspector can ask a component if it's trying to look at the LookAt target, and display the warning only if it is.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

