### PR TITLE
CMCL-1637: Don't auto-create vcams in scene when editing CinemachineShot in prefab mode

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.10.4] - 2025-02-06
 - Bugfix: FramingTransposer with a dead zone would sometimes drift.
+- Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.
 
 
 ## [2.10.3] - 2024-11-05

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotClipEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotClipEditor.cs
@@ -10,6 +10,7 @@ using Cinemachine;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Playables;
+using UnityEditor.SceneManagement;
 
 [CustomTimelineEditor(typeof(CinemachineShot))]
 public class CinemachineShotClipEditor : ClipEditor
@@ -70,15 +71,27 @@ public class CinemachineShotClipEditor : ClipEditor
     public override void OnCreate(TimelineClip clip, TrackAsset track, TimelineClip clonedFrom)
     {
         base.OnCreate(clip, track, clonedFrom);
+
         if (CinemachineShotEditor.AutoCreateShotFromSceneView)
         {
-            var asset = clip.asset as CinemachineShot;
-            var vcam = CinemachineShotEditor.CreatePassiveVcamFromSceneView();
-            var d = TimelineEditor.inspectedDirector;
-            if (d != null && d.GetReferenceValue(asset.VirtualCamera.exposedName, out bool idValid) == null)
+            var director = TimelineEditor.inspectedDirector;
+            if (director != null)
             {
-                asset.VirtualCamera.exposedName = System.Guid.NewGuid().ToString();
-                d.SetReferenceValue(asset.VirtualCamera.exposedName, vcam);
+                var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+                bool isPrefabOrInPrefabMode = (PrefabUtility.IsPartOfPrefabAsset(director) 
+                    || (prefabStage != null && prefabStage.IsPartOfPrefabContents(director.gameObject))
+                    && !PrefabUtility.IsPartOfPrefabInstance(director.gameObject));
+                if (!isPrefabOrInPrefabMode)
+                {
+                    var asset = clip.asset as CinemachineShot;
+                    var vcam = CinemachineShotEditor.CreatePassiveVcamFromSceneView();
+                    var d = TimelineEditor.inspectedDirector;
+                    if (d != null && d.GetReferenceValue(asset.VirtualCamera.exposedName, out bool idValid) == null)
+                    {
+                        asset.VirtualCamera.exposedName = System.Guid.NewGuid().ToString();
+                        d.SetReferenceValue(asset.VirtualCamera.exposedName, vcam);
+                    }
+                }
             }
         }
     }

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -9,6 +9,7 @@ using Cinemachine.Editor;
 using System.Collections.Generic;
 using UnityEditor.Timeline;
 using Cinemachine;
+using UnityEditor.SceneManagement;
 
 //namespace Cinemachine.Timeline
 //{
@@ -83,12 +84,27 @@ using Cinemachine;
         GUIContent m_ClearText = new GUIContent("Clear", "Clear the target position scrubbing cache");
 #endif
 
+        bool m_IsPrefabOrInPrefabMode;
+
         /// <summary>Get the property names to exclude in the inspector.</summary>
         /// <param name="excluded">Add the names to this list</param>
         protected override void GetExcludedPropertiesInInspector(List<string> excluded)
         {
             base.GetExcludedPropertiesInInspector(excluded);
             excluded.Add(FieldPath(x => x.VirtualCamera));
+        }
+
+        private void OnEnable()
+        {
+            var director = TimelineEditor.inspectedDirector;
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            m_IsPrefabOrInPrefabMode = director == null;
+            if (!m_IsPrefabOrInPrefabMode)
+            {
+                m_IsPrefabOrInPrefabMode = !PrefabUtility.IsPartOfPrefabInstance(director)
+                    && (PrefabUtility.IsPartOfPrefabAsset(director) 
+                        || (prefabStage != null && prefabStage.IsPartOfPrefabContents(director.gameObject)));
+            }
         }
 
         private void OnDisable()
@@ -132,9 +148,12 @@ using Cinemachine;
 #endif
 
             EditorGUILayout.Space();
-            CinemachineVirtualCameraBase vcam
-                = vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase;
-            if (vcam != null)
+
+            if (m_IsPrefabOrInPrefabMode)
+                EditorGUILayout.HelpBox("Only virtual cameras inside the prefab can be assigned.", MessageType.Info);
+
+            CinemachineVirtualCameraBase vcam = vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase;;
+            if (m_IsPrefabOrInPrefabMode || vcam != null)
                 EditorGUILayout.PropertyField(vcamProperty, kVirtualCameraLabel);
             else
             {

--- a/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
+++ b/com.unity.cinemachine/Editor/Timeline/CinemachineShotEditor.cs
@@ -150,7 +150,7 @@ using UnityEditor.SceneManagement;
             EditorGUILayout.Space();
 
             if (m_IsPrefabOrInPrefabMode)
-                EditorGUILayout.HelpBox("Only virtual cameras inside the prefab can be assigned.", MessageType.Info);
+                EditorGUILayout.HelpBox("Only virtual cameras inside the prefab can be assigned, and the Property must be Exposed.", MessageType.Info);
 
             CinemachineVirtualCameraBase vcam = vcamProperty.exposedReferenceValue as CinemachineVirtualCameraBase;;
             if (m_IsPrefabOrInPrefabMode || vcam != null)


### PR DESCRIPTION
### Purpose of this PR

CMCL-1637: UX on the CinemachineShot inside Timeline was exposing a button to create a vcam.  This operation is only valid in Scene mode, not in Prefab mode.  

UX was removed for prefab mode, and a clarifying helpbox was added.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
