### PR TITLE
CMCL-1699: Don't force-update camera state from editor if target is not enabled

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachineCameraEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachineCameraEditor.cs
@@ -60,7 +60,7 @@ namespace Unity.Cinemachine.Editor
             {
                 if (Target == null)
                     return; // object deleted
-                if (!Application.isPlaying)
+                if (!Application.isPlaying && (Target.isActiveAndEnabled || Target.IsLive))
                 {
                     var brain = CinemachineCore.FindPotentialTargetBrain(Target);
                     Target.InternalUpdateCameraState(brain == null ? Vector3.up : brain.DefaultWorldUp, -1);


### PR DESCRIPTION
### Purpose of this PR

CMCL-1699: CinemachineCamera editor was updating the camera state too aggressively: don't do it when the target is disabled

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

