### PR TITLE
CMCL-0000: Fix and uniformize BlendHint descriptions (user feedback)

### DIFF
--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -22,8 +22,12 @@ namespace Unity.Cinemachine
         [FormerlySerializedAs("m_LookAt")]
         public Transform LookAtTarget = null;
 
-        /// <summary>Hint for transitioning to and from this virtual camera</summary>
-        [Tooltip("Hint for transitioning to and from this virtual camera")]
+        /// <summary>Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although 
+        /// not all combinations make sense.  In the case of conflicting hints, Cinemachine will 
+        /// make an arbitrary choice.</summary>
+        [Tooltip("Hint for transitioning to and from this CinemachineCamera.  Hints can be combined, although "
+            + "not all combinations make sense.  In the case of conflicting hints, Cinemachine will "
+            + "make an arbitrary choice.")]
         [FormerlySerializedAs("m_PositionBlending")]
         [FormerlySerializedAs("m_BlendHint")]
         public CinemachineCore.BlendHints BlendHint = 0;

--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -78,8 +78,7 @@ namespace Unity.Cinemachine
         public Quaternion OrientationCorrection;
 
         /// <summary>
-        /// These hints can be or'ed together to influence how blending is done, and how state
-        /// is applied to the camera
+        /// Combine these hints to influence how blending is done, and how state is applied to the camera.
         /// </summary>
         public enum BlendHints
         {
@@ -110,8 +109,7 @@ namespace Unity.Cinemachine
         }
 
         /// <summary>
-        /// These hints can be or'ed together to influence how blending is done, and how state
-        /// is applied to the camera
+        /// Combine these hints to influence how blending is done, and how state is applied to the camera.
         /// </summary>
         public BlendHints BlendHint;
 

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -70,7 +70,9 @@ namespace Unity.Cinemachine
             Finalize
         };
 
-        /// <summary>Hint for transitioning to and from Cinemachine cameras</summary>
+        /// <summary>Hint for transitioning to and from CinemachineCameras.  Hints can be combined, although 
+        /// not all combinations make sense.  In the case of conflicting hints, Cinemachine will 
+        /// make an arbitrary choice.</summary>
         [Flags]
         public enum BlendHints
         {


### PR DESCRIPTION
### Purpose of this PR

- Fix BlendHint descriptions as per user feedback [DOCATT-4983](https://jira.unity3d.com/browse/DOCATT-4983).
- Uniformize at best the descriptions of other BlendHint items (found during investigation).

**Note:** I did the minimum at least to point out the affected lines in this PR:
- The descriptions for `CinemachineExternalCamera.cs` and `CinemachineCore.cs` come from `CinemachineCameras.cs` (also used in 2 other places), please tell me if it applies as is to these cases.
- I tried to fix at best the user's concern in the `CameraState.cs` descriptions but I think we can do better by giving a little bit more context similarly to the other descriptions mentioned above, if possible.

**Note 2:** Once it's fixed, I'd like to backport the same in latest 2.x version as the user gave the feedback in v.2.8.