### PR TITLE
CMCL-1644: Fix deoccluder state and damping issues

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Unreleased
 
 ### Bugfixes
+- Deoccluder did not always properly reset its state.
 
 ### Changed
 - Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.

--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraEditor.cs
@@ -60,9 +60,11 @@ namespace Unity.Cinemachine.Editor
             {
                 if (Target == null)
                     return; // object deleted
-                var brain = CinemachineCore.FindPotentialTargetBrain(Target);
-                var deltaTime = Application.isPlaying ? Time.deltaTime : -1;
-                Target.InternalUpdateCameraState(brain == null ? Vector3.up : brain.DefaultWorldUp, deltaTime);
+                if (!Application.isPlaying)
+                {
+                    var brain = CinemachineCore.FindPotentialTargetBrain(Target);
+                    Target.InternalUpdateCameraState(brain == null ? Vector3.up : brain.DefaultWorldUp, -1);
+                }
                 bool haveDefault = Target.Target.TrackingTarget != Target.Follow;
                 defaultTargetRow.SetVisible(haveDefault);
                 if (haveDefault)


### PR DESCRIPTION
### Purpose of this PR

CMCL-1644: camera glitches sometimes:
 - when there is a deoccluder with nonzero smoothing and the camera is newly enabled, there are times when it's smoothing out of a ghost position (see repro project in discussion thread)
 - when there is a deoccluder with nonzero smoothing and damping, sometimes the camera will ignore the damping and pop when the occlusion is resolved


### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
