### PR TITLE
CMCL-1670: post process blend control for cm2

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [2.10.4] - 2025-02-06
-- Bugfix: FramingTransposer with a dead zone would sometimes drift.
-- Cinemachine Shot Editor longer provides UX to create cameras when editing a prefab.
+## [2.10.4] - 2025-12-31
 
+### Unreleased
+
+- Bugfix: FramingTransposer with a dead zone would sometimes drift.
+- Cinemachine Shot Editor no longer displays UX to create cameras when editing a prefab.
+- Added CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS scripting define to tune the PostProcessing blend behaviour.
 
 ## [2.10.3] - 2024-11-05
 - Regression fix: Small changes to camera position and rotation were being filtered out.

--- a/com.unity.cinemachine/Documentation~/CinemachinePostProcessing.md
+++ b/com.unity.cinemachine/Documentation~/CinemachinePostProcessing.md
@@ -26,7 +26,7 @@ To add a Post Process profile to a Virtual Camera
 
 
 > [!NOTE]
-> In some cases, particularly when blending to and from empty profiles, it's possible to get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles: add effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this will have the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
+> In some cases, particularly when blending to and from empty profiles, you might get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles by adding effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this has the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
 
 
 ## Properties:

--- a/com.unity.cinemachine/Documentation~/CinemachinePostProcessing.md
+++ b/com.unity.cinemachine/Documentation~/CinemachinePostProcessing.md
@@ -24,6 +24,11 @@ To add a Post Process profile to a Virtual Camera
 
 5. In the [Inspector](https://docs.unity3d.com/Manual/UsingTheInspector.html), choose __Add Extension > CinemachinePostProcessing__, then configre the Profile asset to have the effects you want when this virtual camera is live.
 
+
+> [!NOTE]
+> In some cases, particularly when blending to and from empty profiles, it's possible to get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles: add effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this will have the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
+
+
 ## Properties:
 
 | **Property:** || **Function:** |

--- a/com.unity.cinemachine/Documentation~/CinemachineVolumeSettings.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineVolumeSettings.md
@@ -12,7 +12,7 @@ To add a Volume Settings profile to a Virtual Camera
 
 
 > [!NOTE]
-> In some cases, particularly when blending to and from empty profiles, it's possible to get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles: add effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this will have the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
+> In some cases, particularly when blending to and from empty profiles, you might get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles by adding effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this has the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
 
 ## Properties:
 

--- a/com.unity.cinemachine/Documentation~/CinemachineVolumeSettings.md
+++ b/com.unity.cinemachine/Documentation~/CinemachineVolumeSettings.md
@@ -10,6 +10,10 @@ To add a Volume Settings profile to a Virtual Camera
 
 2. In the [Inspector](https://docs.unity3d.com/Manual/UsingTheInspector.html), choose __Add Extension > CinemachineVolumeSettings__, then configure the Profile asset to have the effects you want when this virtual camera is live.
 
+
+> [!NOTE]
+> In some cases, particularly when blending to and from empty profiles, it's possible to get a sudden change or pop in the effects.  If this happens, the best solution is to avoid blending to and from empty profiles: add effects with default settings.  If this is not practical, then you can add `CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS` to your project's scripting defines.  However, this will have the side effect of making postprocessing blends more transparent in their center, possibly revealing global effects behind them.
+
 ## Properties:
 
 | **Property:** || **Function:** |

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -258,8 +258,8 @@ namespace Cinemachine.PostFX
                     v.weight = b.m_Weight;
                     ++numPPblendables;
                 }
-#if false // set this to true to force first weight to 1
-                // If more than one volume, then set the frst one's weight to 1
+#if !CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS
+                // If more than one volume, then set the first one's weight to 1 so that it's opaque
                 if (numPPblendables > 1)
                     firstVolume.weight = 1;
 #endif

--- a/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/com.unity.cinemachine/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -266,8 +266,8 @@ namespace Cinemachine.PostFX
                     v.weight = b.m_Weight;
                     ++numPPblendables;
                 }
-#if false // set this to true to force first weight to 1
-                // If more than one volume, then set the frst one's weight to 1
+#if !CINEMACHINE_TRANSPARENT_POST_PROCESSING_BLENDS
+                // If more than one volume, then set the first one's weight to 1 so that it's opaque
                 if (numPPblendables > 1)
                     firstVolume.weight = 1;
 #endif


### PR DESCRIPTION
### Purpose of this PR

This is the CM2 backport.

[CMCL-1670](https://jira.unity3d.com/browse/CMCL-1670): add ability for user to control the post-processing volume blend algorithm.

See discussions thread for repro project: https://discussions.unity.com/t/cinemachine-2-10-1-is-now-available/951450/8

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [x] Updated user documentation

### Technical risk

low

