### PR TITLE
CMCL-0000: Add isDelayed to some fields in a drag-tolerant way

### DIFF
--- a/com.unity.cinemachine/Editor/PropertyDrawers/DelayedVectorPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/DelayedVectorPropertyDrawer.cs
@@ -1,6 +1,5 @@
 using UnityEditor;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 
 namespace Unity.Cinemachine.Editor
 {
@@ -9,14 +8,33 @@ namespace Unity.Cinemachine.Editor
     {
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
-            var ux = new PropertyField(property);
-            ux.OnInitialGeometry(() =>
-            {
-                ux.SafeSetIsDelayed("unity-x-input");
-                ux.SafeSetIsDelayed("unity-y-input");
-                ux.SafeSetIsDelayed("unity-z-input");
-            });
+            var ux = new InspectorUtility.LabeledRow(property.displayName, property.tooltip);
+            ux.Contents.AddChild(ChildField(property.FindPropertyRelative("x")));
+            ux.Contents.AddChild(ChildField(property.FindPropertyRelative("y")));
+            ux.Contents.AddChild(ChildField(property.FindPropertyRelative("z")));
+            ux.Contents.style.marginLeft = -6;
+            ux.Contents.style.minWidth = 100;
             return ux;
+
+            VisualElement ChildField(SerializedProperty p)
+            {
+                if (p == null)
+                    return new VisualElement { style = { flexBasis = 30, flexGrow = 1, marginLeft = 6 } };
+                var f = new InspectorUtility.CompactPropertyField(p) 
+                    { style = { flexBasis = 30, flexGrow = 1, marginLeft = 6 } };
+                f.Label.style.minWidth = 15;
+                f.OnInitialGeometry(() => 
+                {
+                    f.SafeSetIsDelayed();
+                    var ff = f.Q<FloatField>();
+                    if (ff != null)
+                    {
+                        ff.style.marginLeft = -1;
+                        ff.style.marginRight = -3;
+                    }
+                });
+                return f;
+            }
         }
     }
 }

--- a/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/FoldoutWithEnabledButtonPropertyDrawer.cs
@@ -87,7 +87,7 @@ namespace Unity.Cinemachine.Editor
                 { style = { flexGrow = 0, marginLeft = 8, alignSelf = Align.Center }, tooltip = childProperty.tooltip});
             var childField = row.Contents.AddChild(new PropertyField(childProperty, "")
                 { style = { flexGrow = 1, marginTop = -1, marginLeft = 5, marginBottom = -1 }});
-            childLabel.AddPropertyDragger(childProperty, childField);
+            childLabel.AddDelayedFriendlyPropertyDragger(childProperty, childField);
             childField.RemoveFromClassList(InspectorUtility.kAlignFieldClass);
 
             row.TrackPropertyWithInitialCallback(enabledProp, (p) => 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/InputAxisPropertyDrawer.cs
@@ -25,13 +25,20 @@ namespace Unity.Cinemachine.Editor
             var valueProp = property.FindPropertyRelative(() => def.Value);
             var valueLabel = new Label(" ") { style = { minWidth = InspectorUtility.SingleLineHeight * 2}};
             var valueField =  new InspectorUtility.CompactPropertyField(valueProp, "") { style = { flexGrow = 1}};
-            //valueField.OnInitialGeometry(() => valueField.SafeSetIsDelayed());
-            valueLabel.AddPropertyDragger(valueProp, valueField);
+            valueField.OnInitialGeometry(() => valueField.SafeSetIsDelayed());
+            valueLabel.AddDelayedFriendlyPropertyDragger(valueProp, valueField);
 
             var ux = new InspectorUtility.FoldoutWithOverlay(foldout, valueField, valueLabel);
 
-            var valueField2 = foldout.AddChild(new PropertyField(valueProp));
-            //valueField2.OnInitialGeometry(() => valueField2.SafeSetIsDelayed());
+            // We want dynamic dragging on the value, even if isDelayed is set
+            var valueFieldRow = foldout.AddChild(new InspectorUtility.LabeledRow(
+                valueProp.displayName, valueProp.tooltip, new PropertyField(valueProp, "")));
+            valueFieldRow.Contents.OnInitialGeometry(() => 
+            {
+                valueFieldRow.Contents.SafeSetIsDelayed();
+                valueFieldRow.Contents.Q<FloatField>().style.marginLeft = 0;
+            });
+            valueFieldRow.Label.AddDelayedFriendlyPropertyDragger(valueProp, valueFieldRow.Contents);
 
             var centerField = foldout.AddChild(new PropertyField(property.FindPropertyRelative(() => def.Center)));
             var rangeContainer = foldout.AddChild(new VisualElement() { style = { flexDirection = FlexDirection.Row }});

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -92,11 +92,9 @@ namespace Unity.Cinemachine.Editor
             var outerFovControl = new FovPropertyControl(property, true) { style = { flexGrow = 1 }};
             ux.Add(new InspectorUtility.FoldoutWithOverlay(
                 foldout, outerFovControl, outerFovControl.ShortLabel) { style = { flexGrow = 1 }});
-            //outerFovControl.OnInitialGeometry(() => outerFovControl.SafeSetIsDelayed());
 
             // Populate the foldout
             var innerFovControl = foldout.AddChild(new FovPropertyControl(property, false) { style = { flexGrow = 1 }});
-            //innerFovControl.OnInitialGeometry(() => innerFovControl.SafeSetIsDelayed());
 
             var nearClip = property.FindPropertyRelative(() => s_Def.NearClipPlane);
             foldout.AddChild(new PropertyField(nearClip)).RegisterValueChangeCallback((evt) =>
@@ -191,7 +189,8 @@ namespace Unity.Cinemachine.Editor
                 m_Control.RegisterValueChangedCallback(OnControlValueChanged);
                 Label.SetVisible(!hideLabel);
                 Label.AddToClassList("unity-base-field__label--with-dragger");
-                new FieldMouseDragger<float>(m_Control).SetDragZone(Label);
+                new DelayedFriendlyFieldDragger<float>(m_Control).SetDragZone(Label);
+                m_Control.OnInitialGeometry(() => m_Control.SafeSetIsDelayed());
 
                 m_Presets = Contents.AddChild(new PopupField<string>
                     { tooltip = "Customizable Lens Palette", style = {flexBasis = 20, flexGrow = 1}});
@@ -199,7 +198,7 @@ namespace Unity.Cinemachine.Editor
 
                 ShortLabel = new Label("X") { style = { alignSelf = Align.Center, opacity = 0.5f }};
                 ShortLabel.AddToClassList("unity-base-field__label--with-dragger");
-                new FieldMouseDragger<float>(m_Control).SetDragZone(ShortLabel);
+                new DelayedFriendlyFieldDragger<float>(m_Control).SetDragZone(ShortLabel);
 
                 this.TrackPropertyWithInitialCallback(property, OnLensPropertyChanged);
             }

--- a/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
@@ -15,17 +15,18 @@ namespace Unity.Cinemachine.Editor
             var ux = new InspectorUtility.LeftRightRow();
             var label = new Label(property.displayName) 
                 { tooltip = property.tooltip, style = { alignSelf = Align.Center, flexGrow = 1 }};
-            var minField = new PropertyField(xProp, "") { style = { flexBasis = 0, flexGrow = 1}};
+            var minField = new PropertyField(xProp, "") { style = { flexBasis = 0, flexGrow = 1 }};
             var maxField = new InspectorUtility.CompactPropertyField(yProp, "...") 
                 { tooltip = property.tooltip, style = { flexBasis = 10, flexGrow = 1, marginLeft = 5 }};
 
-            //ux.OnInitialGeometry(() =>
-            //{
-            //    minField.SafeSetIsDelayed();
-            //    maxField.SafeSetIsDelayed();
-            //});
+            ux.OnInitialGeometry(() =>
+            {
+                minField.SafeSetIsDelayed();
+                maxField.SafeSetIsDelayed();
+                minField.Q<FloatField>(). style.marginLeft = 2;
+            });
 
-            label.AddPropertyDragger(xProp, minField);
+            label.AddDelayedFriendlyPropertyDragger(xProp, minField);
             ux.Left.Add(label);
             ux.Right.Add(minField);
             ux.Right.Add(maxField);

--- a/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/Vector2AsRangePropertyDrawer.cs
@@ -23,7 +23,7 @@ namespace Unity.Cinemachine.Editor
             {
                 minField.SafeSetIsDelayed();
                 maxField.SafeSetIsDelayed();
-                minField.Q<FloatField>(). style.marginLeft = 2;
+                minField.Q<FloatField>().style.marginLeft = 2;
             });
 
             label.AddDelayedFriendlyPropertyDragger(xProp, minField);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -558,7 +558,7 @@ namespace Unity.Cinemachine.Editor
                     value = enabledProp.boolValue ? priorityProp.intValue : 0,
                     style = { flexBasis = floatFieldWidth, flexGrow = 0, marginRight = 4 }
                 });
-                new FieldMouseDragger<int>(priorityField).SetDragZone(dragger);
+                new DelayedFriendlyFieldDragger<int>(priorityField).SetDragZone(dragger);
                 priorityField.RegisterValueChangedCallback((evt) =>
                 {
                     if (evt.newValue != 0)

--- a/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs
+++ b/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs
@@ -11,9 +11,7 @@ namespace Unity.Cinemachine
     /// </summary>
     class DelayedFriendlyFieldDragger<T> : BaseFieldMouseDragger
     {
-        /// <summary>
-        /// FieldMouseDraggerForDelayed's constructor.
-        /// </summary>
+        /// <summary>DelayedFriendlyFieldDragger's constructor./// </summary>
         /// <param name="drivenField">The field.</param>
         public DelayedFriendlyFieldDragger(IValueField<T> drivenField)
         {
@@ -28,14 +26,10 @@ namespace Unity.Cinemachine
         private Rect m_DragHotZone;
         private bool m_WasDelayed;
 
-        /// <summary>
-        /// Is dragging.
-        /// </summary>
+        /// <summary>Is dragging.</summary>
         public bool dragging { get; set; }
 
-        /// <summary>
-        /// Start value before drag.
-        /// </summary>
+        /// <summary>Start value before drag.</summary>
         public T startValue { get; set; }
 
         /// <inheritdoc />
@@ -98,7 +92,7 @@ namespace Unity.Cinemachine
                 m_WasDelayed = floatField.isDelayed;
                 floatField.isDelayed = false;
             }
-            if (m_DrivenField is TextInputBaseField<int> intField)
+            else if (m_DrivenField is TextInputBaseField<int> intField)
             {
                 m_WasDelayed = intField.isDelayed;
                 intField.isDelayed = false;
@@ -139,10 +133,13 @@ namespace Unity.Cinemachine
                 EditorGUIUtility.SetWantsMouseJumping(0);
                 m_DrivenField.StopDragging();
 
-                if (m_DrivenField is TextInputBaseField<float> floatField)
-                    floatField.isDelayed = m_WasDelayed;
-                if (m_DrivenField is TextInputBaseField<int> intField)
-                    intField.isDelayed = m_WasDelayed;
+                if (m_WasDelayed)
+                {
+                    if (m_DrivenField is TextInputBaseField<float> floatField)
+                        floatField.isDelayed = true;
+                    else if (m_DrivenField is TextInputBaseField<int> intField)
+                        intField.isDelayed = true;
+                }
             }
         }
 

--- a/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs
+++ b/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs
@@ -1,0 +1,163 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using PointerType = UnityEngine.UIElements.PointerType;
+
+namespace Unity.Cinemachine
+{
+    /// <summary>
+    /// Provides dragging on a visual element to change a value field with 
+    /// isDelayed set, but for int and float driven fields turns off isDelayed while dragging.
+    /// </summary>
+    class DelayedFriendlyFieldDragger<T> : BaseFieldMouseDragger
+    {
+        /// <summary>
+        /// FieldMouseDraggerForDelayed's constructor.
+        /// </summary>
+        /// <param name="drivenField">The field.</param>
+        public DelayedFriendlyFieldDragger(IValueField<T> drivenField)
+        {
+            m_DrivenField = drivenField;
+            m_DragElement = null;
+            m_DragHotZone = new Rect(0, 0, -1, -1);
+            dragging = false;
+        }
+
+        private readonly IValueField<T> m_DrivenField;
+        private VisualElement m_DragElement;
+        private Rect m_DragHotZone;
+        private bool m_WasDelayed;
+
+        /// <summary>
+        /// Is dragging.
+        /// </summary>
+        public bool dragging { get; set; }
+
+        /// <summary>
+        /// Start value before drag.
+        /// </summary>
+        public T startValue { get; set; }
+
+        /// <inheritdoc />
+        public sealed override void SetDragZone(VisualElement dragElement, Rect hotZone)
+        {
+            if (m_DragElement != null)
+            {
+                m_DragElement.UnregisterCallback<PointerDownEvent>(UpdateValueOnPointerDown, TrickleDown.TrickleDown);
+                m_DragElement.UnregisterCallback<PointerUpEvent>(UpdateValueOnPointerUp);
+                m_DragElement.UnregisterCallback<KeyDownEvent>(UpdateValueOnKeyDown);
+            }
+
+            m_DragElement = dragElement;
+            m_DragHotZone = hotZone;
+
+            if (m_DragElement != null)
+            {
+                dragging = false;
+                m_DragElement.RegisterCallback<PointerDownEvent>(UpdateValueOnPointerDown, TrickleDown.TrickleDown);
+                m_DragElement.RegisterCallback<PointerUpEvent>(UpdateValueOnPointerUp);
+                m_DragElement.RegisterCallback<KeyDownEvent>(UpdateValueOnKeyDown);
+            }
+        }
+
+        private bool CanStartDrag(int button, Vector2 localPosition)
+        {
+            return button == 0 && (m_DragHotZone.width < 0 || m_DragHotZone.height < 0 ||
+                m_DragHotZone.Contains(m_DragElement.WorldToLocal(localPosition)));
+        }
+
+        private void UpdateValueOnPointerDown(PointerDownEvent evt)
+        {
+            if (CanStartDrag(evt.button, evt.localPosition))
+            {
+                // We want to allow dragging when using a mouse in any context and when in an Editor context with any pointer type.
+                if (evt.pointerType == PointerType.mouse)
+                {
+                    m_DragElement.CaptureMouse();
+                    ProcessDownEvent(evt);
+                }
+                else if (m_DragElement.panel.contextType == ContextType.Editor)
+                {
+                    m_DragElement.CapturePointer(evt.pointerId);
+                    ProcessDownEvent(evt);
+                }
+            }
+        }
+
+        private void ProcessDownEvent(EventBase evt)
+        {
+            // Make sure no other elements can capture the mouse!
+            evt.StopPropagation();
+
+            dragging = true;
+            m_DragElement.RegisterCallback<PointerMoveEvent>(UpdateValueOnPointerMove);
+            startValue = m_DrivenField.value;
+
+            if (m_DrivenField is TextInputBaseField<float> floatField)
+            {
+                m_WasDelayed = floatField.isDelayed;
+                floatField.isDelayed = false;
+            }
+            if (m_DrivenField is TextInputBaseField<int> intField)
+            {
+                m_WasDelayed = intField.isDelayed;
+                intField.isDelayed = false;
+            }
+            m_DrivenField.StartDragging();
+            EditorGUIUtility.SetWantsMouseJumping(1);
+        }
+
+        private void UpdateValueOnPointerMove(PointerMoveEvent evt)
+        {
+            ProcessMoveEvent(evt.shiftKey, evt.altKey, evt.deltaPosition);
+        }
+
+        private void ProcessMoveEvent(bool shiftKey, bool altKey, Vector2 deltaPosition)
+        {
+            if (dragging)
+            {
+                DeltaSpeed s = shiftKey ? DeltaSpeed.Fast : (altKey ? DeltaSpeed.Slow : DeltaSpeed.Normal);
+                m_DrivenField.ApplyInputDeviceDelta(deltaPosition, s, startValue);
+            }
+        }
+
+        private void UpdateValueOnPointerUp(PointerUpEvent evt)
+        {
+            ProcessUpEvent(evt, evt.pointerId);
+        }
+
+        private void ProcessUpEvent(EventBase evt, int pointerId)
+        {
+            if (dragging)
+            {
+                dragging = false;
+                m_DragElement.UnregisterCallback<PointerMoveEvent>(UpdateValueOnPointerMove);
+                m_DragElement.ReleasePointer(pointerId);
+                //if (evt is IMouseEvent)
+                //    m_DragElement.panel.ProcessPointerCapture(PointerId.mousePointerId);
+
+                EditorGUIUtility.SetWantsMouseJumping(0);
+                m_DrivenField.StopDragging();
+
+                if (m_DrivenField is TextInputBaseField<float> floatField)
+                    floatField.isDelayed = m_WasDelayed;
+                if (m_DrivenField is TextInputBaseField<int> intField)
+                    intField.isDelayed = m_WasDelayed;
+            }
+        }
+
+        private void UpdateValueOnKeyDown(KeyDownEvent evt)
+        {
+            if (dragging && evt.keyCode == KeyCode.Escape)
+            {
+                dragging = false;
+                m_DrivenField.value = startValue;
+                m_DrivenField.StopDragging();
+                var target = evt.target as VisualElement;
+                IPanel panel = target?.panel;
+                panel?.ReleasePointer(PointerId.mousePointerId);
+                EditorGUIUtility.SetWantsMouseJumping(0);
+            }
+        }
+    }
+}

--- a/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs.meta
+++ b/com.unity.cinemachine/Editor/Utility/DelayedFriendlyFieldDragger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 084e3bf849254ae4688d18544d82c114
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -531,7 +531,7 @@ namespace Unity.Cinemachine.Editor
         /// <summary>
         /// Add a property dragger to a float or int label, so that dragging it changes the property value.
         /// </summary>
-        public static void AddPropertyDragger(this Label label, SerializedProperty p, VisualElement field)
+        public static void AddDelayedFriendlyPropertyDragger(this Label label, SerializedProperty p, VisualElement field)
         {
             if (p.propertyType == SerializedPropertyType.Float 
                 || p.propertyType == SerializedPropertyType.Integer)
@@ -540,9 +540,9 @@ namespace Unity.Cinemachine.Editor
                 label.OnInitialGeometry(() =>
                 {
                     if (p.propertyType == SerializedPropertyType.Float)
-                        new FieldMouseDragger<float>(field.Q<FloatField>()).SetDragZone(label);
+                        new DelayedFriendlyFieldDragger<float>(field.Q<FloatField>()).SetDragZone(label);
                     else if (p.propertyType == SerializedPropertyType.Integer)
-                        new FieldMouseDragger<int>(field.Q<IntegerField>()).SetDragZone(label);
+                        new DelayedFriendlyFieldDragger<int>(field.Q<IntegerField>()).SetDragZone(label);
                 });
             }
         }
@@ -776,7 +776,7 @@ namespace Unity.Cinemachine.Editor
                         { tooltip = property?.tooltip, style = { alignSelf = Align.Center, minWidth = minLabelWidth }});
                 Field = AddChild(this, new PropertyField(property, "") { style = { flexGrow = 1, flexBasis = 10 } });
                 if (Label != null)
-                    AddPropertyDragger(Label, property, Field);
+                    AddDelayedFriendlyPropertyDragger(Label, property, Field);
             }
         }
 
@@ -789,7 +789,7 @@ namespace Unity.Cinemachine.Editor
             var row = new LabeledRow(label ?? property.displayName, property.tooltip);
             var field = propertyField = row.Contents.AddChild(new PropertyField(property, "")
                 { style = { flexGrow = 1, flexBasis = SingleLineHeight * 5 }});
-            AddPropertyDragger(row.Label, property, propertyField);
+            AddDelayedFriendlyPropertyDragger(row.Label, property, propertyField);
 
             // Kill any left margin that gets inserted into the property field
             field.OnInitialGeometry(() => 

--- a/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
+++ b/com.unity.cinemachine/Runtime/Core/ScreenComposerSettings.cs
@@ -11,7 +11,7 @@ namespace Unity.Cinemachine
         /// tracked object here.  0 is screen center, and +0.5 or -0.5 is screen edge</summary>
         [Tooltip("Screen position for target. The camera will adjust to position the "
         + "tracked object here.  0 is screen center, and +0.5 or -0.5 is screen edge")]
-        //[DelayedVector] // interferes with game guide refresh
+        [DelayedVector]
         public Vector2 ScreenPosition;
 
         /// <summary>Settings for DeadZone, which is an area within which the camera will not adjust itself.</summary>
@@ -24,7 +24,7 @@ namespace Unity.Cinemachine
             /// Full screen size is 1.</summary>
             [Tooltip("The camera will not adjust if the target is within this range of the "
                 + "screen position.  Full screen size is 1.")]
-            //[DelayedVector] // interferes with game guide refresh
+            [DelayedVector]
             public Vector2 Size;
         }
         /// <summary>The camera will not adjust if the target is within this range of the screen position</summary>
@@ -48,14 +48,14 @@ namespace Unity.Cinemachine
                 + "When the target is within this region, the camera will gradually adjust to re-align "
                 + "towards the desired position, depending on the damping speed.  "
                 + "Full screen size is 1")]
-            //[DelayedVector] // interferes with game guide refresh
+            [DelayedVector]
             public Vector2 Size;
             /// <summary>A zero Offset means that the hard limits will be centered around the target screen position.  
             /// A nonzero Offset will uncenter the hard limits relative to the target screen position.
             /// </summary>
             [Tooltip("A zero Offset means that the hard limits will be centered around the target screen position.  "
                 + "A nonzero Offset will uncenter the hard limits relative to the target screen position.")]
-            //[DelayedVector] // interferes with game guide refresh
+            [DelayedVector]
             public Vector2 Offset;
         }
         /// <summary>The target will not be allowed to be outside this region.


### PR DESCRIPTION
### Purpose of this PR

The IsDelayed function on float fields delays processing of the text input until enter is pressed.  This is useful because otherwise OnValidate() kicks in and interferes with your typing when it does its clamping.

However, isDelayed also prevents processing when you drag on the label, until you stop dragging.  This kills the visual feedback that is crucial for some fields.

This PR re-introduces dragging for isDelayed fields by installing a custom dragger that temporarily disables isDelayed while the property is being dragged.

This custom dragger has been added to the following fields:

- FOV/Ortho size (collapsed and expanded versions)
- Axis Value (collapsed and expanded versions)
- Composition settings in PositionComposer and RotationComposer.  

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

