### PR TITLE
CMCL-0000: Fields with NonSerialized attribute should be ignored by SaveDuringPlay

### DIFF
--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -352,7 +352,7 @@ namespace Unity.Cinemachine.Editor
                     if (mValues.TryGetValue(fullName, out string savedValue)
                         && StringFromLeafObject(value) != savedValue)
                     {
-                        //Debug.Log("Put " + mObjectFullPath + "." + fullName + " = " + mValues[fullName]);
+                        //Debug.Log("Put " + mObjectFullPath + "." + fullName + " = " + mValues[fullName] + " --- was " + StringFromLeafObject(value));
                         value = LeafObjectFromString(type, mValues[fullName].Trim(), roots);
                         return true; // changed
                     }
@@ -373,8 +373,12 @@ namespace Unity.Cinemachine.Editor
         {
             var attrs = fieldInfo.GetCustomAttributes(false);
             for (int i = 0; i < attrs.Length; ++i)
+            {
                 if (attrs[i].GetType().Name.Equals("NoSaveDuringPlayAttribute"))
                     return false;
+                if (attrs[i].GetType().Name.Equals("NonSerializedAttribute"))
+                    return false;
+            }
             return true;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Fields with NonSerialized attribute should be ignored by SaveDuringPlay.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

