### PR TITLE
CMCL-1712: add helpboxes to PixelPerfect inspector

### DIFF
--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -13,6 +13,21 @@ namespace Unity.Cinemachine.Editor
 
 #if CINEMACHINE_URP || CINEMACHINE_PIXEL_PERFECT_2_0_3
             this.AddMissingCmCameraHelpBox(ux);
+
+            var infoBox = ux.AddChild(new HelpBox(
+                "This component is driving the Pixel Perfect Camera component on the Unity Camera.",
+                HelpBoxMessageType.Info));
+            var helpBox = ux.AddChild(new HelpBox(
+                "This component requires an active Pixel Perfect Camera component on the Unity Camera.",
+                HelpBoxMessageType.Warning));
+
+            ux.TrackAnyUserActivity(() => 
+            {
+                var pp = target as CinemachinePixelPerfect;
+                bool isValid = pp.HasValidPixelPerfectCamera();
+                infoBox.SetVisible(isValid && pp.enabled);
+                helpBox.SetVisible(!isValid);
+            });
 #else
             ux.Add(new HelpBox("This component is only valid within URP projects", HelpBoxMessageType.Warning));
 #endif


### PR DESCRIPTION
### Purpose of this PR

CMCL-1712: The main PixelPerfect Component is required for the extension to work correctly, so showing a warning when there is no such component detected is crucial for user experience.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

0
