### PR TITLE
CMCL-0000: add missing brain warning to vcam inspector

### DIFF
--- a/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
+++ b/com.unity.cinemachine/Editor/Menus/CinemachineMenu.cs
@@ -299,7 +299,7 @@ namespace Unity.Cinemachine.Editor
         /// Gets the first loaded <see cref="CinemachineBrain"/>. Creates one on 
         /// the <see cref="Camera.main"/> if none were found.
         /// </summary>
-        static CinemachineBrain GetOrCreateBrain()
+        public static CinemachineBrain GetOrCreateBrain()
         {
             if (CinemachineBrain.ActiveBrainCount > 0)
                 return CinemachineBrain.GetActiveBrain(0);
@@ -316,7 +316,9 @@ namespace Unity.Cinemachine.Editor
                 return Undo.AddComponent<CinemachineBrain>(cam.gameObject);
 
             // No camera, just create a brain on an empty object
-            return ObjectFactory.CreateGameObject("CinemachineBrain").AddComponent<CinemachineBrain>();
+            var obj = ObjectFactory.CreateGameObject("CinemachineBrain", typeof(CinemachineBrain));
+            Undo.RegisterCreatedObjectUndo(obj, "CinemachineBrain");
+            return obj.GetComponent<CinemachineBrain>();
         }
     }
 }

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -45,7 +45,7 @@ namespace Unity.Cinemachine.Editor
 
             var noBrainMessage = ux.AddChild(InspectorUtility.HelpBoxWithButton(
                 "A CinemachineBrain is required in the scene.", 
-                HelpBoxMessageType.Error, "Add Brain", () => CinemachineMenu.GetOrCreateBrain()));
+                HelpBoxMessageType.Warning, "Add Brain", () => CinemachineMenu.GetOrCreateBrain()));
 
             var navelGazeMessage = ux.AddChild(new HelpBox(
                 "The camera is trying to look at itself.", 

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -23,7 +23,7 @@ namespace Unity.Cinemachine.Editor
         static bool IsPrefab(UnityEngine.Object target)
         {
             var t = target as CinemachineVirtualCameraBase;
-            return t != null && t.gameObject.scene.name == null; // causes a small GC alloc
+            return t != null && PrefabUtility.IsPartOfPrefabAsset(t);
         }
 
         static Color s_NormalColor = Color.black;
@@ -42,6 +42,10 @@ namespace Unity.Cinemachine.Editor
                 + "<b>Best practice is to have CinemachineCamera, CinemachineBrain, and camera targets as "
                 + "separate objects, not parented to each other.</b>", 
                 HelpBoxMessageType.Error));
+
+            var noBrainMessage = ux.AddChild(InspectorUtility.HelpBoxWithButton(
+                "A CinemachineBrain is required in the scene.", 
+                HelpBoxMessageType.Error, "Add Brain", () => CinemachineMenu.GetOrCreateBrain()));
 
             var navelGazeMessage = ux.AddChild(new HelpBox(
                 "The camera is trying to look at itself.", 
@@ -88,6 +92,9 @@ namespace Unity.Cinemachine.Editor
                 cameraParentingMessage.SetVisible(
                     target.GetComponentInParent<CinemachineBrain>() != null 
                     || (target.ParentCamera != null && target.ParentCamera is not CinemachineCameraManagerBase));
+
+                // Is there a Brain?
+                noBrainMessage.SetVisible(CinemachineBrain.ActiveBrainCount == 0 && !IsPrefab(target));
             });
 
             // Capture "normal" colors


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

If there is no Brain in the scene, add a help box with a "fix it" button.

![image](https://github.com/Unity-Technologies/com.unity.cinemachine/assets/6424658/05e83003-3ed5-40d8-9393-8350bdead17c)


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

