### PR TITLE
CMCL-1397: Use TypeCache where appropriate

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -133,10 +133,8 @@ namespace Unity.Cinemachine
             static ModifierMenuItems()
             {
                 // Get all Modifier types
-                var allTypes
-                    = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                        (Type t) => typeof(CinemachineFreeLookModifier.Modifier).IsAssignableFrom(t) 
-                        && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineFreeLookModifier.Modifier), 
+                    (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
                 s_AllModifiers.Clear();
                 s_ModifierNames.Clear();

--- a/com.unity.cinemachine/Editor/Obsolete/CinemachineVirtualCameraBaseEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/CinemachineVirtualCameraBaseEditor.cs
@@ -43,14 +43,12 @@ namespace Unity.Cinemachine.Editor
             if (sExtensionTypes == null)
             {
                 // Populate the extension list
-                List<Type> exts = new List<Type>();
-                List<string> names = new List<string>();
+                List<Type> exts = new ();
+                List<string> names = new ();
                 exts.Add(null);
                 names.Add("(select)");
-                var allExtensions
-                    = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t)
-                            && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allExtensions = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineExtension),
+                        (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 foreach (Type t in allExtensions)
                 {
                     exts.Add(t);

--- a/com.unity.cinemachine/Editor/Obsolete/VcamStageEditor.cs
+++ b/com.unity.cinemachine/Editor/Obsolete/VcamStageEditor.cs
@@ -36,9 +36,8 @@ namespace Unity.Cinemachine.Editor
                 }
 
                 // Get all ICinemachineComponents
-                var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies((Type t) =>
-                    typeof(CinemachineComponentBase).IsAssignableFrom(t) && !t.IsAbstract &&
-                    t.GetCustomAttribute<CameraPipelineAttribute>() != null); // we allow obsolete attributes here
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineComponentBase),
+                    (t) => !t.IsAbstract && t.GetCustomAttribute<CameraPipelineAttribute>() != null); // we allow obsolete attributes here
 
                 foreach (var t in allTypes)
                 {

--- a/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/EmbeddedAssetPropertyDrawer.cs
@@ -182,10 +182,8 @@ namespace Unity.Cinemachine.Editor
         {
             // Collect all the eligible asset types
             Type type = EmbeddedAssetType(property);
-            if (mAssetTypes == null)
-                mAssetTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                    (Type t) => type.IsAssignableFrom(t) && !t.IsAbstract 
-                        && t.GetCustomAttribute<ObsoleteAttribute>() == null).ToArray();
+            mAssetTypes ??= ReflectionHelpers.GetTypesDerivedFrom(type, 
+                (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null).ToArray();
 
             float iconSize = r.height + 4;
             r.width -= iconSize;

--- a/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/SplineAutoDollyPropertyDrawer.cs
@@ -110,10 +110,8 @@ namespace Unity.Cinemachine.Editor
             static AutoDollyMenuItems()
             {
                 // Get all eligible types
-                var allTypes
-                    = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                        (Type t) => typeof(SplineAutoDolly.ISplineAutoDolly).IsAssignableFrom(t) 
-                            && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(typeof(SplineAutoDolly.ISplineAutoDolly),
+                    (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
                 s_AllItems.Clear();
                 s_AllItems.Add(null);

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -348,10 +348,10 @@ namespace Unity.Cinemachine.Editor
                 }
 
                 // Get all CinemachineComponentBase
-                var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies((Type t) => 
-                    typeof(CinemachineComponentBase).IsAssignableFrom(t) && !t.IsAbstract 
-                    && t.GetCustomAttribute<CameraPipelineAttribute>() != null
-                    && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineComponentBase),
+                    (t) => !t.IsAbstract 
+                        && t.GetCustomAttribute<CameraPipelineAttribute>() != null
+                        && t.GetCustomAttribute<ObsoleteAttribute>() == null);
 
                 var iter = allTypes.GetEnumerator();
                 while (iter.MoveNext())
@@ -367,10 +367,8 @@ namespace Unity.Cinemachine.Editor
                 s_ExtensionNames = new List<string>();
                 s_ExtensionTypes.Add(null);
                 s_ExtensionNames.Add("(select)");
-                var allExtensions
-                    = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                            (Type t) => typeof(CinemachineExtension).IsAssignableFrom(t) 
-                                && !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allExtensions = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineExtension),
+                    (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 var iter2 = allExtensions.GetEnumerator();
                 while (iter2.MoveNext())
                 {

--- a/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmPipelineComponentInspectorUtility.cs
@@ -133,9 +133,8 @@ namespace Unity.Cinemachine.Editor
         {
             if (s_AllAxisControllerTypes == null)
             {
-                var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                    (Type t) => typeof(IInputAxisController).IsAssignableFrom(t) && !t.IsAbstract 
-                        && typeof(MonoBehaviour).IsAssignableFrom(t)
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(typeof(IInputAxisController),
+                    (t) => !t.IsAbstract && typeof(MonoBehaviour).IsAssignableFrom(t) 
                         && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 s_AllAxisControllerTypes = new();
                 var iter = allTypes.GetEnumerator();

--- a/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
@@ -233,9 +233,8 @@ namespace Unity.Cinemachine.Editor
             static List<Type> GetAssetTypes(Type baseType)
             {
                 // GML todo: optimize with TypeCache
-                var allTypes = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                    (Type t) => baseType.IsAssignableFrom(t) && !t.IsAbstract 
-                        && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+                var allTypes = ReflectionHelpers.GetTypesDerivedFrom(baseType,
+                    (t) => !t.IsAbstract && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 var list = new List<Type>();
                 var iter = allTypes.GetEnumerator();
                 while (iter.MoveNext())

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -381,9 +381,8 @@ namespace Unity.Cinemachine.Editor
                 return "(none)";
             if (!s_AssignableTypes.ContainsKey(inputType))
             {
-                var allSources = ReflectionHelpers.GetTypesInAllDependentAssemblies(
-                    (Type t) => inputType.IsAssignableFrom(t) && !t.IsAbstract 
-                        && typeof(MonoBehaviour).IsAssignableFrom(t)
+                var allSources = ReflectionHelpers.GetTypesDerivedFrom(inputType,
+                    (t) => !t.IsAbstract && typeof(MonoBehaviour).IsAssignableFrom(t)
                         && t.GetCustomAttribute<ObsoleteAttribute>() == null);
                 var s = string.Empty;
                 var iter = allSources.GetEnumerator();

--- a/com.unity.cinemachine/Tests/CmCameraProceduralBehaviourCacheTests.cs
+++ b/com.unity.cinemachine/Tests/CmCameraProceduralBehaviourCacheTests.cs
@@ -29,10 +29,9 @@ namespace Unity.Cinemachine.Tests
             m_CmCamera = CreateGameObject("CinemachineCamera", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();
             m_CmCamera.Priority.Value = 100;
             
-            s_AllCinemachineComponents = ReflectionHelpers.GetTypesInAllDependentAssemblies((Type t) => 
-                typeof(CinemachineComponentBase).IsAssignableFrom(t) && !t.IsAbstract 
-                && t.GetCustomAttribute<CameraPipelineAttribute>() != null
-                && t.GetCustomAttribute<ObsoleteAttribute>() == null);
+            s_AllCinemachineComponents = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineComponentBase),
+                (t) => !t.IsAbstract && t.GetCustomAttribute<CameraPipelineAttribute>() != null
+                    && t.GetCustomAttribute<ObsoleteAttribute>() == null);
         }
 
         [TearDown]

--- a/com.unity.cinemachine/Tests/Editor/UpgradeCm2ToCm3Tests.cs
+++ b/com.unity.cinemachine/Tests/Editor/UpgradeCm2ToCm3Tests.cs
@@ -36,10 +36,10 @@ namespace Unity.Cinemachine.Tests.Editor
         {
             get
             {
-                s_AllCinemachineComponents = ReflectionHelpers.GetTypesInAllDependentAssemblies((Type t) => 
-                    typeof(CinemachineComponentBase).IsAssignableFrom(t) && !t.IsAbstract 
-                    && t.GetCustomAttribute<CameraPipelineAttribute>() != null
-                    && t.GetCustomAttribute<ObsoleteAttribute>() != null);
+                s_AllCinemachineComponents = ReflectionHelpers.GetTypesDerivedFrom(typeof(CinemachineComponentBase),
+                    (t) => !t.IsAbstract 
+                        && t.GetCustomAttribute<CameraPipelineAttribute>() != null
+                        && t.GetCustomAttribute<ObsoleteAttribute>() != null);
                 foreach (var cmComponent in s_AllCinemachineComponents)
                     yield return new TestCaseData(cmComponent).SetName(cmComponent.Name).Returns(null);
             }


### PR DESCRIPTION
### Purpose of this PR

TypeCache is an optimization when iterating type using reflection.  Using TypeCache to search for types speeds up domain reload time.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 