### PR TITLE
CMCL-1555: add missing 3rdPersonFollow length check

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [unreleased] - 2024-01-01
+## [2.10.0] - 2024-01-01
 - Bugfix: CinemachineFreeLook.ForceCameraPosition() sometimes did not take full effect immediately.
 - Bugfix: 3rdPersonFollow sometimes generated invalid camera position when the target when DampingWhenOccluded is nonzero.
 

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased] - 2024-01-01
 - Bugfix: CinemachineFreeLook.ForceCameraPosition() sometimes did not take full effect immediately.
+- Bugfix: 3rdPersonFollow sometimes generated invalid camera position when the target when DampingWhenOccluded is nonzero.
 
 
 ## [2.9.8] - 2023-11-29

--- a/com.unity.cinemachine/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -270,12 +270,12 @@ namespace Cinemachine
             float cameraRadius, ref float collisionCorrection)
         {
             if (CameraCollisionFilter.value == 0)
-            {
                 return tip;
-            }
             
             var dir = tip - root;
             var len = dir.magnitude;
+            if (len < Epsilon) 
+                return tip;
             dir /= len;
 
             var result = tip;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1555: errors in console when 3rdPersonFollow.DampingFromCollision is nonzero

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

Fix was just to add an early out if direction length is zero.  Extremely low risk intervention.

