### PR TITLE
CMCL-1636: better clarity for cinemachine shot ux when inside a prefab

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Unreleased
 
 ### Bugfixes
+
 ### Changed
+- Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.
+ 
 ### Added
 
 

--- a/com.unity.cinemachine/Editor/PropertyDrawers/HideIfNoComponentPropertyDrawer.cs
+++ b/com.unity.cinemachine/Editor/PropertyDrawers/HideIfNoComponentPropertyDrawer.cs
@@ -15,6 +15,8 @@ namespace Unity.Cinemachine.Editor
             var ux = new PropertyField(property);
             ux.TrackAnyUserActivity(() =>
             {
+                if (property.serializedObject == null)
+                    return;
                 bool hasComponent = false;
                 var targets = property.serializedObject.targetObjects;
                 for (int i = 0; !hasComponent && i < targets.Length; ++i)


### PR DESCRIPTION
### Purpose of this PR

CMCL-1636: UX on the CinemachineShot inside Timeline was exposing a button to create a vcam.  This operation is only valid in Scene mode, not in Prefab mode.  

UX was removed for prefab mode, and a clarifying helpbox was added.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
