### PR TITLE
CMCL-1579: add SaveDuringPlay confirmation dialog

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added CinemachineShotQualityEvaluator which is a standalone version of the evaluation code in Deoccluder.
 - Added StateDrivenCamera.CancelWait() method to cancel the current wait on a pending state change.
 - Added FlyAround sample scene showing a simple fly-around camera.
+- Added confirmation dialog when exiting play mode, if Save During Play is enabled and changes have been made to saveable properties.
 
 ### Changed
 - SplineDolly and SplineCart: position on spline is preserved when units change.

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -561,18 +561,6 @@ namespace Unity.Cinemachine.Editor
 
         static void RestoreAllInterestingStates()
         {
-            if (s_SavedStates.Count > 0 && !EditorUtility.DisplayDialog(
-                    "Save changes made in Play Mode",
-                    "Some Cinemachine settings have been modified during play mode.  "
-                    + "Would you like to propagate those changes back to the scene?\n\n"
-                    + "Note: if you choose Cancel, then the changes will be lost.  If you choose Save, then it "
-                    + "will still be possible to change your mind later by invoking Undo.",
-                    "Save", "Cancel"))
-            {
-                s_SavedStates = null;
-                return;
-            }
-
             //Debug.Log("Updating state for all interesting objects");
             bool dirty = false;
             var roots = ObjectTreeUtil.FindAllRootObjectsInOpenScenes();
@@ -592,7 +580,19 @@ namespace Unity.Cinemachine.Editor
                 }
             }
             if (dirty)
+            {
+                if (!EditorUtility.DisplayDialog(
+                        "Save changes made in Play Mode",
+                        "Some Cinemachine settings that were modified during play mode are being "
+                        + "propagated back to the scene.  Would you like to keep these changes, or undo them?\n\n"
+                        + "Note: if you choose Cancel, then the changes will be undone now.  If you choose Keep, then it "
+                        + "will still be possible to change your mind later by invoking Undo.",
+                        "Keep", "Cancel"))
+                {
+                    Undo.PerformUndo();
+                }
                 UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+            }
             s_SavedStates = null;
         }
     }

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -561,6 +561,18 @@ namespace Unity.Cinemachine.Editor
 
         static void RestoreAllInterestingStates()
         {
+            if (s_SavedStates.Count > 0 && !EditorUtility.DisplayDialog(
+                    "Save changes made in Play Mode",
+                    "Some Cinemachine settings have been modified during play mode.  "
+                    + "Would you like to propagate those changes back to the scene?\n\n"
+                    + "Note: if you choose Cancel, then the changes will be lost.  If you choose Save, then it "
+                    + "will still be possible to change your mind later by invoking Undo.",
+                    "Save", "Cancel"))
+            {
+                s_SavedStates = null;
+                return;
+            }
+
             //Debug.Log("Updating state for all interesting objects");
             bool dirty = false;
             var roots = ObjectTreeUtil.FindAllRootObjectsInOpenScenes();


### PR DESCRIPTION
### Purpose of this PR

CMCL-1579: Add confirmation when exiting play mode is SaveDuringPlay is enabled and changes have been made.

![image](https://github.com/Unity-Technologies/com.unity.cinemachine/assets/6424658/6c6f7325-f6d3-4684-8a84-399ac96419d0)


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

