### PR TITLE
CMCL-1586: SaveDuringPlay check for unloaded scenes CM3

### DIFF
--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -68,7 +68,8 @@ namespace Unity.Cinemachine.Editor
         {
             var allRoots = new List<GameObject>();
             for (int i = 0; i < SceneManager.sceneCount; ++i)
-                allRoots.AddRange(SceneManager.GetSceneAt(i).GetRootGameObjects());
+                if (SceneManager.GetSceneAt(i).isLoaded)
+                    allRoots.AddRange(SceneManager.GetSceneAt(i).GetRootGameObjects());
             return allRoots;
         }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1586: When there is an unloaded scene in the hierarchy, an error is thrown when exiting play mode.

details here: https://unity.slack.com/archives/C4P4KJR9A/p1715060122618279

Issue is present in CM2 and CM3.
This is CM3 version of #987 

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 
