### PR TITLE
CMCL-0000: remove some isdelayed attributes because it interferes with dynamic refresh

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
@@ -25,13 +25,13 @@ namespace Unity.Cinemachine.Editor
             var valueProp = property.FindPropertyRelative(() => def.Value);
             var valueLabel = new Label(" ") { style = { minWidth = InspectorUtility.SingleLineHeight * 2}};
             var valueField =  new InspectorUtility.CompactPropertyField(valueProp, "") { style = { flexGrow = 1}};
-            valueField.OnInitialGeometry(() => valueField.SafeSetIsDelayed());
+            //valueField.OnInitialGeometry(() => valueField.SafeSetIsDelayed());
             valueLabel.AddPropertyDragger(valueProp, valueField);
 
             var ux = new InspectorUtility.FoldoutWithOverlay(foldout, valueField, valueLabel);
 
             var valueField2 = foldout.AddChild(new PropertyField(valueProp));
-            valueField2.OnInitialGeometry(() => valueField2.SafeSetIsDelayed());
+            //valueField2.OnInitialGeometry(() => valueField2.SafeSetIsDelayed());
 
             var centerField = foldout.AddChild(new PropertyField(property.FindPropertyRelative(() => def.Center)));
             var rangeContainer = foldout.AddChild(new VisualElement() { style = { flexDirection = FlexDirection.Row }});

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -92,11 +92,11 @@ namespace Unity.Cinemachine.Editor
             var outerFovControl = new FovPropertyControl(property, true) { style = { flexGrow = 1 }};
             ux.Add(new InspectorUtility.FoldoutWithOverlay(
                 foldout, outerFovControl, outerFovControl.ShortLabel) { style = { flexGrow = 1 }});
-            outerFovControl.OnInitialGeometry(() => outerFovControl.SafeSetIsDelayed());
+            //outerFovControl.OnInitialGeometry(() => outerFovControl.SafeSetIsDelayed());
 
             // Populate the foldout
             var innerFovControl = foldout.AddChild(new FovPropertyControl(property, false) { style = { flexGrow = 1 }});
-            innerFovControl.OnInitialGeometry(() => innerFovControl.SafeSetIsDelayed());
+            //innerFovControl.OnInitialGeometry(() => innerFovControl.SafeSetIsDelayed());
 
             var nearClip = property.FindPropertyRelative(() => s_Def.NearClipPlane);
             foldout.AddChild(new PropertyField(nearClip)).RegisterValueChangeCallback((evt) =>

--- a/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
@@ -19,11 +19,11 @@ namespace Unity.Cinemachine.Editor
             var maxField = new InspectorUtility.CompactPropertyField(yProp, "...") 
                 { tooltip = property.tooltip, style = { flexBasis = 10, flexGrow = 1, marginLeft = 5 }};
 
-            ux.OnInitialGeometry(() =>
-            {
-                minField.SafeSetIsDelayed();
-                maxField.SafeSetIsDelayed();
-            });
+            //ux.OnInitialGeometry(() =>
+            //{
+            //    minField.SafeSetIsDelayed();
+            //    maxField.SafeSetIsDelayed();
+            //});
 
             label.AddPropertyDragger(xProp, minField);
             ux.Left.Add(label);


### PR DESCRIPTION
### Purpose of this PR

A recent PR had added isDelayed to some float fields (e.g. FOV, axis value) because when typing values OnValidate() got called and interfered with the typing.  However, the side-effect of this was that when dragging the label to change the value, no dynamic refresh happened until dragging stopped.

We think that the cure is worse than the disease, so we are reverting the isDelayed while we look for a better solution.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

