### PR TITLE
CMCL-1585: GroupAverage Rotation Mode not calculated correctly CM3

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Bugfix: InputAxis.TriggerRecentering() function caused the axis to immediately snap to its recenter value.
 - SimplePlayerController no longer uses PlayerController.isGrounded because it's not reliable outside of FixedUpdate.
+- Bugfix: The GroupAverage Rotation Mode in CinemachineTargetGroup was not calculated properly.
 
 ### Changed
 - CinemachineGroupFraming now has a compatibility mode so that it can work with CinemachineConfiner2D out of the box.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -143,6 +143,7 @@ namespace Unity.Cinemachine
 
 
         float m_MaxWeight;
+        float m_WeightSum;
         Vector3 m_AveragePos;
         Bounds m_BoundingBox;
         BoundingSphere m_BoundingSphere;
@@ -346,13 +347,12 @@ namespace Unity.Cinemachine
         /// </summary>
         public void DoUpdate()
         {
-            Targets ??= new (); // in case user set it to null
-
             m_LastUpdateFrame = Time.frameCount;
+
             UpdateMemberValidity();
-            m_AveragePos = CalculateAveragePosition(out m_MaxWeight);
-            BoundingBox = CalculateBoundingBox(m_MaxWeight);
-            m_BoundingSphere = CalculateBoundingSphere(m_MaxWeight);
+            m_AveragePos = CalculateAveragePosition();
+            BoundingBox = CalculateBoundingBox();
+            m_BoundingSphere = CalculateBoundingSphere();
 
             switch (PositionMode)
             {
@@ -376,47 +376,48 @@ namespace Unity.Cinemachine
 
         void UpdateMemberValidity()
         {
+            Targets ??= new (); // in case user set it to null
             var count = Targets.Count;
             m_ValidMembers.Clear();
             m_ValidMembers.Capacity = Mathf.Max(m_ValidMembers.Capacity, count);
             m_MemberValidity.Clear();
             m_MemberValidity.Capacity = Mathf.Max(m_MemberValidity.Capacity, count);
+            m_WeightSum = m_MaxWeight = 0;
             for (int i = 0; i < count; ++i)
             {
                 m_MemberValidity.Add(Targets[i].Object != null 
                         && Targets[i].Weight > UnityVectorExtensions.Epsilon 
                         && Targets[i].Object.gameObject.activeInHierarchy);
                 if (m_MemberValidity[i])
+                {
                     m_ValidMembers.Add(i);
+                    m_MaxWeight = Mathf.Max(m_MaxWeight, Targets[i].Weight);
+                    m_WeightSum += Targets[i].Weight;
+                }
             }
         }
 
         // Assumes that UpdateMemberValidity() has been called
-        Vector3 CalculateAveragePosition(out float maxWeight)
+        Vector3 CalculateAveragePosition()
         {
+            if (m_WeightSum < UnityVectorExtensions.Epsilon)
+                return transform.position;
+
             var pos = Vector3.zero;
-            float weightSum = 0;
-            maxWeight = 0;
             var count = m_ValidMembers.Count;
             for (int i = 0; i < count; ++i)
             {
                 var targetIndex = m_ValidMembers[i];
                 var weight = Targets[targetIndex].Weight;
-                weightSum += weight;
                 pos += TargetPositionCache.GetTargetPosition(Targets[targetIndex].Object) * weight;
-                maxWeight = Mathf.Max(maxWeight, weight);
             }
-            if (weightSum > UnityVectorExtensions.Epsilon)
-                pos /= weightSum;
-            else
-                pos = transform.position;
-            return pos;
+            return pos / m_WeightSum;
         }
         
-        // Assumes that CalculateAveragePosition() has been called 
-        Bounds CalculateBoundingBox(float maxWeight)
+        // Assumes that UpdateMemberValidity() has been called 
+        Bounds CalculateBoundingBox()
         {
-            if (maxWeight < UnityVectorExtensions.Epsilon)
+            if (m_MaxWeight < UnityVectorExtensions.Epsilon)
                 return m_BoundingBox;
             var b = new Bounds(m_AveragePos, Vector3.zero);
             var count = m_ValidMembers.Count;
@@ -430,20 +431,20 @@ namespace Unity.Cinemachine
         
         /// <summary>
         /// Use Ritter's algorithm for calculating an approximate bounding sphere.
-        /// Assumes that CalculateBoundingBox() has been called.
+        /// Assumes that UpdateMemberValidity() has been called.
         /// </summary>
         /// <param name="maxWeight">The maximum weight of members in the group</param>
         /// <returns>An approximate bounding sphere.  Will be slightly large.</returns>
-        BoundingSphere CalculateBoundingSphere(float maxWeight)
+        BoundingSphere CalculateBoundingSphere()
         {
             var count = m_ValidMembers.Count;
-            if (count == 0 || maxWeight < UnityVectorExtensions.Epsilon)
+            if (count == 0 || m_MaxWeight < UnityVectorExtensions.Epsilon)
                 return m_BoundingSphere;
 
-            var sphere = WeightedMemberBoundsForValidMember(Targets[m_ValidMembers[0]], m_AveragePos, maxWeight);
+            var sphere = WeightedMemberBoundsForValidMember(Targets[m_ValidMembers[0]], m_AveragePos, m_MaxWeight);
             for (int i = 1; i < count; ++i)
             {
-                var s = WeightedMemberBoundsForValidMember(Targets[m_ValidMembers[i]], m_AveragePos, maxWeight);
+                var s = WeightedMemberBoundsForValidMember(Targets[m_ValidMembers[i]], m_AveragePos, m_MaxWeight);
                 var distance = (s.position - sphere.position).magnitude + s.radius;
                 if (distance > sphere.radius)
                 {
@@ -455,24 +456,26 @@ namespace Unity.Cinemachine
             return sphere;
         }
 
-        // Assumes that CalculateBoundingSphere() has been called
+        // Assumes that UpdateMemberValidity() has been called
         Quaternion CalculateAverageOrientation()
         {
-            if (m_MaxWeight <= UnityVectorExtensions.Epsilon)
-                return transform.rotation;
-            
-            float weightedAverage = 0;
-            var r = Quaternion.identity;
-            var count = m_ValidMembers.Count;
-            for (int i = 0; i < count; ++i)
+            if (m_WeightSum > 0.001f)
             {
-                var targetIndex = m_ValidMembers[i];
-                var scaledWeight = Targets[targetIndex].Weight / m_MaxWeight;
-                var rot = TargetPositionCache.GetTargetRotation(Targets[targetIndex].Object);
-                r *= Quaternion.Slerp(Quaternion.identity, rot, scaledWeight);
-                weightedAverage += scaledWeight;
+                var averageForward = Vector3.zero;
+                var averageUp = Vector3.zero;
+                var count = m_ValidMembers.Count;
+                for (int i = 0; i < count; ++i)
+                {
+                    var targetIndex = m_ValidMembers[i];
+                    var scaledWeight = m_Targets[targetIndex].Weight / m_WeightSum;
+                    var rot = TargetPositionCache.GetTargetRotation(Targets[targetIndex].Object);
+                    averageForward += rot * Vector3.forward * scaledWeight;
+                    averageUp += rot * Vector3.up * scaledWeight;
+                }
+                if (averageForward.sqrMagnitude > 0.0001f && averageUp.sqrMagnitude > 0.0001f)
+                    return Quaternion.LookRotation(averageForward, averageUp);
             }
-            return Quaternion.Slerp(Quaternion.identity, r, 1.0f / weightedAverage);
+            return transform.rotation;
         }
 
         void FixedUpdate()


### PR DESCRIPTION
### Purpose of this PR

CMCL-1585.  CM3 version of #983 
Use same test scene (upgrade it to CM3)

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
