### PR TITLE
CMCL-1641: respect blend time when backing out of a heterogeneous blend

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Decollider would sometimes cause camera to slip inside cracks between adjacent colliders.
 - The Deoccluder failed to reset its state when initially enabled, and sometimes caused small spurious camera rotations.
 - Fixed the Radial Axis input axis in the CinemachineOrbitalFollow component to map to the y axis.
+- Desired blend time is respected when interrupting blends with heterogeneous blend-in and blend-out times.
 
 ### Changed
 - Added delayed processing to near and far clip plane inspector fields for the CinemachineCamera lens.


### PR DESCRIPTION
### Purpose of this PR

CMCL-1641: In cases where blend time A->B is not the same as B->A, interrupting a blend in will not always respect the desired blend time. 

Description here: https://discussions.unity.com/t/i-dont-understand-the-cinemachine-camera-blend-duration-behavior/1592488

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

