### PR TITLE
CMCL-1360: framingtransposer dead zone drift cm2

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.10.4] - 2024-11-05
+- Bugfix: FramingTransposer with a dead zone would sometimes drift.
+
+
 ## [2.10.3] - 2024-11-05
 - Regression fix: Small changes to camera position and rotation were being filtered out.
 

--- a/com.unity.cinemachine/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineFramingTransposer.cs
@@ -606,7 +606,7 @@ namespace Cinemachine
                         realTargetPos - cameraOffset, hardGuideOrtho);
                 }
             }
-            curState.RawPosition = localToWorld * (cameraPos + cameraOffset);
+            curState.RawPosition = camPosWorld + localToWorld * cameraOffset;
             m_PreviousCameraPosition = curState.RawPosition;
             m_InheritingPosition = false;
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1630: FramingTransposer camera drift when nonzero dead zone.
Fix was to improve precision of calculation.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

