### PR TITLE
CMCL-1551: add missing empty check when overriding a blend stack

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-
+- Bugfix: index out of range exception when adding a Cm Shot to a timeline track whoce CMBrain is inactive.
+-
 ### Added
 
 ### Changed

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Bugfix: index out of range exception when adding a Cm Shot to a timeline track whoce CMBrain is inactive.
+- Bugfix: index out of range exception when adding a Cm Shot to a timeline track whose CMBrain is inactive.
 -
 ### Added
 

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -119,6 +119,8 @@ namespace Unity.Cinemachine
             if (overrideId < 0)
                 overrideId = m_NextFrameId++;
 
+            if (m_FrameStack.Count == 0)
+                m_FrameStack.Add(new StackFrame());
             var frame = m_FrameStack[FindFrame(overrideId, priority)];
             frame.DeltaTimeOverride = deltaTime;
             frame.Source.TimeInBlend = weightB;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1551: index out of range exceptions when running a CM track on a disabled camera

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

none at all

