### PR TITLE
CMCL-0000: SimplePlayerController no longer uses PlayerController.isGrounded

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Bugfix: InputAxis.TriggerRecentering() function caused the axis to immediately snap to its recenter value.
+- SimplePlayerController no longer uses PlayerController.isGrounded because it's not reliable outside of FixedUpdate.
 
 ### Changed
 - CinemachineGroupFraming now has a compatibility mode so that it can work with CinemachineConfiner2D out of the box.

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -109,14 +109,7 @@ namespace Unity.Cinemachine.Samples
         public bool IsJumping => m_IsJumping;
         public Camera Camera => CameraOverride == null ? Camera.main : CameraOverride;
 
-        public bool IsGrounded()
-        {
-            if (m_Controller != null)
-                return m_Controller.isGrounded;
-
-            // No controller - must compute manually with raycast
-            return GetDistanceFromGround(transform.position, UpDirection, 10) < 0.01f;
-        }
+        public bool IsGrounded() => GetDistanceFromGround(transform.position, UpDirection, 10) < 0.01f;
 
         void Start() => TryGetComponent(out m_Controller);
 
@@ -329,7 +322,7 @@ namespace Unity.Cinemachine.Samples
 
         float GetDistanceFromGround(Vector3 pos, Vector3 up, float max)
         {
-            float kExtraHeight = 2; // start a little above the player in case it's moving down fast
+            float kExtraHeight = m_Controller == null ? 2 : 0; // start a little above the player in case it's moving down fast
             if (Physics.Raycast(pos + up * kExtraHeight, -up, out var hit, 
                     max + kExtraHeight, GroundLayers, QueryTriggerInteraction.Ignore))
                 return hit.distance - kExtraHeight; 


### PR DESCRIPTION
### Purpose of this PR

SimplePlayerController no longer uses PlayerController.isGrounded because it's not reliable outside of FixedUpdate.
Reported via salck: https://unity.slack.com/archives/C4P4KJR9A/p1714691648512799


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Just sample code.
