### PR TITLE
Remove default target from ThirdPersonFollow

### DIFF
--- a/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
@@ -274,7 +274,7 @@ namespace Unity.Cinemachine
 
             // Correct the case where by default we're looking at the follow target
             if (!curState.HasLookAt() || curState.ReferenceLookAt.Equals(targetPos))
-                curState.ReferenceLookAt = targetPos + targetForward * 0.01f; // so that there's something
+                curState.ReferenceLookAt = CameraState.kNoPoint;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

CMCL-1717: When blending between a no-lookat-target 3rdPerson camera and a camera with a look-at target, the blend was incorrect.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
