### PR TITLE
CMCL-1548: always update vcam transform, even if no tracking target

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added CinemachineSplineSmoother for creating smooth splines suitable for camera paths.  This replicates the behaviour of CinemachineSmoothPath in CM2.
 - Added Easing option to CinemachineSplineRoll.
 
+### Changed
+- The presence of a tracking target no longer affects whether the CinemachineCamera state's position and rotation are pushed back to the transform.
+
 
 ## [3.1.1] - 2024-06-15
 

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -223,13 +223,7 @@ namespace Unity.Cinemachine
 
             // Push the raw position back to the game object's transform, so it
             // moves along with the camera.
-            var pos = transform.position;
-            var rot = transform.rotation;
-            if (Follow != null)
-                pos = m_State.RawPosition;
-            if (LookAt != null)
-                rot = m_State.RawOrientation;
-            transform.ConservativeSetPositionAndRotation(pos, rot);
+            transform.ConservativeSetPositionAndRotation(m_State.RawPosition, m_State.RawOrientation);
             
             // Signal that it's all done
             PreviousStateIsValid = true;


### PR DESCRIPTION
### Purpose of this PR

CMCL-1548: In the past, the CinemachineCamera's position and rotation were only pushed back to the transform if a tracking target was present.  This was to protect statically-positioned cameras from having their transforms changed by procedural extensions.

This limitation has been removed, as the relevant extensions will affect the corrected position/rotation in the state, not the raw position/rotation, and only the raw position/rotation is pushed back to the transform.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

