### PR TITLE
CMCL-1668: mac dropdowns and popups not behaving consistently

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfixes
 - Deoccluder did not always properly reset its state.
 - Deoccluder and Decollider were introducing spurious damping when the FreeLook orbit size changed.
-- Mac only: Extensions dropdown in CinemachineCamera inspector did not work consistently.
+- Mac only: Some dropdowns and popups in Cinemachine inspectors did not work consistently.
 - Regression fix: Confiner2D was not always confining when a camera was newly activated.
 - The RotationComposer no longer damps in response to composition changes from the FreeLookModifier.
 - The game-view composer guides dynamically reflect the current composition when a FreeLookModifier is changing it.

--- a/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/InspectorUtility.cs
@@ -375,6 +375,7 @@ namespace Unity.Cinemachine.Editor
                 contextMenu.activators.Clear();
                 contextMenu.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
                 button.AddManipulator(contextMenu);
+                button.clickable = null;
             }
             return button;
         }
@@ -396,6 +397,7 @@ namespace Unity.Cinemachine.Editor
                 contextMenu.activators.Clear();
                 contextMenu.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
                 button.AddManipulator(contextMenu);
+                button.clickable = null;
             }
             return button;
         }
@@ -616,6 +618,7 @@ namespace Unity.Cinemachine.Editor
                 contextMenu.activators.Clear();
                 contextMenu.activators.Add(new ManipulatorActivationFilter { button = MouseButton.LeftMouse });
                 button.AddManipulator(contextMenu);
+                button.clickable = null;
             }
             return box;
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1668: Mac only (works on windows): dropdowns and popups in Cinemachine inspectors were flaky.  This is the same issue as a previous fix for the CinemachineExtensions dropdown, but in another area of the code.

Repro steps in the ticket.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

none whatsoever
