### PR TITLE
CMCL-1581: Add Recenter Target option to PanTilt

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.1.1] - 2025-01-01
 
+### Fixed
+- Bugfix: InputAxis.TriggerRecentering() function caused the axis to immediately snap to its recenter value.
+
 ### Changed
 - CinemachineGroupFraming now has a compatibility mode so that it can work with CinemachineConfiner2D out of the box.
-- Bugfix: InputAxis.TriggerRecentering() function caused the axis to immediately snap to its recenter value.
+
+### Added
+- Added Recenter Target setting to CinemachinePanTilt
 
 
 ## [3.1.0] - 2024-04-01

--- a/com.unity.cinemachine/Documentation~/CinemachinePanTilt.md
+++ b/com.unity.cinemachine/Documentation~/CinemachinePanTilt.md
@@ -21,7 +21,11 @@ This CinemachineCamera __Rotation Control__ behavior pans and tilts the camera i
 | | _Center_ | The value that Recentering will recenter to, if Recentering is enabled. |
 | | _Range_ | The minimum and maximum for the Value. Must fall inside of [-90, 90]. |
 | | _Wrap_ | If enabled, the axis wraps around when it reaches the end of its range, forming a loop. |
-| __Recentering__ | | If enabled for an axis, Recentering will gradually return the axis value to its Center. |
+| __Recentering__ | | If enabled for an axis, Recentering will gradually return the axis value to the recentering target. |
 |  | _Wait_ | If recentering is enabled for an axis, it will wait this many seconds after the last user input before beginning the recentering process. |
 |  | _Time_ | The time it takes for the recentering to complete, once it has started. |
+| __Recenter Target__ || When Axis Recentering happens, it will recenter towards this target.  |
+| | _Axis Center_ | Recenter to the Center value defined within the axis. |
+| | _Tracking Target Forward_ | Recenter to the value that aligns with the Tracking Target's forward axis. |
+| | _LookAt Target Forward_ | Recenter to the value that aligns with the LookAt Target's forward axis. |
 

--- a/com.unity.cinemachine/Runtime/Core/InputAxis.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxis.cs
@@ -245,11 +245,18 @@ namespace Unity.Cinemachine
             Value = m_RecenteringState.m_LastValue = value;
         }
 
-        /// <summary>Call this to manage re-centering axis value to axis center.
+        /// <summary>Call this to manage re-centering axis value towards axis center.
         /// This assumes that TrackValueChange() has been called already this frame.</summary>
         /// <param name="deltaTime">Current deltaTime, or -1 for immediate re-centering</param>
         /// <param name="forceCancel">If true, cancel any re-centering currently in progress and reset the timer.</param>
-        public void UpdateRecentering(float deltaTime, bool forceCancel)
+        public void UpdateRecentering(float deltaTime, bool forceCancel) => UpdateRecentering(deltaTime, forceCancel, Center);
+
+        /// <summary>Call this to manage re-centering axis value towards the supplied center value.
+        /// This assumes that TrackValueChange() has been called already this frame.</summary>
+        /// <param name="deltaTime">Current deltaTime, or -1 for immediate re-centering</param>
+        /// <param name="forceCancel">If true, cancel any re-centering currently in progress and reset the timer.</param>
+        /// <param name="center">The value to recenter toward.</param>
+        public void UpdateRecentering(float deltaTime, bool forceCancel, float center)
         {
             if ((Restrictions & (RestrictionFlags.NoRecentering | RestrictionFlags.Momentary)) != 0)
                 return;
@@ -261,7 +268,7 @@ namespace Unity.Cinemachine
             }
             if ((m_RecenteringState.m_ForceRecenter || Recentering.Enabled) && deltaTime < 0)
             {
-                Value = Center;
+                Value = ClampValue(center);
                 CancelRecentering();
             }
             else if (m_RecenteringState.m_ForceRecenter 
@@ -269,7 +276,7 @@ namespace Unity.Cinemachine
                     - m_RecenteringState.m_LastValueChangeTime >= Recentering.Wait))
             {
                 var v = ClampValue(Value);
-                var c = Center;
+                var c = center;
                 var distance = Mathf.Abs(c - v);
                 if (distance < RecenteringState.k_Epsilon || Recentering.Time < RecenteringState.k_Epsilon)
                 {

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachinePOV.cs
@@ -254,6 +254,7 @@ namespace Unity.Cinemachine
         internal void UpgradeToCm3(CinemachinePanTilt c)
         {
             c.ReferenceFrame = CinemachinePanTilt.ReferenceFrames.ParentObject;
+            c.RecenterTarget = (CinemachinePanTilt.RecenterTargetModes)m_RecenterTarget;
 
             c.PanAxis.Range = new Vector2(m_HorizontalAxis.m_MinValue, m_HorizontalAxis.m_MaxValue);
             c.PanAxis.Center = 0;


### PR DESCRIPTION
### Purpose of this PR

Added "Recenter Target" feature to PanTilt, because it was available in CM2 POV and missing in CM3.
Reported on forums:  https://forum.unity.com/threads/cm3-pan-tilt-w-tracking-target-reference-frame-causes-spinning-camera.1583394/#post-9792165

![image](https://github.com/Unity-Technologies/com.unity.cinemachine/assets/6424658/10d2853e-ba9e-48d4-8a13-8bc8d6bf7656)


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low

