### PR TITLE
CMCL-1631: FramingTransposer with a dead zone would sometimes drift

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfixes
 - CameraDeactivated events were not sent consistently when a blend interrupted another blend before completion.
 - CameraActivated events were not sent consistently when activation was due to timeline blends.
+- Bugfix: FramingTransposer with a dead zone would sometimes drift.
 
 
 ## [3.1.2] - 2024-10-01

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
@@ -319,7 +319,7 @@ namespace Unity.Cinemachine
                         realTargetPos - cameraOffset, hardGuideOrtho);
                 }
             }
-            curState.RawPosition = localToWorld * (cameraPos + cameraOffset);
+            curState.RawPosition = camPosWorld + localToWorld * cameraOffset;
             m_PreviousCameraPosition = curState.RawPosition;
 
             m_InheritingPosition = false;

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFramingTransposer.cs
@@ -549,7 +549,7 @@ namespace Unity.Cinemachine
                         realTargetPos - cameraOffset, hardGuideOrtho);
                 }
             }
-            curState.RawPosition = localToWorld * (cameraPos + cameraOffset);
+            curState.RawPosition = camPosWorld + localToWorld * cameraOffset;
             m_PreviousCameraPosition = curState.RawPosition;
 
             // Adjust lens for group framing


### PR DESCRIPTION
### Purpose of this PR

CMCL-1361: FramingTransposer camera drift when nonzero dead zone.
Fix was to improve precision of calculation.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low