### PR TITLE
CMCL-0000: Add inspector warning for brain update mode

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBrainEditor.cs
@@ -18,6 +18,10 @@ namespace Unity.Cinemachine.Editor
         {
             var ux = new VisualElement();
 
+            var brainModesWarning = ux.AddChild(new HelpBox("The <b>Fixed Update</b> setting of Blend Update Method is intended "
+                + "to be used only when the Update Method is also <b>Fixed Update</b>, to address specific blending issues.\n"
+                + "<b>Late Update</b> is usually the recommended setting.", HelpBoxMessageType.Warning));
+
             // Show the active camera and blend
             var row = ux.AddChild(new InspectorUtility.LeftRightRow());
             row.Left.Add(new Label("Live Camera")
@@ -42,6 +46,13 @@ namespace Unity.Cinemachine.Editor
                     return;
                 liveCamera.value = Target.ActiveVirtualCamera as CinemachineVirtualCameraBase;
                 liveBlend.value = Target.ActiveBlend != null ? Target.ActiveBlend.Description : string.Empty;
+            });
+            ux.TrackAnyUserActivity(() =>
+            {
+                if (target == null)
+                    return;
+                brainModesWarning.SetVisible(Target.BlendUpdateMethod == CinemachineBrain.BrainUpdateMethods.FixedUpdate
+                    && Target.UpdateMethod != CinemachineBrain.UpdateMethods.FixedUpdate);
             });
 
             return ux;


### PR DESCRIPTION
[Delete any line or section that does not apply]

### Purpose of this PR

Sometimes people improperly set the Brain's BlendUpdateMethod to FixedUpdate, because they don't know whet they're doing.  This warning should help.  It's visible only when the BlendUpdateMethod is set to FixedUpdate and the UpdateMethod is set to something other than FixedUpdate.

![image](https://github.com/user-attachments/assets/fced9af5-1f62-4721-a8e5-7789ba43a12a)

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

