### PR TITLE
CMCL-1574: zero member targetgroup behaves better

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreeleased] - 2024-01-02
 - Bugfix: Solo not updating when brain is in FixedUpdate.
+- Bugfix: Target Groups with zero active members now report their last valid position and dimensions.
 
 
 ## [2.10.0] - 2024-01-01

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [Unreeleased] - 2024-01-02
+## [2.10.1] - 2024-03-27
 - Bugfix: Solo not updating when brain is in FixedUpdate.
 - Bugfix: Target Groups with zero active members now report their last valid position and dimensions.
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs.meta
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: e5eb80d8e62d9d145bb50fb783c0f731
-timeCreated: 1496785096
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "unity": "2019.4",
     "description": "Smart camera tools for passionate creators. \n\nNew starting from 2.7.1: Are you looking for the Cinemachine menu? It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
### Purpose of this PR

CMCL-1574: 
When all members of a target group are disabled, target group should retain its most recent valid position and dimensions, to avoid camera pops.

This fixes a regression reported in CMCL-1574

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
