### PR TITLE
CMCL-0000: Group Framing works with Confiner 2D

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-01-01
+
+### Changed
+- CinemachineGroupFraming now has a compatibility mode so that it can work with CinemachineConfiner2D out of the box.
+
+
 ## [3.1.0] - 2024-04-01
 
 ### Fixed

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -133,11 +133,17 @@ namespace Unity.Cinemachine
             public Vector2 RotAdjustment;
             public float FovAdjustment;
 
+            public CinemachineCore.Stage Stage = CinemachineCore.Stage.Finalize; // uninitialized state
+            public CinemachineConfiner2D Confiner;
+            public float PreviousOrthoSize;
+
             public void Reset()
             {
                 PosAdjustment = Vector3.zero;
                 RotAdjustment = Vector2.zero;
                 FovAdjustment = 0;
+                Stage = CinemachineCore.Stage.Finalize;
+                PreviousOrthoSize = 0;
             }
         };
 
@@ -157,10 +163,32 @@ namespace Unity.Cinemachine
             CinemachineVirtualCameraBase vcam,
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
-            // We have to do it after both Body and Aim, and the only way to ensure that is to
-            // do it after noise (because body and aim can be inverted).
-            // We ignore the noise effect anyway, so it doesn't hurt.
-            if (stage != CinemachineCore.Stage.Noise)
+            var extra = GetExtraState<VcamExtraState>(vcam);
+            if (!vcam.PreviousStateIsValid)
+                extra.Reset();
+
+            if (extra.Stage == CinemachineCore.Stage.Finalize || !Application.isPlaying)
+            {
+                // We have a special compatibility mode for Confiner2D, because it is a common use-case
+                vcam.TryGetComponent(out extra.Confiner);
+                if (extra.Confiner != null)
+                    extra.Stage = CinemachineCore.Stage.Body;
+                else
+                {
+                    // Default: applies after Aim
+                    extra.Stage = CinemachineCore.Stage.Aim;
+
+                    // Exception: if vcam has a BodyAppliesAfterAim component, we do it in the Body stage
+                    if (vcam is CinemachineCamera cam)
+                    {
+                        var c = cam.GetCinemachineComponent(CinemachineCore.Stage.Body);
+                        if (c != null && c.BodyAppliesAfterAim)
+                            extra.Stage = CinemachineCore.Stage.Body;
+                    }
+                }
+            }
+
+            if (stage != extra.Stage)
                 return;
             
             var group = vcam.LookAtTargetAsGroup;
@@ -168,14 +196,17 @@ namespace Unity.Cinemachine
             if (group == null || !group.IsValid)
                 return;
 
-            var extra = GetExtraState<VcamExtraState>(vcam);
-            if (!vcam.PreviousStateIsValid)
-                extra.Reset();
-
             if (state.Lens.Orthographic)
                 OrthoFraming(vcam, group, extra, ref state, deltaTime);
             else
                 PerspectiveFraming(vcam, group, extra, ref state, deltaTime);
+
+            // Confiner2D compatibility mode: invalidate the cache if the ortho size changed
+            if (extra.Confiner != null && Mathf.Abs(extra.PreviousOrthoSize - state.Lens.OrthographicSize) > Epsilon)
+            {
+                extra.Confiner.InvalidateLensCache();
+                extra.PreviousOrthoSize = state.Lens.OrthographicSize;
+            }
         }
 
         void OrthoFraming(

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -134,8 +134,10 @@ namespace Unity.Cinemachine
             public float FovAdjustment;
 
             public CinemachineCore.Stage Stage = CinemachineCore.Stage.Finalize; // uninitialized state
+#if CINEMACHINE_PHYSICS_2D
             public CinemachineConfiner2D Confiner;
             public float PreviousOrthoSize;
+#endif
 
             public void Reset()
             {
@@ -143,7 +145,6 @@ namespace Unity.Cinemachine
                 RotAdjustment = Vector2.zero;
                 FovAdjustment = 0;
                 Stage = CinemachineCore.Stage.Finalize;
-                PreviousOrthoSize = 0;
             }
         };
 
@@ -169,10 +170,12 @@ namespace Unity.Cinemachine
 
             if (extra.Stage == CinemachineCore.Stage.Finalize || !Application.isPlaying)
             {
+#if CINEMACHINE_PHYSICS_2D
                 // We have a special compatibility mode for Confiner2D, because it is a common use-case
                 if (vcam.TryGetComponent(out extra.Confiner))
                     extra.Stage = CinemachineCore.Stage.Body;
                 else
+#endif
                 {
                     // Default: applies after Aim
                     extra.Stage = CinemachineCore.Stage.Aim;
@@ -200,12 +203,14 @@ namespace Unity.Cinemachine
             else
                 PerspectiveFraming(vcam, group, extra, ref state, deltaTime);
 
+#if CINEMACHINE_PHYSICS_2D
             // Confiner2D compatibility mode: invalidate the cache if the ortho size changed
             if (extra.Confiner != null && Mathf.Abs(extra.PreviousOrthoSize - state.Lens.OrthographicSize) > Epsilon)
             {
                 extra.Confiner.InvalidateLensCache();
                 extra.PreviousOrthoSize = state.Lens.OrthographicSize;
             }
+#endif
         }
 
         void OrthoFraming(

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -170,8 +170,7 @@ namespace Unity.Cinemachine
             if (extra.Stage == CinemachineCore.Stage.Finalize || !Application.isPlaying)
             {
                 // We have a special compatibility mode for Confiner2D, because it is a common use-case
-                vcam.TryGetComponent(out extra.Confiner);
-                if (extra.Confiner != null)
+                if (vcam.TryGetComponent(out extra.Confiner))
                     extra.Stage = CinemachineCore.Stage.Body;
                 else
                 {

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs.meta
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {fileID: 2800000, guid: 3327a326efc0c4079a8eada111b11d29, type: 3}
   userData: 
   assetBundleName: 

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "unity": "2022.3",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [


### PR DESCRIPTION
### Purpose of this PR

GroupFraming and Confiner2D did not play well together.  
Slack thread: https://unity.slack.com/archives/C4P4KJR9A/p1713367131830879

This PR introduces a special compatibility mode to handle this common use-case.  GroupFraming checks for the presence of Confiner2D and if it finds one, it runs in the Body stage (with an early execution order) so that it happens before Confiner2D.  Also, in this mode it monitors the ortho size and invalidates the confiner lens cache when the ortho size changes.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
