### PR TITLE
CMCL-1621: add isdelayed to near and far clip plane fields

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CameraDeactivated events were not sent consistently when a blend interrupted another blend before completion.
 - CameraActivated events were not sent consistently when activation was due to timeline blends.
 
+### Changed
+- Added delayed processing to near and far clip plane inspector fields for the CinemachineCamera lens.
+
 
 ## [3.1.2] - 2024-10-01
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -97,7 +97,9 @@ namespace Unity.Cinemachine.Editor
             var innerFovControl = foldout.AddChild(new FovPropertyControl(property, false));
 
             var nearClip = property.FindPropertyRelative(() => s_Def.NearClipPlane);
-            foldout.AddChild(new PropertyField(nearClip)).RegisterValueChangeCallback((evt) =>
+            var nearClipField = foldout.AddChild(new PropertyField(nearClip));
+            nearClipField.OnInitialGeometry(() => nearClipField.SafeSetIsDelayed());
+            nearClipField.RegisterValueChangeCallback((evt) =>
             {
                 if (!IsOrtho(property) && nearClip.floatValue < 0.01f)
                 {
@@ -105,7 +107,8 @@ namespace Unity.Cinemachine.Editor
                     property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
                 }
             });
-            foldout.Add(new PropertyField(property.FindPropertyRelative(() => s_Def.FarClipPlane)));
+            var farClipField = foldout.AddChild(new PropertyField(property.FindPropertyRelative(() => s_Def.FarClipPlane)));
+            farClipField.OnInitialGeometry(() => farClipField.SafeSetIsDelayed());
             foldout.Add(new PropertyField(property.FindPropertyRelative(() => s_Def.Dutch)));
 
             var physical = foldout.AddChild(new PropertyField(property.FindPropertyRelative(() => s_Def.PhysicalProperties)));


### PR DESCRIPTION
### Purpose of this PR

CMCL-1621: Added missing delayed processing on near and far clip plane fields of CM camera lens

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
