### PR TITLE
CMCL-1580: scene always dirtied 2.x

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.10.1] - 2024-03-27
 - Bugfix: Solo not updating when brain is in FixedUpdate.
 - Bugfix: Target Groups with zero active members now report their last valid position and dimensions.
+- Bugfix: Cinemachine cameras would sometimes unnecessarily dirty the scene due to floating-point imprecision when setting transform rotations.
 
 
 ## [2.10.0] - 2024-01-01

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -963,10 +963,16 @@ namespace Cinemachine
         {
             CurrentCameraState = state;
             var target = ControlledObject.transform;
+            var pos = target.position;
+            var rot = target.rotation;
             if ((state.BlendHint & CameraState.BlendHintValue.NoPosition) == 0)
-                target.position = state.FinalPosition;
+                pos = state.FinalPosition;
             if ((state.BlendHint & CameraState.BlendHintValue.NoOrientation) == 0)
-                target.rotation = state.FinalOrientation;
+                rot = state.FinalOrientation;
+
+            // Avoid dirtying the scene with insignificant rotations diffs
+            target.ConservativeSetPositionAndRotation(pos, rot);
+
             if ((state.BlendHint & CameraState.BlendHintValue.NoLens) == 0)
             {
                 Camera cam = OutputCamera;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Cinemachine.Utility;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -157,10 +158,13 @@ namespace Cinemachine
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.
+            var pos = transform.position;
+            var rot = transform.rotation;
             if (Follow != null)
-                transform.position = State.RawPosition;
+                pos = m_State.RawPosition;
             if (LookAt != null)
-                transform.rotation = State.RawOrientation;
+                rot = m_State.RawOrientation;
+            transform.ConservativeSetPositionAndRotation(pos, rot);
             
             PreviousStateIsValid = true;
         }
@@ -562,8 +566,7 @@ namespace Cinemachine
         public override void ForceCameraPosition(Vector3 pos, Quaternion rot)
         {
             PreviousStateIsValid = true;
-            transform.position = pos;
-            transform.rotation = rot;
+            transform.ConservativeSetPositionAndRotation(pos, rot);
             m_State.RawPosition = pos;
             m_State.RawOrientation = rot;
 

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Cinemachine.Utility
@@ -214,6 +215,40 @@ namespace Cinemachine.Utility
         public static bool AlmostZero(this Vector3 v)
         {
             return v.sqrMagnitude < (Epsilon * Epsilon);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ConservativeSetPositionAndRotation(this Transform t, Vector3 pos, Quaternion rot)
+        {
+#if UNITY_EDITOR
+            // Avoid dirtying the scene with insignificant diffs
+            if (Application.isPlaying)
+                t.SetPositionAndRotation(pos, rot);
+            else
+            {
+                // Work in local space to reduce precision mismatches
+                if (t.parent != null)
+                {
+                    pos = t.parent.InverseTransformPoint(pos);
+                    rot = Quaternion.Inverse(t.parent.rotation) * rot;
+                }
+                const float tolerance = 0.0001f;
+                var p = t.localPosition;
+                if (Mathf.Abs(p.x - pos.x) < tolerance
+                    && Mathf.Abs(p.y - pos.y) < tolerance
+                    && Mathf.Abs(p.z - pos.z) < tolerance)
+                    pos = p;
+                var r = t.localRotation;
+                if (Mathf.Abs(r.x - rot.x) < tolerance
+                    && Mathf.Abs(r.y - rot.y) < tolerance 
+                    && Mathf.Abs(r.z - rot.z) < tolerance
+                    && Mathf.Abs(r.w - rot.w) < tolerance)
+                    rot = r;
+                t.SetLocalPositionAndRotation(pos, rot);
+            }
+#else
+            t.SetPositionAndRotation(pos, rot);
+#endif
         }
 
         /// <summary>Much more stable for small angles than Unity's native implementation</summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1580: Cinemachine dirties scenes for nothing.  This is a long-standing issue.

Fix is to set the vcam and main camera transform's position and rotation only if significantly different from what it is.  There is one gotcha: because transform rotation is stored in local space, setting it in global space will introduce imprecisions when conversion is made.  So we do the delta check in local space, and set the values in local spacee also.

Because all that takes processing power, we do it only if in editor and not playing.

**NOTE: This needs to be done for 3.X also.**

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
