### PR TITLE
CMCL-0000: Add list of modified objects to SaveDuringPlay dialog

### DIFF
--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -568,6 +568,9 @@ namespace Unity.Cinemachine.Editor
             //Debug.Log("Updating state for all interesting objects");
             bool dirty = false;
             var roots = ObjectTreeUtil.FindAllRootObjectsInOpenScenes();
+            string savedObjects = "";
+            int numNamesCollected = 0;
+            const int MaxNamesToCollect = 10;
             for (int i = 0; i < s_SavedStates.Count; ++i)
             {
                 var saver = s_SavedStates[i];
@@ -578,6 +581,16 @@ namespace Unity.Cinemachine.Editor
                     if (saver.PutFieldValues(go, roots))
                     {
                         //Debug.Log("SaveDuringPlay: updated settings of " + saver.ObjetFullPath);
+                        ++numNamesCollected;
+                        if (numNamesCollected == MaxNamesToCollect)
+                            savedObjects += "...(and more)\n";
+                        else if (numNamesCollected < MaxNamesToCollect)
+                        {
+                            var name = saver.ObjetFullPath;
+                            if (name[0] == '/')
+                                name = name.Substring(1);
+                            savedObjects += name + "\n";
+                        }
                         EditorUtility.SetDirty(go);
                         dirty = true;
                     }
@@ -585,19 +598,18 @@ namespace Unity.Cinemachine.Editor
             }
             if (dirty)
             {
-                if (!EditorUtility.DisplayDialog(
-                        "Save changes made in Play Mode",
-                        "Some Cinemachine settings that were modified during play mode are being "
+                var text = "Some Cinemachine settings that were modified during play mode are being "
                         + "propagated back to the scene.  Would you like to keep these changes, or undo them?\n\n"
-                        + "Note: if you choose Cancel, then the changes will be undone now.  If you choose Keep, then it "
-                        + "will still be possible to change your mind later by invoking Undo.",
-                        "Keep", "Cancel"))
-                {
+                        + "Modified objects include:\n\n"
+                        + savedObjects
+                        + "\nNote: if you choose Cancel, then the changes will be undone now.  If you choose Keep, then it "
+                        + "will still be possible to change your mind later by invoking Undo.";
+                if (!EditorUtility.DisplayDialog("Save changes made in Play Mode", text, "Keep", "Cancel"))
                     Undo.PerformUndo();
-                }
                 UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
             }
             s_SavedStates = null;
         }
+
     }
 }

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -566,10 +566,9 @@ namespace Unity.Cinemachine.Editor
         static void RestoreAllInterestingStates()
         {
             //Debug.Log("Updating state for all interesting objects");
-            bool dirty = false;
             var roots = ObjectTreeUtil.FindAllRootObjectsInOpenScenes();
             string savedObjects = "";
-            int numNamesCollected = 0;
+            int numObjectsSaved = 0;
             const int MaxNamesToCollect = 10;
             for (int i = 0; i < s_SavedStates.Count; ++i)
             {
@@ -581,10 +580,10 @@ namespace Unity.Cinemachine.Editor
                     if (saver.PutFieldValues(go, roots))
                     {
                         //Debug.Log("SaveDuringPlay: updated settings of " + saver.ObjetFullPath);
-                        ++numNamesCollected;
-                        if (numNamesCollected == MaxNamesToCollect)
+                        ++numObjectsSaved;
+                        if (numObjectsSaved == MaxNamesToCollect)
                             savedObjects += "...(and more)\n";
-                        else if (numNamesCollected < MaxNamesToCollect)
+                        else if (numObjectsSaved < MaxNamesToCollect)
                         {
                             var name = saver.ObjetFullPath;
                             if (name[0] == '/')
@@ -592,11 +591,10 @@ namespace Unity.Cinemachine.Editor
                             savedObjects += name + "\n";
                         }
                         EditorUtility.SetDirty(go);
-                        dirty = true;
                     }
                 }
             }
-            if (dirty)
+            if (numObjectsSaved > 0)
             {
                 var text = "Some Cinemachine settings that were modified during play mode are being "
                         + "propagated back to the scene.  Would you like to keep these changes, or undo them?\n\n"


### PR DESCRIPTION
### Purpose of this PR

As a small assistance so you know what you're saving.

![image](https://github.com/Unity-Technologies/com.unity.cinemachine/assets/6424658/00ad75fb-da69-4894-a0dc-870512fb61d9)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
