### PR TITLE
CMCL-1673: embedded asset editor generates errors on maximize

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed sample asset selection at import depending on current render pipeline and input configuration.  You need to re-import the samples to fix any existing issues.
 - Confiner2D was behaving inconsistently for large sized bounding boxes due to precision issues.
 - StateDrivenCamera inspector was not populating the states in the instruction list correctly.
+- Maximizing an inspector which contained custom blends would generate console errors and cause the inspector to be unresponsive.
 
 ### Changed
 - Cinemachine Shot Editor for Timeline no longer displays improper UX to create cameras when editing a prefab.

--- a/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineBlenderSettingsEditor.cs
@@ -86,12 +86,12 @@ namespace Unity.Cinemachine.Editor
                     var container = new VisualElement { style = { flexDirection = FlexDirection.Row, flexGrow = 1 }};
                     var textField = container.AddChild(new TextField { bindingPath = bindingPath, isDelayed = true, style = { flexGrow = 1, flexBasis = 20 }});
 
-                    var warning = container.AddChild(InspectorUtility.MiniHelpIcon($"No in-scene camera matches this name"));
+                    var warning = container.AddChild(InspectorUtility.MiniHelpIcon($"No candidate camera matches this name"));
                     textField.RegisterValueChangedCallback((evt) => OnCameraUpdated());
                     onCamerasUpdated += OnCameraUpdated;
                     void OnCameraUpdated()
                     {
-                        warning.tooltip = $"No in-scene camera matches \"{textField.value}\"";
+                        warning.tooltip = $"No candidate camera matches \"{textField.value}\"";
                         warning.SetVisible(availableCameras.FindIndex(x => x == textField.value) < 0);
                     };
 

--- a/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
+++ b/com.unity.cinemachine/Editor/Utility/EmbeddedAssetEditorUtility.cs
@@ -71,9 +71,13 @@ namespace Unity.Cinemachine.Editor
                 HelpBoxMessageType.Info));
 
             EmbeddedEditorContext context = new ();
-            OnAssetChanged(property, context);
             ux.TrackPropertyValue(property, (p) => OnAssetChanged(p, context));
-            embeddedInspectorParent.RegisterCallback<DetachFromPanelEvent>((e) => DestroyEditor(context));
+
+            embeddedInspectorParent.RegisterCallback<AttachToPanelEvent>((e) => 
+            {
+                OnAssetChanged(property, context);
+                embeddedInspectorParent.RegisterCallback<DetachFromPanelEvent>((e) => DestroyEditor(context));
+            });
 
             return ux;
 
@@ -101,8 +105,7 @@ namespace Unity.Cinemachine.Editor
                         eContext.Inspector = embeddedInspectorParent.AddChild(new InspectorElement(eContext.Editor));
                 }
                 unassignedUx?.SetVisible(target == null);
-                if (assignedUx != null)
-                    assignedUx.SetVisible(target != null);
+                assignedUx?.SetVisible(target != null);
             }
 
             // Local function
@@ -112,6 +115,8 @@ namespace Unity.Cinemachine.Editor
                 {
                     Object.DestroyImmediate(eContext.Editor);
                     eContext.Editor = null;
+                    eContext.Inspector?.RemoveFromHierarchy();
+                    eContext.Inspector = null;
                 }
             }
         }


### PR DESCRIPTION
### Purpose of this PR

CMCL-1673: embedded asset editor generates errors on maximize.

Fix is to ensure that multiple AttachToPanel and DetachFromPanel event cycles are handled.  Code was assuming that it would only happen once.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
