### PR TITLE
CMCL-0000: Fix typo in Editor min req version

### DIFF
--- a/com.unity.cinemachine/Documentation~/index.md
+++ b/com.unity.cinemachine/Documentation~/index.md
@@ -26,7 +26,7 @@ There are similar `ifdef`-protected behaviours for other packages, such as Timel
 
 This version of Cinemachine is supported by the following versions of the Unity Editor:
 
-* 20222.2.16f1 and later
+* 2022.2.16f1 and later
 
 ### Upgrading from previous versions of Cinemachine
 


### PR DESCRIPTION
### Purpose of this PR

There is a typo in the mention of Editor minimum required version in the documentation landing page.

It's a 1-digit PR, but 3 different people already reported the issue, I'd like to get rid of the corresponding sticky tickets [DOCATT-4982](https://jira.unity3d.com/browse/DOCATT-4982), [DOCATT-5185](https://jira.unity3d.com/browse/DOCATT-5185), and [DOCATT-4699](https://jira.unity3d.com/browse/DOCATT-4699), and be able to do so with any potential subsequent ones by the time we release the next patch.

### Note to reviewers

Please confirm that the mentioned version is accurate as of today. Thanks!
