### PR TITLE
CMCL-0000: Add IgnoreTimeScale option to InputAxisControllerBase

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added CinemachineShotQualityEvaluator which is a standalone version of the evaluation code in Deoccluder.
 - Added StateDrivenCamera.CancelWait() method to cancel the current wait on a pending state change.
 - Added FlyAround sample scene showing a simple fly-around camera.
+- Added IgnoreTimeScale option to InputAxisControllerBase.
 
 ### Changed
 - SplineDolly and SplineCart: position on spline is preserved when units change.

--- a/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineInputAxisController.md
@@ -22,6 +22,7 @@ This component makes it easy to control a `CinemachineCamera` in a single player
 | __Auto Enable Inputs__ | If Unity's Input package is installed, this option is available. It will automatically enable any mapped input actions at startup |
 | __Scan Recursively__ | If set, a recursive search for IInputAxisOwners behaviours will be performed.  Otherwise, only behaviours attached directly to this GameObject will be considered, and child objects will be ignored. |
 | __Suppress Input While Blending__ | If set and if this component is attached to a CinemachineCamera, input will not be processed while the camera is participating in a blend. |
+| __Ignore Time Scale__ | If set, then input will be processed using unscaled deltaTime, and not scaled deltaTime.  This allows input to continue even when the timescale is set to 0. |
 | __Enabled__ | The controller will drive the input axis while this value is true.  If false, the axis will not be driven by the controller. |
 | __Legacy Input__ | If the legacy input manager is being used, the Input Axis Name to query is specified here. |
 | __Legacy Gain__ | If the legacy input manager is being used, the input value read will be multiplied by this amount. |

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -181,9 +181,8 @@ namespace Unity.Cinemachine
         }
     
         /// <summary>Read all the controllers and process their input.</summary>
-        public void UpdateControllers(UnityEngine.Object context)
+        public void UpdateControllers(UnityEngine.Object context, float deltaTime)
         {
-            var deltaTime = Time.deltaTime;
             for (int i = 0; i < Controllers.Count; ++i)
             {
                 var c = Controllers[i];
@@ -225,6 +224,12 @@ namespace Unity.Cinemachine
         [Tooltip("If set, input will not be processed while the Cinemachine Camera is "
             + "participating in a blend.")]
         public bool SuppressInputWhileBlending = true;
+
+        /// <summary>
+        /// If set, then input will be processed using unscaled deltaTime, and not scaled deltaTime.  
+        /// This allows input to continue even when the timescale is set to 0.
+        /// </summary>
+        public bool IgnoreTimeScale;
 
         /// <summary>
         /// Each discovered axis will get a Controller to drive it in Update().
@@ -308,15 +313,23 @@ namespace Unity.Cinemachine
         protected virtual void InitializeControllerDefaultsForAxis(
             in IInputAxisOwner.AxisDescriptor axis, Controller controller) {}
            
-        /// <summary>Read all the controllers and process their input.</summary>
+        /// <summary>Read all the controllers and process their input.
+        /// Default implementation calls UpdateControllers(IgnoreTimeScale ? Time.unscaledDeltaTime : Time.deltaTime)</summary>
         protected void UpdateControllers()
+        {
+            UpdateControllers(IgnoreTimeScale ? Time.unscaledDeltaTime : Time.deltaTime);
+        }
+
+        /// <summary>Read all the controllers and process their input.</summary>
+        /// <param name="deltaTime">The time interval for which to process the input</param>
+        protected void UpdateControllers(float deltaTime)
         {
             if (SuppressInputWhileBlending 
                 && TryGetComponent<CinemachineVirtualCameraBase>(out var vcam)
                 && vcam.IsParticipatingInBlend())
                 return;
 
-            m_ControllerManager.UpdateControllers(this);
+            m_ControllerManager.UpdateControllers(this, deltaTime);
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

https://forum.unity.com/threads/how-to-make-cinemachine-still-follow-player-when-time-timescale-0.723806/#post-9749095

Adds an option to InpuAxisController to continue processing input even when timescle is 0. 

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
