### PR TITLE
Properly reset Snapshots when blending.

### DIFF
--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -82,6 +82,8 @@ namespace Unity.Cinemachine
                 {
                     // No snapshot required - reset it
                     m_Snapshot.TakeSnapshot(null);
+                    m_SnapshotSource = null;
+                    m_SnapshotBlendWeight = 0;
                     return cam;
                 }
                 // A snapshot is needed


### PR DESCRIPTION


[Delete any line or section that does not apply]

### Purpose of this PR

Fixes #963 
When using the Blend Hint "Freeze When Blending Out" the blend snapshot was not properly reset causing issues when blending to the same camera again (using an empty snapshot, causing the camera to jump to 0,0,0).

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [X ] Manually tested 
