### PR TITLE
CMCL-1580: save rotations so as to not dirty the scene unnecessarily

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Solo not updating when brain is in FixedUpdate.
 - Bugfix: Spline roll was being calculated incorrectly when spline was rotated.
 - Bugfix: "Freeze When Blending Out" didn't work when switching betwen two cameras multiple times.
+- Bugfix: Cinemachine cameras would sometimes unnecessarily dirty the scene due to floating-point imprecision when setting transform rotations.
 
 ### Added
 - Added CinemachineDecollider to resolve camera intersection with colliders and terrains, without necessarily preserving line-of-sight to target.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -666,10 +666,15 @@ namespace Unity.Cinemachine
         {
             m_CameraState = state;
             var target = ControlledObject.transform;
+
+            var pos = target.position;
+            var rot = target.rotation;
             if ((state.BlendHint & CameraState.BlendHints.NoPosition) == 0)
-                target.position = state.GetFinalPosition();
+                pos = state.GetFinalPosition();
             if ((state.BlendHint & CameraState.BlendHints.NoOrientation) == 0)
-                target.rotation = state.GetFinalOrientation();
+                rot = state.GetFinalOrientation();
+            target.ConservativeSetPositionAndRotation(pos, rot);
+
             if ((state.BlendHint & CameraState.BlendHints.NoLens) == 0)
             {
                 Camera cam = OutputCamera;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -137,7 +137,7 @@ namespace Unity.Cinemachine
         public override void ForceCameraPosition(Vector3 pos, Quaternion rot)
         {
             PreviousStateIsValid = false;
-            transform.SetPositionAndRotation(pos, rot);
+            transform.ConservativeSetPositionAndRotation(pos, rot);
             m_State.RawPosition = pos;
             m_State.RawOrientation = rot;
 
@@ -222,10 +222,13 @@ namespace Unity.Cinemachine
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.
+            var pos = transform.position;
+            var rot = transform.rotation;
             if (Follow != null)
-                transform.position = State.RawPosition;
+                pos = m_State.RawPosition;
             if (LookAt != null)
-                transform.rotation = State.RawOrientation;
+                rot = m_State.RawOrientation;
+            transform.ConservativeSetPositionAndRotation(pos, rot);
             
             // Signal that it's all done
             PreviousStateIsValid = true;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineSplineCart.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineSplineCart.cs
@@ -149,7 +149,7 @@ namespace Unity.Cinemachine
                 SplinePosition = Spline.Spline.StandardizePosition(distanceAlongPath, PositionUnits, Spline.Spline.GetLength());
                 var t = Spline.Spline.ConvertIndexUnit(SplinePosition, PositionUnits, PathIndexUnit.Normalized);
                 Spline.EvaluateSplineWithRoll(SplineRoll, transform.rotation, t, out var pos, out var rot);
-                transform.SetPositionAndRotation(pos, rot);
+                transform.ConservativeSetPositionAndRotation(pos, rot);
             }
         }
 

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Unity.Cinemachine
@@ -216,7 +215,6 @@ namespace Unity.Cinemachine
             return v.sqrMagnitude < (Epsilon * Epsilon);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ConservativeSetPositionAndRotation(this Transform t, Vector3 pos, Quaternion rot)
         {
 #if UNITY_EDITOR


### PR DESCRIPTION
### Purpose of this PR

This is the CM3 version of PR #967

CMCL-1580: Cinemachine dirties scenes for nothing. This is a long-standing issue.

Fix is to set the vcam and main camera transform's position and rotation only if significantly different from what it is. There is one gotcha: because transform rotation is stored in local space, setting it in global space will introduce imprecisions when conversion is made. So we do the delta check in local space, and set the values in local spacee also.

Because all that takes processing power, we do it only if in editor and not playing.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

