### PR TITLE
CMCL-1657: CinemachineDeoccluder damping interferes with FreeLook

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfixes
 - Deoccluder did not always properly reset its state.
-- Deoccluder was introducing spurious damping when the FreeLook orbit size changed.
+- Deoccluder and Decollider were introducing spurious damping when the FreeLook orbit size changed.
 - Mac only: Extensions dropdown in CinemachineCamera inspector did not work consistently.
 - Regression fix: Confiner2D was not always confining when a camera was newly activated.
 - The RotationComposer no longer damps in response to composition changes from the FreeLookModifier.

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfixes
 - Deoccluder did not always properly reset its state.
+- Deoccluder was introducing spurious damping when the FreeLook orbit size changed.
 - Mac only: Extensions dropdown in CinemachineCamera inspector did not work consistently.
 - Regression fix: Confiner2D was not always confining when a camera was newly activated.
 - The RotationComposer no longer damps in response to composition changes from the FreeLookModifier.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -468,7 +468,14 @@ namespace Unity.Cinemachine
                                 var newOffset = initialCamPos + displacement - resolutionTargetPoint;
                                 var newOffsetMag = newOffset.magnitude;
                                 var newOffsetDir = newOffset / newOffsetMag;
+
+                                // Avoid introducing spurious damping when the camera changed position relative to the target.
+                                // We calculate the previous offset from target in two ways, and take the one that's closest
+                                // to the current desired offset.
                                 var prevOffsetMag = extra.PreviousCameraOffset.magnitude;
+                                var prevOffsetMag2 = (initialCamPos - resolutionTargetPoint).magnitude - Mathf.Sqrt(prevDispMag);
+                                if (Mathf.Abs(newOffsetMag - prevOffsetMag2) < Mathf.Abs(newOffsetMag - prevOffsetMag))
+                                    prevOffsetMag = prevOffsetMag2;
 
                                 newOffsetMag = prevOffsetMag + Damper.Damp(newOffsetMag - prevOffsetMag, dampTime, deltaTime);
                                 newCamPos = resolutionTargetPoint + newOffsetDir * newOffsetMag;

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineDeoccluder.cs
@@ -459,7 +459,7 @@ namespace Unity.Cinemachine
                         {
                             dampTime = dispMag > prevDispMag ? AvoidObstacles.DampingWhenOccluded : AvoidObstacles.Damping;
 
-                            // To ease the transition between damped and undamped regions, we damp the damp time
+                            // To ease the transition between damped and undamped regions, we damp the damp time!
                             if (dispMag < Epsilon && dampTime < extra.PreviousDampTime)
                                 dampTime = extra.PreviousDampTime + Damper.Damp(dampTime - extra.PreviousDampTime, dampTime, deltaTime);
 
@@ -484,6 +484,9 @@ namespace Unity.Cinemachine
                             else
                             {
                                 var prevDisp = resolutionTargetPoint + dampingBypass * extra.PreviousCameraOffset - initialCamPos;
+                                if (prevDisp.sqrMagnitude > prevDispMag)
+                                    prevDisp = extra.PreviousDisplacement;
+
                                 displacement = prevDisp + Damper.Damp(displacement - prevDisp, dampTime, deltaTime);
                             }
                         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1657:
This fixes an artifact introduced by a recent change to the Deoccluder damping algorithm.

Open the FreeLook Deoccluder sample scene.
Put a large Damping value on the deoccluder (e.g.3)
Make the top orbit very high, so that the camera is far away compared to the other orbits
Play the scene.
Move the character cloase enough to a wall while looking horizontally to make the camera deocclude.
Rotate on X axis to eliminate the occlusion (camera begins to damp back to position)
Now, go to top orbit.  We expect to get there quickly (because it's a user-triggered action) but damping makes it happen slowly.


### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

