### PR TITLE
CMCL-1704: InheritPosition was not inheriting the camera position in all cases

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2025-012-31
+### Unreleased
+
+### Bugfixes
+- InheritPosition was not inheriting the camera position in all cases.
+
+
 ## [3.1.4] - 2025-06-10
 
 ### Bugfixes

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineCamera.cs
@@ -137,8 +137,6 @@ namespace Unity.Cinemachine
         /// <param name="rot">World-space orientation to take</param>
         public override void ForceCameraPosition(Vector3 pos, Quaternion rot)
         {
-            PreviousStateIsValid = false;
-
             UpdatePipelineCache();
             for (int i = 0; i < m_Pipeline.Length; ++i)
                 if (m_Pipeline[i] != null)

--- a/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -677,6 +677,7 @@ namespace Unity.Cinemachine
             }
             if (ParentCamera is CinemachineVirtualCameraBase vcamParent)
                 vcamParent.ForceCameraPosition(vcam, pos, rot);
+            PreviousStateIsValid = true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1704: InheritPosition was working for the commonly-used cases (i.e. setting orbital axes, lazy follow), but has been broken for some time for the less commonly-used cases (e.g. as in the sample scene).

The fix is simple: don't invalidate the previous state after setting it in ForceCameraPosition.  Validate it instead.  Dumb bug.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
