### PR TITLE
CMCL-0000: sync recentering with matching times

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - SimplePlayerAimController sample upgraded to work on arbitrary surfaces (no longer depends on world up).
 - SimplePlayerController sample has logic to avoid input gimbal lock when player is upside-down relative to the camera.
 - PlayerOnSphere sample is now PlayerOnSurface - can walk on arbitrary surfaces.
-- Axis recentering happens independently on axes, so that input on one axis does not impact the recentering state of the others.
+- Axis recentering happens independently on axes with differing recentering tmes, so that input on one axis does not impact the recentering state of the others.
 - FreeLookOnSphericalSurface sample is improved, adding a moving surface and second camera.
 
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineOrbitalFollow.cs
@@ -451,6 +451,14 @@ namespace Unity.Cinemachine
             if (HorizontalAxis.Recentering.Enabled)
                 UpdateHorizontalCenter(orient);
 
+            // Sync recentering if the recenter times match
+            gotInputX |= gotInputY && (HorizontalAxis.Recentering.Time == VerticalAxis.Recentering.Time);
+            gotInputX |= gotInputZ && (HorizontalAxis.Recentering.Time == RadialAxis.Recentering.Time);
+            gotInputY |= gotInputX && (VerticalAxis.Recentering.Time == HorizontalAxis.Recentering.Time);
+            gotInputY |= gotInputZ && (VerticalAxis.Recentering.Time == RadialAxis.Recentering.Time);
+            gotInputZ |= gotInputX && (RadialAxis.Recentering.Time == HorizontalAxis.Recentering.Time);
+            gotInputZ |= gotInputY && (RadialAxis.Recentering.Time == VerticalAxis.Recentering.Time);
+
             HorizontalAxis.UpdateRecentering(deltaTime, gotInputX);
             VerticalAxis.UpdateRecentering(deltaTime, gotInputY);
             RadialAxis.UpdateRecentering(deltaTime, gotInputZ);

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -138,8 +138,18 @@ namespace Unity.Cinemachine
                         rot * Vector3.forward, curState.ReferenceUp);
             m_PreviousCameraRotation = rot;
             
-            PanAxis.UpdateRecentering(deltaTime, PanAxis.TrackValueChange());
-            TiltAxis.UpdateRecentering(deltaTime, TiltAxis.TrackValueChange());
+            var gotInputX = PanAxis.TrackValueChange();
+            var gotInputY = TiltAxis.TrackValueChange();
+
+            // Sync recentering if the recenter times match
+            if (PanAxis.Recentering.Time == TiltAxis.Recentering.Time)
+            {
+                gotInputX |= gotInputY;
+                gotInputY |= gotInputX;
+            }
+
+            PanAxis.UpdateRecentering(deltaTime, gotInputX);
+            TiltAxis.UpdateRecentering(deltaTime, gotInputY);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Axis recentering happens independently **on axes with differing recentering tmes**, so that input on one axis does not impact the recentering state of the others.

**note:** This should be backported to 3.0 branch

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 
