### PR TITLE
CMCL-0000: Fix documentation typos reported by users

### DIFF
--- a/com.unity.cinemachine/Documentation~/CinemachineEvents.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineEvents.md
@@ -1,8 +1,8 @@
 # Cinemachine Events
 
-Cinemachine will generate events whenever cameras are activated and deactivated, and also when blends are started and when they finish.  Furthermore, an event is generted when there is a camera cut - that is, when the active cinemachine camera changes without blending.
+Cinemachine generates events whenever cameras are activated and deactivated, and also when blends are started and when they finish.  Furthermore, an event is generated when there is a camera cut - that is, when the active Cinemachine Camera changes without blending.
 
-When Cinemachine sends an event, it is sent globally via CinemachineCore.  Scripts can add listeners to those events and take action based on them.  Listeners will receive events for all cameras.
+When Cinemachine sends an event, it is sent globally via CinemachineCore.  Scripts can add listeners to those events and take action based on them.  Listeners receive events for all cameras.
 
 Events are generated in every context that manages blends.  This includes the CinemachineBrain, which handles blends at the highest level, but it also applies to Cinemachine Manager Cameras, which thenselves manage blends between their child cameras.
 

--- a/com.unity.cinemachine/Documentation~/InputSystemComponents.md
+++ b/com.unity.cinemachine/Documentation~/InputSystemComponents.md
@@ -12,7 +12,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using Unity.Cinemachine;
 
-// This class receives input from a PlayerInput component and disptaches it
+// This class receives input from a PlayerInput component and dispatches it
 // to the appropriate Cinemachine InputAxis.  The playerInput component should
 // be on the same GameObject, or specified in the PlayerInput field.
 class CustomInputHandler : InputAxisControllerBase<CustomInputHandler.Reader>

--- a/com.unity.cinemachine/Documentation~/concept-camera-control-transitions.md
+++ b/com.unity.cinemachine/Documentation~/concept-camera-control-transitions.md
@@ -17,7 +17,7 @@ At any time, each Cinemachine Camera may be in one of three different states, bu
 The conditions that make a Cinemachine Camera the live one depend on the context in which you're using Cinemachine.  By default, the Cinemachine Brain is responsible for handling the live Cinemachine Camera selection.
 
 - The Brain chooses the active [Cinemachine Camera component](CinemachineCamera.md) with the highest Priority and makes it Live.
-- If multiple active CinemchineCameras share the same highest priority, then the ost recently [activated](https://docs.unity3d.com/Manual/DeactivatingGameObjects.html) of them will be chosen.
+- If multiple active CinemchineCameras share the same highest priority, then the most recently [activated](https://docs.unity3d.com/Manual/DeactivatingGameObjects.html) of them will be chosen.
 - Deactivated or lower-priority CinemachineCameras can be Live if they are part of a blend, until the blend is finished.
 - If a Timeline is active with Cinemachine tracks, it overrides the Brain's priority system and drives the Live cameras and blends explicitly, regardless of their Priority and active state.
 


### PR DESCRIPTION
### Purpose of this PR

Fixing small documentation issues reported by users:
- [x] [DOCATT-7227](https://jira.unity3d.com/browse/DOCATT-7227) - Typo in Cinemachine events page
- [x] [DOCATT-7337](https://jira.unity3d.com/browse/DOCATT-7337) - Typo in Camera control and transitions page
- [x] [DOCATT-7431](https://jira.unity3d.com/browse/DOCATT-7431) - Typo in code sample comment (input system)

