### PR TITLE
Backport of DOCATT-4983 fix

### DIFF
--- a/com.unity.cinemachine/Runtime/Core/CameraState.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraState.cs
@@ -112,8 +112,7 @@ namespace Cinemachine
         }
 
         /// <summary>
-        /// These hints can be or'ed toether to influence how blending is done, and how state
-        /// is applied to the camera
+        /// Combine these hints to influence how blending is done, and how state is applied to the camera.
         /// </summary>
         public enum BlendHintValue
         {
@@ -138,8 +137,7 @@ namespace Cinemachine
         }
 
         /// <summary>
-        /// These hints can be or'ed toether to influence how blending is done, and how state
-        /// is applied to the camera
+        /// Combine these hints to influence how blending is done, and how state is applied to the camera.
         /// </summary>
         public BlendHintValue BlendHint;
 


### PR DESCRIPTION
### Purpose of this PR

Backporting fix: [DOCATT-4983](https://jira.unity3d.com/browse/DOCATT-4983) - BlendHint description fix.