### PR TITLE
CMCL-1647: Extensions dropdown in CinemachineCamera inspector did not work consistently

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfixes
 - Deoccluder did not always properly reset its state.
+- Mac only: Extensions dropdown in CinemachineCamera inspector did not work consistently.
 
 ### Changed
 - Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.

--- a/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/CmCameraInspectorUtility.cs
@@ -286,6 +286,7 @@ namespace Unity.Cinemachine.Editor
                     unityTextAlign = TextAnchor.MiddleLeft
                 }
             });
+            button.clickable = null;
             menu.activators.Clear();
             menu.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
             button.AddManipulator(menu);


### PR DESCRIPTION
### Purpose of this PR

Workaround for UITK bug: extensions dropdown did not work on mac.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
