### PR TITLE
Changing `CinemachineSplineDolly.PositionUnits` now adjusts the `CinemachineSplineDolly.CameraPosition` value to stay at the same world position.

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineSplineDollyEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineSplineDollyEditor.cs
@@ -22,7 +22,7 @@ namespace Unity.Cinemachine.Editor
 
             var row = ux.AddChild(InspectorUtility.PropertyRow(
                 serializedObject.FindProperty(() => Target.CameraPosition), out _));
-            row.Contents.Add(new PropertyField(serializedObject.FindProperty(() => Target.PositionUnits), "") 
+            row.Contents.Add(new PropertyField(serializedObject.FindProperty(() => Target.positionUnitsBackingField), "") 
                 { style = { flexGrow = 2, flexBasis = 0 }});
 
             ux.Add(new PropertyField(serializedObject.FindProperty(() => Target.SplineOffset)));

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
@@ -34,9 +34,6 @@ namespace Unity.Cinemachine
             + "according to the Position Units setting.")]
         public float CameraPosition;
         
-        #if UNITY_EDITOR
-        [SerializeField, HideInInspector] internal PathIndexUnit previousPositionUnitsBackingField = PathIndexUnit.Normalized;
-        #endif
         [Tooltip("How to interpret the Spline Position:\n"
             + "- Distance: Values range from 0 (start of Spline) to Length of the Spline (end of Spline).\n"
             + "- Normalized: Values range from 0 (start of Spline) to 1 (end of Spline).\n"
@@ -59,18 +56,8 @@ namespace Unity.Cinemachine
                 {
                     UpdateDistanceForPositionUnits(oldUnits: positionUnitsBackingField, newUnits: value);
                 }
-                else
-                {
-                    #if UNITY_EDITOR
-                    UpdateDistanceForPositionUnits(oldUnits: previousPositionUnitsBackingField, newUnits: value);
-                    #endif    
-                }
                 
                 positionUnitsBackingField = value;
-                
-                #if UNITY_EDITOR
-                previousPositionUnitsBackingField = value;
-                #endif
             }
         }
 
@@ -170,14 +157,10 @@ namespace Unity.Cinemachine
         #if UNITY_EDITOR
         void OnValidate()
         {
-            //Required or change check in PositionUnits is never called when changed from the inspector.
-            PositionUnits = positionUnitsBackingField; 
-            
             Damping.Position.x = Mathf.Clamp(Damping.Position.x, 0, 20);
             Damping.Position.y = Mathf.Clamp(Damping.Position.y, 0, 20);
             Damping.Position.z = Mathf.Clamp(Damping.Position.z, 0, 20);
             Damping.Angular = Mathf.Clamp(Damping.Angular, 0, 20);
-            
             if (AutomaticDolly.Method != null)
                 AutomaticDolly.Method.Validate();
         }

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
@@ -33,18 +33,34 @@ namespace Unity.Cinemachine
             + "get as close as possible to the Follow target.  The value is interpreted "
             + "according to the Position Units setting.")]
         public float CameraPosition;
-
-        /// <summary>How to interpret the Spline Position:
-        /// - Distance: Values range from 0 (start of Spline) to Length of the Spline (end of Spline).
-        /// - Normalized: Values range from 0 (start of Spline) to 1 (end of Spline).
-        /// - Knot: Values are defined by knot indices and a fractional value representing the normalized
-        /// interpolation between the specific knot index and the next knot."</summary>
+        
         [Tooltip("How to interpret the Spline Position:\n"
             + "- Distance: Values range from 0 (start of Spline) to Length of the Spline (end of Spline).\n"
             + "- Normalized: Values range from 0 (start of Spline) to 1 (end of Spline).\n"
             + "- Knot: Values are defined by knot indices and a fractional value representing the normalized " 
             + "interpolation between the specific knot index and the next knot.\n")]
-        public PathIndexUnit PositionUnits = PathIndexUnit.Normalized;
+        [SerializeField] 
+        [FormerlySerializedAs(oldName: "PositionUnits")]
+        internal PathIndexUnit positionUnitsBackingField = PathIndexUnit.Normalized;
+        /// <summary>How to interpret the Spline Position:
+        /// - Distance: Values range from 0 (start of Spline) to Length of the Spline (end of Spline).
+        /// - Normalized: Values range from 0 (start of Spline) to 1 (end of Spline).
+        /// - Knot: Values are defined by knot indices and a fractional value representing the normalized
+        /// interpolation between the specific knot index and the next knot."</summary>
+        public PathIndexUnit PositionUnits
+        {
+            get => positionUnitsBackingField;
+            set
+            {
+                PathIndexUnit previousValue = positionUnitsBackingField;
+                positionUnitsBackingField = value;
+                
+                if (value != previousValue)
+                {
+                    //Update the CameraPosition to match the new unit type.
+                }
+            }
+        }
 
         /// <summary>Where to put the camera relative to the spline position.  X is perpendicular 
         /// to the spline, Y is up, and Z is parallel to the spline.</summary>

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
@@ -76,7 +76,10 @@ namespace Unity.Cinemachine
 
         internal void UpdateDistanceForPositionUnits(PathIndexUnit oldUnits, PathIndexUnit newUnits)
         {
-            CameraPosition = Spline.Spline.ConvertDistance(distance: CameraPosition, oldUnits: oldUnits, newUnits: newUnits);
+            if (Spline != null && Spline.Spline != null)
+            {
+                CameraPosition = Spline.Spline.ConvertDistance(distance: CameraPosition, oldUnits: oldUnits, newUnits: newUnits);   
+            }
         }
 
         /// <summary>Where to put the camera relative to the spline position.  X is perpendicular 

--- a/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineSplineDolly.cs
@@ -170,6 +170,7 @@ namespace Unity.Cinemachine
         #if UNITY_EDITOR
         void OnValidate()
         {
+            //Required or change check in PositionUnits is never called when changed from the inspector.
             PositionUnits = positionUnitsBackingField; 
             
             Damping.Position.x = Mathf.Clamp(Damping.Position.x, 0, 20);
@@ -178,9 +179,7 @@ namespace Unity.Cinemachine
             Damping.Angular = Mathf.Clamp(Damping.Angular, 0, 20);
             
             if (AutomaticDolly.Method != null)
-            {
                 AutomaticDolly.Method.Validate();
-            }
         }
 
         void Reset()

--- a/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
@@ -1,8 +1,15 @@
+using System;
+using System.Runtime.CompilerServices;
+using static System.Runtime.CompilerServices.MethodImplOptions;
+
 using UnityEngine;
 using UnityEngine.Splines;
 
+using static UnityEngine.Splines.PathIndexUnit;
+
 namespace Unity.Cinemachine
 {
+
     /// <summary>
     /// A collection of helpers for UnityEngine Spline.
     /// </summary>
@@ -137,6 +144,112 @@ namespace Unity.Cinemachine
             if (t < 0)
                 t += max;
             return t;
+        }
+        
+        /// <summary>
+        /// Converts the distance from one unit to another.
+        /// </summary>
+        /// <param name="spline">The spline which length is used for conversion.</param>
+        /// <param name="distance">The distance to convert.</param>
+        /// <param name="oldUnits">The original units of the distance.</param>
+        /// <param name="newUnits">The units to convert the distance to.</param>
+        /// <returns>The converted distance.</returns>
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        internal static float ConvertDistance(this Spline spline, float distance, PathIndexUnit oldUnits, PathIndexUnit newUnits)
+        {
+            if(distance == 0) return 0;
+            
+            return (oldUnits, newUnits) switch
+            {
+                (oldUnits: Distance,   newUnits: Normalized) => ConvertDistanceMetresToNormalized(spline, distance),
+                (oldUnits: Normalized, newUnits: Distance)   => ConvertDistanceNormalizedToMetres(spline, distance),
+                (oldUnits: Distance,   newUnits: Knot)       => ConvertDistanceMetresToKnot(      spline, distance),
+                (oldUnits: Knot,       newUnits: Distance)   => ConvertDistanceKnotToMetres(      spline, distance),
+                (oldUnits: Normalized, newUnits: Knot)       => ConvertDistanceNormalizedToKnot(  spline, distance),
+                (oldUnits: Knot,       newUnits: Normalized) => ConvertDistanceKnotToNormalized(  spline, distance),
+                _                                            => distance,
+            };
+        }
+        
+        /// <summary>
+        /// Converts the distance from metres to normalized units.
+        /// </summary>
+        /// <param name="distance">The distance in metres to convert.</param>
+        /// <param name="spline">The spline which length is used for conversion.</param>
+        /// <returns>The converted distance in normalized units.</returns>
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceMetresToNormalized(this Spline spline, float distance)
+        {
+            return distance / spline.GetLength();
+        }
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceNormalizedToMetres(this Spline spline, float distance)
+        {
+            return distance * spline.GetLength();
+        }
+
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceMetresToKnot(this Spline spline, float distance) => ConvertDistanceNormalizedToKnot(spline, distance: ConvertDistanceMetresToNormalized(spline, distance), pathLengthReciprocal: 1 / spline.GetLength());
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceKnotToMetres(this Spline spline, float distance)
+        {
+            return ConvertDistanceNormalizedToMetres(spline, distance: ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength()));
+        }
+        
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance) => ConvertDistanceNormalizedToKnot(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance, float pathLengthReciprocal)
+        {
+            if(distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            
+            distance %= 1;
+            
+            float accumulatedDistanceNormalized = 0;
+            for (int knotIndex = 0; knotIndex < spline.Count; knotIndex++)
+            {
+                float curveLengthNormalized = spline.GetCurveLength(knotIndex) * pathLengthReciprocal;
+                
+                if(accumulatedDistanceNormalized + curveLengthNormalized < distance)
+                {
+                    accumulatedDistanceNormalized += curveLengthNormalized;
+                    continue;
+                }
+                
+                float remainingSplineDistanceNormalized = distance - accumulatedDistanceNormalized;
+                
+                float distanceBetweenKnotsNormalized = remainingSplineDistanceNormalized / curveLengthNormalized;
+                
+                return knotIndex + distanceBetweenKnotsNormalized;
+            }
+            return spline.Count - 1;
+        }
+        
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceKnotToNormalized(this Spline spline, float distance) => ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        private static float ConvertDistanceKnotToNormalized(this Spline spline, float distance, float pathLengthReciprocal)
+        {
+            if(distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            
+            distance %= spline.Count - 1;
+            
+            int knotIndex = Mathf.FloorToInt(distance);
+            
+            float distanceToKnotIndexNormalized = 0;
+            for (int i = 0; i < knotIndex; i++)
+            {
+                distanceToKnotIndexNormalized += spline.GetCurveLength(i) * pathLengthReciprocal;
+            }
+            
+            float distanceDecimal   = distance - knotIndex;
+            float remainingDistance = spline.GetCurveLength(knotIndex) * distanceDecimal;
+            
+            float remainingDistanceNormalized = remainingDistance * pathLengthReciprocal;
+
+            float normalizedDistance = distanceToKnotIndexNormalized + remainingDistanceNormalized;
+            
+            return normalizedDistance;
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
@@ -178,32 +178,62 @@ namespace Unity.Cinemachine
         /// <param name="spline">The spline which length is used for conversion.</param>
         /// <returns>The converted distance in normalized units.</returns>
         [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceMetresToNormalized(this Spline spline, float distance)
+        internal static float ConvertDistanceMetresToNormalized(this Spline spline, float distance)
         {
-            return distance / spline.GetLength();
-        }
-        [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceNormalizedToMetres(this Spline spline, float distance)
-        {
-            return distance * spline.GetLength();
-        }
-
-        [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceMetresToKnot(this Spline spline, float distance) => ConvertDistanceNormalizedToKnot(spline, distance: ConvertDistanceMetresToNormalized(spline, distance), pathLengthReciprocal: 1 / spline.GetLength());
-        [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceKnotToMetres(this Spline spline, float distance)
-        {
-            return ConvertDistanceNormalizedToMetres(spline, distance: ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength()));
+            float splineLength = spline.GetLength();
+            
+            if(distance < 0)            throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance > splineLength) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than the length of the spline.");
+            
+            return distance / splineLength;
         }
         
         [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance) => ConvertDistanceNormalizedToKnot(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
+        internal static float ConvertDistanceNormalizedToMetres(this Spline spline, float distance)
+        {
+            float splineLength = spline.GetLength();
+            
+            if(distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance > 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than 1.");
+            
+            return distance * splineLength;
+        }
+
+        
         [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance, float pathLengthReciprocal)
+        internal static float ConvertDistanceMetresToKnot(this Spline spline, float distance)
+        {
+            float splineLength = spline.GetLength();
+            
+            if(distance < 0)            throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance > splineLength) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than the length of the spline.");
+            
+            return ConvertDistanceNormalizedToKnot(spline, distance: ConvertDistanceMetresToNormalized(spline, distance), pathLengthReciprocal: 1 / splineLength);
+        }
+        
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        internal static float ConvertDistanceKnotToMetres(this Spline spline, float distance)
+        {
+            if (distance < 0)                throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if (distance > spline.Count - 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than the number of knots.");
+            
+            return ConvertDistanceNormalizedToMetres(spline, distance: ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength()));
+        }
+        
+        
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        internal static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance)
+        {
+            if (distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if (distance > 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than 1.");
+            
+            return ConvertDistanceNormalizedToKnot(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
+        }
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        internal static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance, float pathLengthReciprocal)
         {
             if(distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
-            
-            distance %= 1;
+            if(distance > 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than 1.");
             
             float accumulatedDistanceNormalized = 0;
             for (int knotIndex = 0; knotIndex < spline.Count; knotIndex++)
@@ -226,13 +256,18 @@ namespace Unity.Cinemachine
         }
         
         [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceKnotToNormalized(this Spline spline, float distance) => ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
-        [MethodImpl(methodImplOptions: AggressiveInlining)]
-        private static float ConvertDistanceKnotToNormalized(this Spline spline, float distance, float pathLengthReciprocal)
+        internal static float ConvertDistanceKnotToNormalized(this Spline spline, float distance)
         {
-            if(distance < 0) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance < 0)                throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance > spline.Count - 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than the number of knots.");
             
-            distance %= spline.Count - 1;
+            return ConvertDistanceKnotToNormalized(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
+        }
+        [MethodImpl(methodImplOptions: AggressiveInlining)]
+        internal static float ConvertDistanceKnotToNormalized(this Spline spline, float distance, float pathLengthReciprocal)
+        {
+            if(distance < 0)                throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be negative.");
+            if(distance > spline.Count - 1) throw new ArgumentOutOfRangeException(paramName: nameof(distance), message: "Distance cannot be greater than the number of knots.");
             
             int knotIndex = Mathf.FloorToInt(distance);
             

--- a/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
@@ -190,11 +190,11 @@ namespace Unity.Cinemachine
         }
 
         /// <summary>
-        /// Converts the distance from knots to normalized units.
+        /// Converts the distance from metres to knots.
         /// </summary>
         /// <param name="spline"> The spline which length is used for conversion. </param>
         /// <param name="distance"> The distance in knots to convert .</param>
-        /// <returns> The converted distance in normalized units. </returns>
+        /// <returns> The converted distance in knots. </returns>
         [MethodImpl(methodImplOptions: AggressiveInlining)]
         internal static float ConvertDistanceMetresToKnot(this Spline spline, float distance)
         {
@@ -267,12 +267,12 @@ namespace Unity.Cinemachine
             return ConvertDistanceNormalizedToKnot(spline, distance, pathLengthReciprocal: 1 / spline.GetLength());
         }
         /// <summary>
-        /// Converts the distance from knots to normalized units.
+        /// Converts the distance from normalized units to knots.
         /// </summary>
         /// <param name="spline"> The spline which length is used for conversion. </param>
         /// <param name="distance"> The distance in knots to convert .</param>
         /// <param name="pathLengthReciprocal"> The reciprocal of the length of the spline. </param>
-        /// <returns> The converted distance in normalized units. </returns>
+        /// <returns> The converted distance in knots. </returns>
         [MethodImpl(methodImplOptions: AggressiveInlining)]
         internal static float ConvertDistanceNormalizedToKnot(this Spline spline, float distance, float pathLengthReciprocal)
         {
@@ -300,11 +300,11 @@ namespace Unity.Cinemachine
         }
         
         /// <summary>
-        /// Converts the distance from normalized units to knots.
+        /// Converts the distance from knots to metres.
         /// </summary>
         /// <param name="spline"> The spline which length is used for conversion. </param>
         /// <param name="distance"> The distance in normalized units to convert .</param>
-        /// <returns> The converted distance in knots. </returns>
+        /// <returns> The converted distance in metres. </returns>
         [MethodImpl(methodImplOptions: AggressiveInlining)]
         internal static float ConvertDistanceKnotToMetres(this Spline spline, float distance)
         {

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineTrackedDolly.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineTrackedDolly.cs
@@ -342,18 +342,19 @@ namespace Unity.Cinemachine
                     SearchIteration = 2
                 };
             }
+            // set splineDolly spline reference
+            if (m_Path != null)
+            {
+                m_Path.TryGetComponent(out c.Spline);
+            }
             c.CameraPosition = m_PathPosition;
             switch (m_PositionUnits)
             {
-                case CinemachinePathBase.PositionUnits.PathUnits: c.PositionUnits = UnityEngine.Splines.PathIndexUnit.Knot; break;
-                case CinemachinePathBase.PositionUnits.Distance: c.PositionUnits = UnityEngine.Splines.PathIndexUnit.Distance; break;
+                case CinemachinePathBase.PositionUnits.PathUnits:  c.PositionUnits = UnityEngine.Splines.PathIndexUnit.Knot; break;
+                case CinemachinePathBase.PositionUnits.Distance:   c.PositionUnits = UnityEngine.Splines.PathIndexUnit.Distance; break;
                 case CinemachinePathBase.PositionUnits.Normalized: c.PositionUnits = UnityEngine.Splines.PathIndexUnit.Normalized; break;
             }
             c.SplineOffset = m_PathOffset;
-            
-            // set splineDolly spline reference
-            if (m_Path != null) 
-                m_Path.TryGetComponent(out c.Spline);
         }
     }
 }

--- a/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
+++ b/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
@@ -153,6 +153,93 @@ namespace Unity.Cinemachine.Tests
             yield return null;
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(7, 1, -2.5f)), 0, 0.1f);
         }
+
+        [UnityTest]
+        public IEnumerator PositionUnits_ChangesCameraPositionCorrectly_WhenPositionUnitsChanged()
+        {
+            //NOTE: Initial PositionUnits is Normalized, so anything other than that will be a change.
+            //NOTE: For any of these the "GetFinalPosition()" output shouldn't change but "CameraPosition" should.
+            
+            //Test:
+            //Normalized -> Distance
+            //Distance   -> Knot
+            //Knot       -> Normalized
+            //
+            //Normalized -> Knot
+            //Knot       -> Distance
+            //Distance   -> Normalized
+            
+            // Arrange
+            m_Dolly.CameraPosition = 0.5f;
+            
+            // Act (Normalized -> Distance)
+            m_Dolly.PositionUnits = PathIndexUnit.Distance;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 13, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+            
+            // Act (Distance   -> Knot)
+            m_Dolly.PositionUnits = PathIndexUnit.Knot;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 2, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+            
+            // Act (Knot       -> Normalized)
+            m_Dolly.PositionUnits = PathIndexUnit.Normalized;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 0.5f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+            
+            // Act (Normalized -> Knot)
+            m_Dolly.PositionUnits = PathIndexUnit.Knot;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 2, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+            
+            // Act (Knot       -> Distance)
+            m_Dolly.PositionUnits = PathIndexUnit.Distance;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 13, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+            
+            // Act (Distance   -> Normalized)
+            m_Dolly.PositionUnits = PathIndexUnit.Normalized;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 0.5f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), new Vector3(13, 1, 1)), actual: 0, tolerance: Mathf.Epsilon);
+        }
+
+        [UnityTest]
+        public IEnumerator PositionUnits_DoesNotChangeCameraPosition_WhenPositionUnitsSame()
+        {
+            // Arrange
+            m_Dolly.PositionUnits = PathIndexUnit.Normalized;
+            m_Dolly.CameraPosition = 0.5f;
+            
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            Vector3 initialPosition = m_CmCam.State.GetFinalPosition();
+            
+            // Act (Normalized -> Normalized)
+            m_Dolly.PositionUnits = PathIndexUnit.Normalized;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert (Normalized -> Normalized)
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 0.5f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), initialPosition), actual: 0, tolerance: Mathf.Epsilon);
+        }
     }
 }
 #endif

--- a/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
+++ b/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
@@ -236,8 +236,42 @@ namespace Unity.Cinemachine.Tests
             m_Dolly.PositionUnits = PathIndexUnit.Normalized;
             m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
             yield return null;
-            // Assert (Normalized -> Normalized)
+            // Assert
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 0.5f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), initialPosition), actual: 0, tolerance: Mathf.Epsilon);
+            
+            
+            // Arrange
+            m_Dolly.PositionUnits  = PathIndexUnit.Distance;
+            m_Dolly.CameraPosition = 13f;
+            
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            initialPosition = m_CmCam.State.GetFinalPosition();
+            
+            // Act (Distance -> Distance)
+            m_Dolly.PositionUnits = PathIndexUnit.Distance;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 13f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), initialPosition), actual: 0, tolerance: Mathf.Epsilon);
+            
+            
+            // Arrange
+            m_Dolly.PositionUnits = PathIndexUnit.Knot;
+            m_Dolly.CameraPosition = 2f;
+            
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            initialPosition = m_CmCam.State.GetFinalPosition();
+            
+            // Act (Knot -> Knot)
+            m_Dolly.PositionUnits = PathIndexUnit.Knot;
+            m_CmCam.InternalUpdateCameraState(Vector3.up, deltaTime: 0);
+            yield return null;
+            // Assert
+            UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: 2f, actual: m_Dolly.CameraPosition, tolerance: Mathf.Epsilon);
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(expected: Vector3.Distance(m_CmCam.State.GetFinalPosition(), initialPosition), actual: 0, tolerance: Mathf.Epsilon);
         }
     }


### PR DESCRIPTION
### Purpose of this PR

Currently, changing a `CinemachineSplineDolly`'s `PositionUnits` does not change the value of `CameraPosition`, except for some clamping. This PR changes that.

**Before:**
https://github.com/Unity-Technologies/com.unity.cinemachine/assets/77513543/1c03e09d-17ab-4b29-ae2f-1a7792c4f022
_Adjusting the `PositionUnits` doesn't adjust the value to stay in the same relative position._
(Notice how the camera jumps around when you change it?)

**After:**
https://github.com/Unity-Technologies/com.unity.cinemachine/assets/77513543/5c79ed41-23ba-4fab-9fec-8bfac76f6ed8
_Adjusting the `PositionUnits` DOES adjust the value to stay in the same relative position._
(Notice how the cameras stays at the same position when you change it?)

This enhancement also applies when adjusting `PositionUnits` via code, not just the inspector.

### Testing status

I have implemented PlayMode unit tests to validate the correct modification of the `CameraPosition` when changing the `PositionUnits`. 
Additionally, I've included tests to ensure that values remain unchanged when setting the `PositionUnits` to the same value. Manual testing has been performed on the inspector functionality, and the CM2 to CM3 upgrade process has been validated.

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

Not sure what to modify in user documentation here, but I did add summaries to all the public/internal code I've added.

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

This PR introduces a change in the behaviour of modifying `PositionUnits`, which now modifies`CameraPosition` as well. 
Users with existing scripts relying on the previous behaviour will encounter a different outcome. 
Overall, I think that tradeoff is worth it for the extra ease of use.
If users want to keep the same value after setting PositionUnits, they can save the position before changing the units and reapply it after calling. 

Perhaps an additional method could be added to modify `PositionUnits` *without* modifying `CameraPosition`, not unlike the `.SetValueWithoutNotify` that exists for UI Elements? Let me know what you think.

### Comments to reviewers

There's one major thing I'm not sure about, and that's the `ArgumentOutOfRangeException`s I throw in `SplineContainerExtensions.cs`, perhaps it would be better to loop around the input for them if it's incorrect? 
We have the spline data so it's trivial to do, on the other hand, it's fault input and they could just do such a loop around themselves before manually calling `ConvertDistance` and friends, which are internal anyway.
Cinemachine's internal code doesn't call it with faulty input.

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
