### PR TITLE
CMCL-1576:  Spline roll calculated incorrectly when spline rotated

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Bugfix: index out of range exception when adding a Cm Shot to a timeline track whose CMBrain is inactive.
+- Bugfix: index out of range exception when adding a Cm Shot to a timeline track whose CinemachineBrain is inactive.
 - Bugfix: OrbitalFollow with 3-ring setup would inappropriately damp in respose to vertical input if LookAt and Follow were at different vertical positions.
 - Bugfix: StateDrivenCamera min activation time was broken.
 - Bugfix: Solo not updating when brain is in FixedUpdate.
+- Bugfix: Spline roll was being calculated incorrectly when spline was rotated.
 
 ### Added
 - FlyAround sample scene showing a simple fly-around camera.

--- a/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/SplineContainerExtensions.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Runtime.CompilerServices;
-using static System.Runtime.CompilerServices.MethodImplOptions;
-
 using UnityEngine;
 using UnityEngine.Splines;
-
-using static UnityEngine.Splines.PathIndexUnit;
 
 namespace Unity.Cinemachine
 {
@@ -94,7 +88,7 @@ namespace Unity.Cinemachine
         {
             var result = LocalEvaluateSplineWithRoll(spline, roll, defaultRotation, tNormalized, out position, out rotation);
             position = spline.transform.TransformPoint(position);
-            rotation = rotation * spline.transform.rotation;
+            rotation = spline.transform.rotation * rotation;
             return result;
         }
         


### PR DESCRIPTION
### Purpose of this PR

**This fix should be backported to 3.0 branch.**

https://forum.unity.com/threads/3-0-1-spline-cart-rotates-wrongly-if-the-splinecontainer-is-rotated.1559951/

A spline cart that's following a rotated spline container winds up with an incorrect rotation

rotation = rotation * spline.transform.rotation;
This applies the spline container's rotation after the evaluated rotation, which is backwards. This results in weird orientations that wobble around as you rotate the spline container.

It should go like this:

rotation = spline.transform.rotation * rotation;
After the fix, the cart behaves as expected. This code is in SplineContainerExtension.cs in version 3.0.1.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

