### PR TITLE
CMCL-1629: pantilt recentering was ignoring axis center setting

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.1.3] - 2025-12-31
 
 ### Bugfixes
+- Regression fix: CinemachinePanTilt recentering was ignoring axis Center setting.
 - CameraDeactivated events were not sent consistently when a blend interrupted another blend before completion.
 - CameraActivated events were not sent consistently when activation was due to timeline blends.
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePanTilt.cs
@@ -258,7 +258,7 @@ namespace Unity.Cinemachine
                 var v = Quaternion.FromToRotation(Vector3.forward, fwd).eulerAngles;
                 return new Vector2(NormalizeAngle(v.y), NormalizeAngle(v.x));
             }
-            return Vector2.zero;
+            return new Vector2(PanAxis.Center, TiltAxis.Center);
 
             static float NormalizeAngle(float angle) => ((angle + 180) % 360) - 180; 
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1629: PanTilt recentering was ignoring axis center setting.  Was using hardcoded (0, 0).

### Testing status

- [x] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

