### PR TITLE
CMCL-1654: freelook improvements

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfixes
 - Deoccluder did not always properly reset its state.
 - Mac only: Extensions dropdown in CinemachineCamera inspector did not work consistently.
-- Regresion fix: Confiner2D was not always confining when a camera was newly activated.
+- Regression fix: Confiner2D was not always confining when a camera was newly activated.
+- The RotationComposer no longer damps in response to composition changes from the FreeLookModifier.
+- The game-view composer guides dynamically reflect the current composition when a FreeLookModifier is changing it.
 
 ### Changed
 - Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.
+- When a FreeLookModifier is enabled for composition, the game-view composer guides are not draggable.
  
 ### Added
 

--- a/com.unity.cinemachine/Documentation~/CinemachineFreeLookModifier.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineFreeLookModifier.md
@@ -14,4 +14,8 @@ As an example, if the CinemachineCamera has a lens FOV of 60, and you add a lens
 
 ![Free Look Modifier Inspector Lens](images/FreeLookModifierInspectorLens.png)
 
-**Note:** When the FreeLook Modifier is modifying the Composition, the Game View guides will show the dynamic result of the modified composition.  In this situation, the Game View guides will not be draggable on-screen.  The inspector will have to be used to set the top, center, and bottom values.
+> [!TIP] 
+> When the FreeLook Modifier is modifying the Composition, the Game View guides will show the dynamic result of the modified composition.  In this situation, the Game View guides will not be draggable on-screen.  The inspector will have to be used to set the top, center, and bottom values.
+
+> [!TIP] 
+> SaveDuringPlay will track changes to properties of the existing items in the Modifiers list.  However, if you add or remove modifiers while in play mode, those changes will not be tracked by SaveDuringPlay.

--- a/com.unity.cinemachine/Documentation~/CinemachineFreeLookModifier.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineFreeLookModifier.md
@@ -4,7 +4,7 @@ This component is intended to be added to a CinemachineCamera set up as a [FreeL
 
 It allows you to vary some settings (for instance lens, noise, damping, composition, or camera distance) depending on whether the camera is at the top, middle, or bottom of its defined orbit. By default, the camera settings remain constant over the entire orbit. With the FreeLook  Modifier, you can change that.
 
-The behavior holds a list of setting modifiers, and you can add any of the available ones. You can also create your own modifiers which will automatically get added to the list.
+The behavior holds a list of setting modifiers, and you can add any of the available ones. You can also create your own modifiers which will automatically get added to the selection list.
 
 ![Free Look Modifier Inspector](images/FreeLookModifierInspector.png)
 
@@ -14,3 +14,4 @@ As an example, if the CinemachineCamera has a lens FOV of 60, and you add a lens
 
 ![Free Look Modifier Inspector Lens](images/FreeLookModifierInspectorLens.png)
 
+**Note:** When the FreeLook Modifier is modifying the Composition, the Game View guides will show the dynamic result of the modified composition.  In this situation, the Game View guides will not be draggable on-screen.  The inspector will have to be used to set the top, center, and bottom values.

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using Unity.Cinemachine.Editor;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
-using UnityEngine;
 
 namespace Unity.Cinemachine
 {
@@ -23,9 +22,6 @@ namespace Unity.Cinemachine
                 + "of the camera's vertical orbit.",
                 HelpBoxMessageType.Info));
 
-            var noSaveDuringPlayMsg = ux.AddChild(new HelpBox("SaveDuringPlay will not save changes to this component.",
-                HelpBoxMessageType.Info));
-
             var invalidSrcMsg = ux.AddChild(
                 new HelpBox("<b>Component will be ignored because no modifiable targets are present.</b>\n\n"
                     + "Modifiable target components include: "
@@ -37,7 +33,7 @@ namespace Unity.Cinemachine
             ux.Add(new Label(controllersProperty.displayName) { tooltip = controllersProperty.tooltip });
             var list = ux.AddChild(new ListView()
             {
-                reorderable = true,
+                reorderable = false,
                 showAddRemoveFooter = true,
                 showBorder = true,
                 showBoundCollectionSize = false,
@@ -85,7 +81,6 @@ namespace Unity.Cinemachine
                 var hasModifiers = Target.Modifiers.Count > 0;
                 invalidSrcMsg.SetVisible(!hasModifiableSource);
                 instructionsMsg.SetVisible(hasModifiableSource && !hasModifiers);
-                noSaveDuringPlayMsg.SetVisible(Application.isPlaying && SaveDuringPlay.Enabled && hasModifiers);
             });
 
             return ux;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineFreeLookModifierEditor.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Unity.Cinemachine.Editor;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
+using UnityEngine;
 
 namespace Unity.Cinemachine
 {
@@ -17,9 +18,12 @@ namespace Unity.Cinemachine
         {
             var ux = new VisualElement();
 
-            ux.Add(new HelpBox("This component is optional and can be removed if you don't need it.  "
+            var instructionsMsg = ux.AddChild(new HelpBox("This component is optional and can be removed if you don't need it.  "
                 + "The modifiers you add will override settings for the top and bottom portions "
                 + "of the camera's vertical orbit.",
+                HelpBoxMessageType.Info));
+
+            var noSaveDuringPlayMsg = ux.AddChild(new HelpBox("SaveDuringPlay will not save changes to this component.",
                 HelpBoxMessageType.Info));
 
             var invalidSrcMsg = ux.AddChild(
@@ -73,7 +77,16 @@ namespace Unity.Cinemachine
             button.AddManipulator(manipulator);
             button.clickable = null;
 
-            ux.TrackAnyUserActivity(() => invalidSrcMsg.SetVisible(Target != null && !Target.HasValueSource()));
+            ux.TrackAnyUserActivity(() => 
+            {
+                if (Target == null)
+                    return;
+                var hasModifiableSource = Target.HasValueSource();
+                var hasModifiers = Target.Modifiers.Count > 0;
+                invalidSrcMsg.SetVisible(!hasModifiableSource);
+                instructionsMsg.SetVisible(hasModifiableSource && !hasModifiers);
+                noSaveDuringPlayMsg.SetVisible(Application.isPlaying && SaveDuringPlay.Enabled && hasModifiers);
+            });
 
             return ux;
         }

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePositionComposerEditor.cs
@@ -14,9 +14,19 @@ namespace Unity.Cinemachine.Editor
 
         protected virtual void OnEnable()
         {
-            m_GameViewGuides.GetComposition = () => Target.Composition;
-            m_GameViewGuides.SetComposition = (s) => Target.Composition = s;
+            m_GameViewGuides.GetComposition = () => Target.GetEffectiveComposition;
+            m_GameViewGuides.SetComposition = (s) => 
+            {
+                if (m_GameViewGuides.IsDraggable()) 
+                    Target.Composition = s;
+            };
             m_GameViewGuides.Target = () => serializedObject;
+            m_GameViewGuides.IsDraggable = () => 
+            {
+                return Target.GetEffectiveComposition.ScreenPosition == Target.Composition.ScreenPosition
+                    && Target.GetEffectiveComposition.DeadZoneRect == Target.Composition.DeadZoneRect
+                    && Target.GetEffectiveComposition.HardLimitsRect == Target.Composition.HardLimitsRect;
+            };
             m_GameViewGuides.OnEnable();
 
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;

--- a/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineRotationComposerEditor.cs
@@ -14,9 +14,19 @@ namespace Unity.Cinemachine.Editor
 
         protected virtual void OnEnable()
         {
-            m_GameViewGuides.GetComposition = () => Target.Composition;
-            m_GameViewGuides.SetComposition = (s) => Target.Composition = s;
+            m_GameViewGuides.GetComposition = () => Target.GetEffectiveComposition;
+            m_GameViewGuides.SetComposition = (s) => 
+            {
+                if (m_GameViewGuides.IsDraggable()) 
+                    Target.Composition = s;
+            };
             m_GameViewGuides.Target = () => serializedObject;
+            m_GameViewGuides.IsDraggable = () => 
+            {
+                return Target.GetEffectiveComposition.ScreenPosition == Target.Composition.ScreenPosition
+                    && Target.GetEffectiveComposition.DeadZoneRect == Target.Composition.DeadZoneRect
+                    && Target.GetEffectiveComposition.HardLimitsRect == Target.Composition.HardLimitsRect;
+            };
             m_GameViewGuides.OnEnable();
 
             CinemachineDebug.OnGUIHandlers -= OnGuiHandler;

--- a/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
+++ b/com.unity.cinemachine/Editor/SaveDuringPlay/SaveDuringPlay.cs
@@ -193,8 +193,16 @@ namespace Unity.Cinemachine.Editor
                         var currentLength = list.Count;
                         for (int i = 0; i < currentLength - newLength; ++i)
                             list.RemoveAt(currentLength - i - 1); // make list shorter if needed
-                        for (int i = 0;  i < newLength - currentLength; ++i)
-                            list.Add(GetValue(type.GetGenericArguments()[0])); // make list longer if needed
+
+                        // Can only grow non-serializereference lists
+                        var elementType = type.GetGenericArguments()[0];
+                        var attributes = elementType.GetCustomAttributes(typeof(SerializeReference), true);
+                        if (attributes == null || attributes.Length == 0)
+                        {
+                            if (elementType.GetCustomAttributes(typeof(SerializeReference), true) == null)
+                            for (int i = 0;  i < newLength - currentLength; ++i)
+                                list.Add(GetValue(type.GetGenericArguments()[0])); // make list longer if needed
+                        }
                         doneSomething = true;
                     }
 

--- a/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
+++ b/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
@@ -22,12 +22,18 @@ namespace Unity.Cinemachine.Editor
         /// <returns>The target object whose guides are being drawn</returns>
         public delegate SerializedObject ObjectGetter();
 
+        /// <summary>Delegete to test if the guides can be dragged</summary>
+        /// <returns>True if the guides can be dragged</returns>
+        public delegate bool BoolGetter();
+
         /// <summary>Get the Composition settings.  Client must implement this</summary>
         public CompositionGetter GetComposition;
         /// <summary>Get the Composition settings.  Client must implement this</summary>
         public CompositionSetter SetComposition;
         /// <summary>Get the target object whose guides are being drawn.  Client must implement this</summary>
         public ObjectGetter Target;
+        /// <summary>Delegete to test if the guides can be dragged</summary>
+        public BoolGetter IsDraggable = () => CinemachineCorePrefs.DraggableComposerGuides.Value;
 
         // This is necessary because we don't get mouse events in the game view in Edit mode.
         // We need to trigger repaint when the mouse moves over the window.
@@ -228,7 +234,7 @@ namespace Unity.Cinemachine.Editor
             m_DragBars[(int)DragBar.Center] = ClipToCamera(new Rect(dead.xMin, dead.yMin, dead.xMax - dead.xMin, dead.yMax - dead.yMin));
 
             // Handle dragging bars
-            if (CinemachineCorePrefs.DraggableComposerGuides.Value && isLive)
+            if (IsDraggable() && isLive)
                 OnGuiHandleBarDragging(cameraRect.width, cameraRect.height, ref composition);
 
             // Draw the masks

--- a/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
+++ b/com.unity.cinemachine/Editor/Utility/GameViewComposerGuides.cs
@@ -22,8 +22,7 @@ namespace Unity.Cinemachine.Editor
         /// <returns>The target object whose guides are being drawn</returns>
         public delegate SerializedObject ObjectGetter();
 
-        /// <summary>Delegete to test if the guides can be dragged</summary>
-        /// <returns>True if the guides can be dragged</returns>
+        /// <summary>Delegete to get a bool value</summary>
         public delegate bool BoolGetter();
 
         /// <summary>Get the Composition settings.  Client must implement this</summary>

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
@@ -9,6 +9,7 @@ namespace Unity.Cinemachine
     /// It modifies the camera distance as a function of vertical angle.
     /// </summary>
     [AddComponentMenu("Cinemachine/Procedural/Extensions/Cinemachine FreeLook Modifier")]
+    [SaveDuringPlay]
     [ExecuteAlways]
     [DisallowMultipleComponent]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineFreeLookModifier.html")]

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineFreeLookModifier.cs
@@ -8,8 +8,7 @@ namespace Unity.Cinemachine
     /// This is an add-on for CinemachineCameras containing the OrbitalFollow component.
     /// It modifies the camera distance as a function of vertical angle.
     /// </summary>
-    [SaveDuringPlay]
-    [AddComponentMenu("Cinemachine/Procedural/Extensions/Cinemachine FreeLook Modifier")] // Hide in menu
+    [AddComponentMenu("Cinemachine/Procedural/Extensions/Cinemachine FreeLook Modifier")]
     [ExecuteAlways]
     [DisallowMultipleComponent]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineFreeLookModifier.html")]
@@ -577,7 +576,7 @@ namespace Unity.Cinemachine
         /// These will modify settings as a function of the FreeLook's Vertical axis value.
         /// </summary>
         [Tooltip("These will modify settings as a function of the FreeLook's Vertical axis value")]
-        [SerializeReference] [NoSaveDuringPlay] public List<Modifier> Modifiers = new ();
+        [SerializeReference] public List<Modifier> Modifiers = new ();
 
         IModifierValueSource m_ValueSource;
         float m_CurrentValue;

--- a/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachinePositionComposer.cs
@@ -81,12 +81,16 @@ namespace Unity.Cinemachine
         [FoldoutWithEnabledButton]
         public LookaheadSettings Lookahead;
 
+        /// <summary>Internal API for inspector</summary>
+        internal ScreenComposerSettings GetEffectiveComposition => m_CompositionLastFrame;
+
         const float kMinimumCameraDistance = 0.01f;
 
         /// <summary>State information for damping</summary>
         Vector3 m_PreviousCameraPosition = Vector3.zero;
         internal PositionPredictor m_Predictor = new PositionPredictor(); // internal for tests
         Quaternion m_prevRotation;
+        ScreenComposerSettings m_CompositionLastFrame;
 
         bool m_InheritingPosition;
 
@@ -321,6 +325,7 @@ namespace Unity.Cinemachine
             }
             curState.RawPosition = camPosWorld + localToWorld * cameraOffset;
             m_PreviousCameraPosition = curState.RawPosition;
+            m_CompositionLastFrame = Composition;
 
             m_InheritingPosition = false;
         }

--- a/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
+++ b/com.unity.cinemachine/Runtime/Core/UnityVectorExtensions.cs
@@ -382,7 +382,7 @@ namespace Unity.Cinemachine
         /// <param name="lookAtDir">The world-space target direction in which we want to look</param>
         /// <param name="worldUp">Which way is up.  Must have a length of 1.</param>
         /// <returns>Vector2.y is rotation about worldUp, and Vector2.x is second rotation,
-        /// about local right.</returns>
+        /// about local right.  Angles are in degrees.</returns>
         public static Vector2 GetCameraRotationToTarget(
             this Quaternion orient, Vector3 lookAtDir, Vector3 worldUp)
         {
@@ -421,7 +421,7 @@ namespace Unity.Cinemachine
         /// </summary>
         /// <param name="orient">The quaternion to which to apply the rotation.</param>
         /// <param name="rot">Vector2.y is rotation about worldUp, and Vector2.x is second rotation,
-        /// about local right.</param>
+        /// about local right.  Angles are in degrees.</param>
         /// <param name="worldUp">Which way is up</param>
         /// <returns>Result rotation after the input is applied to the input quaternion</returns>
         public static Quaternion ApplyCameraRotation(


### PR DESCRIPTION
### Purpose of this PR

CMCL-1654: When the FreeLookModifier modifies the screen composition, the RotationComposer applies damping to the change, producing a sluggish effect:

![broken](https://github.com/user-attachments/assets/69a1afe0-e5dd-4763-93dd-e97e32e66746)

The desired behaviour is to bypass damping for this change, giving an undamped direct response.  The current behaviour is a regression compared to CM 2.X, which behaved as desired.

This PR addresses this problem, and others:
- RotationComposer damping is bypassed for changes to the ScreenPosition parameter, whether via inspector or FreeLookModifier
- RotationComposer code was optimized for performance.  The UpdateCache method was improved so that it does less work.
- When a FreeLookModifier is actively modifying the composition, the GameView composer guides now show the modified composition instead of misleadingly showing the center value.
- When a FreeLookModifier is actively modifying the composition, the GameView composer guides are no longer draggable since they are displaying the blended result.  Top/center/bottom values have to be set via the inspector.
- FreeLookModifier now supports SaveDuringPlay for tweaks to existing item properties.

The fixed version (there is still a small amount of damping, but it's acceptable):

![fixed](https://github.com/user-attachments/assets/b9ebf9dd-ca44-4f3f-9eef-0ae01ecf3f83)


### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low
