### PR TITLE
CMCL-0000: Update CodeCov Reporting and Integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,37 @@
+codecov:
+  require_ci_to_pass: no
+  notify:
+    wait_for_ci: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...70"
+  status:
+    patch: off
+    default_rules:
+      flag_coverage_not_uploaded_behavior: exclude
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto 
+        if_ci_failed: success
+        informational: false
+        only_pulls: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: no
+  after_n_builds: 1
+
+# Components configuration
+component_management:
+  individual_components:
+    - component_id: "com.unity.cinemachine"
+      name: "com.unity.cinemachine"
+      paths:
+        - com.unity.cinemachine

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -9,7 +9,7 @@ code_coverage_-_ubuntu_-_trunk:
     flavor: b1.large
   commands:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*;" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
+  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
   artifacts:
     packages:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -9,7 +9,7 @@ code_coverage_-_ubuntu_-_trunk:
     flavor: b1.large
   commands:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
+  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
   artifacts:
     packages:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -9,7 +9,7 @@ code_coverage_-_ubuntu_-_trunk:
     flavor: b1.large
   commands:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
+  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*;" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
   artifacts:
     packages:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -9,10 +9,7 @@ code_coverage_-_ubuntu_-_trunk:
     flavor: b1.large
   commands:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*" --extra-utr-arg=--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults
-  - command: curl -Os https://uploader.codecov.io/latest/linux/codecov
-  - command: chmod a+x ./codecov
-  - command: ./codecov -v -t "${CODECOV_TOKEN}" -B "${GIT_BRANCH}" -T "${GIT_TAG}" -P "${YAMATO_PR_ID}" -f "upm-ci~/test-results/CoverageResults/**/*.xml"
+  - command: upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*" --extra-utr-arg="--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\"reportsDir:upm-ci~/test-results;name:Ubuntu_trunk;flags:Ubuntu_trunk\""
   artifacts:
     packages:
       paths:

--- a/.yamato/wrench/api-validation-jobs.yml
+++ b/.yamato/wrench/api-validation-jobs.yml
@@ -20,7 +20,7 @@ api_validation_-_cinemachine_-_2022_3_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/PackageJsonCondersor.py
@@ -51,8 +51,8 @@ api_validation_-_cinemachine_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -24,5 +24,5 @@ package_pack_-_cinemachine:
     UPMCI_ACK_LARGE_PACKAGE: 1
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -22,7 +22,7 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_windows
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (MacOS).
 preview_apv_-_2022_3_-_macos:
@@ -39,7 +39,7 @@ preview_apv_-_2022_3_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -73,10 +73,10 @@ preview_apv_-_2022_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Ubuntu).
 preview_apv_-_2022_3_-_ubuntu:
@@ -93,7 +93,7 @@ preview_apv_-_2022_3_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -127,10 +127,10 @@ preview_apv_-_2022_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Windows).
 preview_apv_-_2022_3_-_windows:
@@ -148,7 +148,7 @@ preview_apv_-_2022_3_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -182,10 +182,10 @@ preview_apv_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (MacOS).
 preview_apv_-_6000_0_-_macos:
@@ -202,7 +202,7 @@ preview_apv_-_6000_0_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -236,10 +236,10 @@ preview_apv_-_6000_0_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Ubuntu).
 preview_apv_-_6000_0_-_ubuntu:
@@ -256,7 +256,7 @@ preview_apv_-_6000_0_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -290,10 +290,10 @@ preview_apv_-_6000_0_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Windows).
 preview_apv_-_6000_0_-_windows:
@@ -311,7 +311,7 @@ preview_apv_-_6000_0_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -345,10 +345,10 @@ preview_apv_-_6000_0_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (MacOS).
 preview_apv_-_6000_1_-_macos:
@@ -365,7 +365,7 @@ preview_apv_-_6000_1_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -399,10 +399,10 @@ preview_apv_-_6000_1_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (Ubuntu).
 preview_apv_-_6000_1_-_ubuntu:
@@ -419,7 +419,7 @@ preview_apv_-_6000_1_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -453,10 +453,10 @@ preview_apv_-_6000_1_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (Windows).
 preview_apv_-_6000_1_-_windows:
@@ -474,7 +474,7 @@ preview_apv_-_6000_1_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -508,10 +508,10 @@ preview_apv_-_6000_1_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (MacOS).
 preview_apv_-_6000_2_-_macos:
@@ -528,7 +528,7 @@ preview_apv_-_6000_2_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -562,10 +562,10 @@ preview_apv_-_6000_2_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (Ubuntu).
 preview_apv_-_6000_2_-_ubuntu:
@@ -582,7 +582,7 @@ preview_apv_-_6000_2_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -616,10 +616,10 @@ preview_apv_-_6000_2_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (Windows).
 preview_apv_-_6000_2_-_windows:
@@ -637,7 +637,7 @@ preview_apv_-_6000_2_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -671,10 +671,10 @@ preview_apv_-_6000_2_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (MacOS).
 preview_apv_-_6000_3_-_macos:
@@ -691,7 +691,7 @@ preview_apv_-_6000_3_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -725,10 +725,10 @@ preview_apv_-_6000_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Ubuntu).
 preview_apv_-_6000_3_-_ubuntu:
@@ -745,7 +745,7 @@ preview_apv_-_6000_3_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -779,10 +779,10 @@ preview_apv_-_6000_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Windows).
 preview_apv_-_6000_3_-_windows:
@@ -800,7 +800,7 @@ preview_apv_-_6000_3_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -834,8 +834,8 @@ preview_apv_-_6000_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -178,10 +178,10 @@ publish_cinemachine:
         ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 
 # Publish Dry Run  for cinemachine to https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-npm
 publish_dry_run_cinemachine:
@@ -360,8 +360,8 @@ publish_dry_run_cinemachine:
         ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/recipe-regeneration.yml
+++ b/.yamato/wrench/recipe-regeneration.yml
@@ -26,5 +26,5 @@ test_-_wrench_jobs_up_to_date:
     cancel_old_ci: true
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -13,7 +13,7 @@ validate_-_cinemachine_-_2022_3_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -21,7 +21,7 @@ validate_-_cinemachine_-_2022_3_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -29,12 +29,15 @@ validate_-_cinemachine_-_2022_3_-_macos:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_MacOS_2022.3;flags:cinemachine_MacOS_2022.3" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -60,10 +63,10 @@ validate_-_cinemachine_-_2022_3_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -79,7 +82,7 @@ validate_-_cinemachine_-_2022_3_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -87,7 +90,7 @@ validate_-_cinemachine_-_2022_3_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -95,12 +98,15 @@ validate_-_cinemachine_-_2022_3_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Ubuntu_2022.3;flags:cinemachine_Ubuntu_2022.3" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -126,10 +132,10 @@ validate_-_cinemachine_-_2022_3_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -145,7 +151,7 @@ validate_-_cinemachine_-_2022_3_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -153,7 +159,7 @@ validate_-_cinemachine_-_2022_3_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -161,12 +167,15 @@ validate_-_cinemachine_-_2022_3_-_windows:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Windows_2022.3;flags:cinemachine_Windows_2022.3" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -192,10 +201,10 @@ validate_-_cinemachine_-_2022_3_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -211,7 +220,7 @@ validate_-_cinemachine_-_6000_0_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -219,7 +228,7 @@ validate_-_cinemachine_-_6000_0_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -227,12 +236,15 @@ validate_-_cinemachine_-_6000_0_-_macos:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_MacOS_6000.0;flags:cinemachine_MacOS_6000.0" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -258,10 +270,10 @@ validate_-_cinemachine_-_6000_0_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -277,7 +289,7 @@ validate_-_cinemachine_-_6000_0_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -285,7 +297,7 @@ validate_-_cinemachine_-_6000_0_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -293,12 +305,15 @@ validate_-_cinemachine_-_6000_0_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Ubuntu_6000.0;flags:cinemachine_Ubuntu_6000.0" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -324,10 +339,10 @@ validate_-_cinemachine_-_6000_0_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -343,7 +358,7 @@ validate_-_cinemachine_-_6000_0_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -351,7 +366,7 @@ validate_-_cinemachine_-_6000_0_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -359,12 +374,15 @@ validate_-_cinemachine_-_6000_0_-_windows:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Windows_6000.0;flags:cinemachine_Windows_6000.0" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -390,10 +408,10 @@ validate_-_cinemachine_-_6000_0_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -409,7 +427,7 @@ validate_-_cinemachine_-_6000_1_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -417,7 +435,7 @@ validate_-_cinemachine_-_6000_1_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -425,12 +443,15 @@ validate_-_cinemachine_-_6000_1_-_macos:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_MacOS_6000.1;flags:cinemachine_MacOS_6000.1" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -456,10 +477,10 @@ validate_-_cinemachine_-_6000_1_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -475,7 +496,7 @@ validate_-_cinemachine_-_6000_1_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -483,7 +504,7 @@ validate_-_cinemachine_-_6000_1_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -491,12 +512,15 @@ validate_-_cinemachine_-_6000_1_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Ubuntu_6000.1;flags:cinemachine_Ubuntu_6000.1" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -522,10 +546,10 @@ validate_-_cinemachine_-_6000_1_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -541,7 +565,7 @@ validate_-_cinemachine_-_6000_1_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -549,7 +573,7 @@ validate_-_cinemachine_-_6000_1_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -557,12 +581,15 @@ validate_-_cinemachine_-_6000_1_-_windows:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Windows_6000.1;flags:cinemachine_Windows_6000.1" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -588,10 +615,10 @@ validate_-_cinemachine_-_6000_1_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -607,7 +634,7 @@ validate_-_cinemachine_-_6000_2_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -615,7 +642,7 @@ validate_-_cinemachine_-_6000_2_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -623,12 +650,15 @@ validate_-_cinemachine_-_6000_2_-_macos:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_MacOS_6000.2;flags:cinemachine_MacOS_6000.2" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -654,10 +684,10 @@ validate_-_cinemachine_-_6000_2_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -673,7 +703,7 @@ validate_-_cinemachine_-_6000_2_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -681,7 +711,7 @@ validate_-_cinemachine_-_6000_2_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -689,12 +719,15 @@ validate_-_cinemachine_-_6000_2_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Ubuntu_6000.2;flags:cinemachine_Ubuntu_6000.2" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -720,10 +753,10 @@ validate_-_cinemachine_-_6000_2_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -739,7 +772,7 @@ validate_-_cinemachine_-_6000_2_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -747,7 +780,7 @@ validate_-_cinemachine_-_6000_2_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -755,12 +788,15 @@ validate_-_cinemachine_-_6000_2_-_windows:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Windows_6000.2;flags:cinemachine_Windows_6000.2" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -786,10 +822,10 @@ validate_-_cinemachine_-_6000_2_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -805,7 +841,7 @@ validate_-_cinemachine_-_6000_3_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -813,7 +849,7 @@ validate_-_cinemachine_-_6000_3_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -821,12 +857,15 @@ validate_-_cinemachine_-_6000_3_-_macos:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_MacOS_6000.3;flags:cinemachine_MacOS_6000.3" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -852,10 +891,10 @@ validate_-_cinemachine_-_6000_3_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -871,7 +910,7 @@ validate_-_cinemachine_-_6000_3_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -879,7 +918,7 @@ validate_-_cinemachine_-_6000_3_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -887,12 +926,15 @@ validate_-_cinemachine_-_6000_3_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Ubuntu_6000.3;flags:cinemachine_Ubuntu_6000.3" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -918,10 +960,10 @@ validate_-_cinemachine_-_6000_3_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 
@@ -937,7 +979,7 @@ validate_-_cinemachine_-_6000_3_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c Editor --fast
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-cinemachine --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -945,7 +987,7 @@ validate_-_cinemachine_-_6000_3_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -953,12 +995,15 @@ validate_-_cinemachine_-_6000_3_-_windows:
   - command: upm-pvp require "rme PVP-160-1 PVP-20-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-cinemachine --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:cinemachine_Windows_6000.3;flags:cinemachine_Windows_6000.3" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
     Crash Dumps:
       paths:
       - CrashDumps/**
@@ -984,10 +1029,10 @@ validate_-_cinemachine_-_6000_3_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_cinemachine
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.50.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.50.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:cinemachine
 

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -12,7 +12,7 @@
       "InternalOnly": false,
       "NeverPublish": false,
       "MaxEditorVersion": "",
-      "coverageEnabled": false,
+      "coverageEnabled": true,
       "coverageCommands": [
         "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:ASSEMBLY_NAME;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:YAMATO_SOURCE_DIR/Packages;"
       ],
@@ -31,7 +31,7 @@
   },
   "publishing_job": ".yamato/wrench/promotion-jobs.yml#publish_cinemachine",
   "branch_pattern": "ReleaseSlash",
-  "wrench_version": "0.10.50.0",
+  "wrench_version": "0.12.2.0",
   "pvp_exemption_path": ".yamato/wrench/pvp-exemptions.json",
   "cs_project_path": "Tools/Cinemachine-Recipes/Cinemachine.Cookbook.csproj"
 }

--- a/Tools/Cinemachine-Recipes/Cinemachine.Cookbook.csproj
+++ b/Tools/Cinemachine-Recipes/Cinemachine.Cookbook.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="0.10.50" />
+      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="0.12.2" />
     </ItemGroup>
 
 </Project>

--- a/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
+++ b/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
@@ -36,7 +36,7 @@ public class CodeCoverage :RecipeBase
                 .WithPlatform(Platform)
                 .WithCommands( c => c
                     .Add("npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm")
-                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
+                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
                     )
                 .WithUpmCiArtifacts()
                 .WithDescription($"Generate codecov data for {settings.Wrench.Packages[PackageName].DisplayName} on {Platform.System}")

--- a/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
+++ b/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
@@ -36,7 +36,7 @@ public class CodeCoverage :RecipeBase
                 .WithPlatform(Platform)
                 .WithCommands( c => c
                     .Add("npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm")
-                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*;\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
+                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine,+Unity.Cinemachine.Editor\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
                     )
                 .WithUpmCiArtifacts()
                 .WithDescription($"Generate codecov data for {settings.Wrench.Packages[PackageName].DisplayName} on {Platform.System}")

--- a/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
+++ b/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
@@ -21,6 +21,7 @@ public class CodeCoverage :RecipeBase
     private const string PackageName = "com.unity.cinemachine";
     private static readonly Platform Platform = settings.Wrench.Packages[PackageName].EditorPlatforms[SystemType.Ubuntu];
     private const string EditorVersion = "trunk";
+    private const string YamatoSourceDir = "${YAMATO_SOURCE_DIR}";
 
 
     public IEnumerable<Dependency> AsDependencies()
@@ -35,10 +36,7 @@ public class CodeCoverage :RecipeBase
                 .WithPlatform(Platform)
                 .WithCommands( c => c
                     .Add("npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm")
-                    .Add("upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*\" --extra-utr-arg=--coverage-results-path=${YAMATO_SOURCE_DIR}/upm-ci~/test-results/CoverageResults")
-                    .Add("curl -Os https://uploader.codecov.io/latest/linux/codecov")
-                    .Add("chmod a+x ./codecov")
-                    .Add("./codecov -v -t \"${CODECOV_TOKEN}\" -B \"${GIT_BRANCH}\" -T \"${GIT_TAG}\" -P \"${YAMATO_PR_ID}\" -f \"upm-ci~/test-results/CoverageResults/**/*.xml\"")
+                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Cinemachine*\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
                     )
                 .WithUpmCiArtifacts()
                 .WithDescription($"Generate codecov data for {settings.Wrench.Packages[PackageName].DisplayName} on {Platform.System}")

--- a/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
+++ b/Tools/Cinemachine-Recipes/Recipes/CodeCoverage.cs
@@ -36,7 +36,7 @@ public class CodeCoverage :RecipeBase
                 .WithPlatform(Platform)
                 .WithCommands( c => c
                     .Add("npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm")
-                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
+                    .Add($"upm-ci package test -u trunk --package-path com.unity.cinemachine --type package-tests --enable-code-coverage --code-coverage-options \"generateAdditionalMetrics;generateHtmlReport;assemblyFilters:-*Tests*;\" --extra-utr-arg=\"--coverage-results-path={YamatoSourceDir}/upm-ci~/test-results/CoverageResults --coverage-upload-options=\\\"reportsDir:upm-ci~/test-results;name:{Platform.System}_{EditorVersion};flags:{Platform.System}_{EditorVersion}\\\"\"")
                     )
                 .WithUpmCiArtifacts()
                 .WithDescription($"Generate codecov data for {settings.Wrench.Packages[PackageName].DisplayName} on {Platform.System}")

--- a/Tools/Cinemachine-Recipes/Settings/CinemachineSettings.cs
+++ b/Tools/Cinemachine-Recipes/Settings/CinemachineSettings.cs
@@ -7,6 +7,10 @@ public class CinemachineSettings
 {
     // Path from the root of the repository where packages are located.
     string[] PackagesRootPaths = { "." };
+    
+    // Environment variables
+    private const string packageName = "com.unity.cinemachine";
+
 
     // update this to list all packages in this repo that you want to release.
     Dictionary<string, PackageOptions> PackageOptions = new()
@@ -34,6 +38,12 @@ public class CinemachineSettings
             PackageOptions,
             useLocalPvpExemptions: true
         );
+
+        Wrench.Packages[packageName].CoverageCommands.Enabled = true;
+        
+        // Exclude code coverage for tests
+        Wrench.Packages[packageName].CoverageCommands.AssemblyAllowList.Add("^Unity.Cinemachine$");
+        Wrench.Packages[packageName].CoverageCommands.AssemblyAllowList.Add("^Unity.Cinemachine.Editor$");
 
         Wrench.PvpProfilesToCheck = PvPprofilesToCheck;
     }


### PR DESCRIPTION
### Purpose of this PR

Jira Ticket: [WBTR-1290](https://jira.unity3d.com/browse/WBTR-1290)

Since it is now compatible for repositories in github.com, this PR updates the code coverage jobs to use Unity's CodeCov reporting. This includes updating and regenerating Wrench jobs with version `0.12.2` in order to enable CodeCov and exclude tests in the report.

See [CodeCov dashboard](https://codecov.unity3d.com/gh/Unity-Technologies/com.unity.cinemachine/tree/ci%2Fcodecov-setup)

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [ ] Manually tested
- [x] Ran Code Coverage jobs and the respective Wrench Validate jobs

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Technical Risk: None
Halo Effect: None

### Comments to reviewers

None.

### Package version
- [ ] Updated package version
